### PR TITLE
facade/attachment_preprocessor.py

### DIFF
--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -1345,7 +1345,9 @@ class DocumentProcessor:
 
         vectors = []
         for chunk_idx, chunk in enumerate(chunks):
-            page = chunk.metadata.get('page', 0)
+            page = chunk.metadata.get('page', 1)
+            if ext not in ['.hwpx', '.docx']:
+                page += 1
             text = chunk.page_content
 
             if page != current_page:

--- a/genon/preprocessor/uv.lock
+++ b/genon/preprocessor/uv.lock
@@ -1132,7 +1132,7 @@ requires-dist = [
     { name = "langchain-core", specifier = ">=1.0.0" },
     { name = "markdown", specifier = "==3.8.2" },
     { name = "markdown2", specifier = ">=2.5.4" },
-    { name = "minio", specifier = ">=7.2.20" },
+    { name = "minio", specifier = "==7.2.20" },
     { name = "numpy", specifier = "==2.3.4" },
     { name = "numpy", specifier = ">=2.3.4" },
     { name = "opencv-python", specifier = "==4.11.0.86" },


### PR DESCRIPTION
# 파일 확장자에 따른 langchain, docling 사용여부 구분
## docling
- hwpx, docx
## langchain
- 그 외 확장자
---
hwpx, docx를 제외한 확장자에 대해서는 page에 +1

### 확인필요

- [ ] 한국은행에 전달한 코드가 facade에 있는 첨부용 코드인지 확인 필요.