### PR TITLE
이미지만 들어있는 pdf 첨부시에 빈청크 오류가 발생하여 생긴  첨부무한로딩 오류 해결

### DIFF
--- a/doc_preprocessors/attachment_processor.py
+++ b/doc_preprocessors/attachment_processor.py
@@ -1200,7 +1200,12 @@ class DocumentProcessor:
         chunks = text_splitter.split_documents(documents)
         chunks = [chunk for chunk in chunks if chunk.page_content]
         if not chunks:
-            raise Exception('Empty document')
+            chunks = [
+                Document(
+                    page_content=".", 
+                    metadata={"page": 0}
+                )
+            ]
 
         for chunk in chunks:
             page = chunk.metadata.get('page', 0)

--- a/doc_preprocessors/attachment_processor_origin.py
+++ b/doc_preprocessors/attachment_processor_origin.py
@@ -1199,7 +1199,12 @@ class DocumentProcessor:
         chunks = text_splitter.split_documents(documents)
         chunks = [chunk for chunk in chunks if chunk.page_content]
         if not chunks:
-            raise Exception('Empty document')
+            chunks = [
+                Document(
+                    page_content=".", 
+                    metadata={"page": 0}
+                )
+            ]
 
         for chunk in chunks:
             page = chunk.metadata.get('page', 0)


### PR DESCRIPTION
close #44 