### PR TITLE
hwpx에서 청크1개만 생성되는 버그 수정.

### DIFF
--- a/docling/utils/document_enrichment.py
+++ b/docling/utils/document_enrichment.py
@@ -942,8 +942,8 @@ class DocumentEnrichmentUtils:
         text_items = [
             (i, item.text.strip())
             for i, item in enumerate(document.texts)
-            if (isinstance(item, TextItem) or isinstance(item, ListItem))
-            and (item.label in [DocItemLabel.TEXT, DocItemLabel.LIST_ITEM, DocItemLabel.PAGE_HEADER, DocItemLabel.PARAGRAPH])
+            if isinstance(item, (TextItem, ListItem))
+            and item.label in [DocItemLabel.TEXT, DocItemLabel.LIST_ITEM, DocItemLabel.PAGE_HEADER, DocItemLabel.PARAGRAPH]
             and len(item.text.strip()) >= 2
         ]
         text_items_reversed = text_items[::-1]


### PR DESCRIPTION
- hwpx 파싱할 때 일반 텍스트를 paragraph로 가져오고 있음.
- toc 결과와 매칭할 때 paragraph를 비교 대상에 포함시킴

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
