### PR TITLE
[BE] 첨부형 전처리기 배포 시 리소스 파일 자동 다운로드 (GenOS #9078)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -454,3 +454,7 @@ test_results/
 
 # 로컬 빌드 설정 (HF_TOKEN 등 민감 정보 포함, 절대 커밋 금지)
 build-script/hf_private_token.env
+
+# debug
+debug/
+samples/

--- a/genon/preprocessor/src/common/settings.py
+++ b/genon/preprocessor/src/common/settings.py
@@ -1,5 +1,7 @@
 import os
 from pathlib import Path
+from typing import Optional
+
 from pydantic_settings import BaseSettings
 
 PROFILE = os.getenv("PROFILE", "dev")
@@ -28,9 +30,10 @@ class Settings(BaseSettings):
     class Config(BaseConfig):
         pass
 
+    PREPROCESSOR_ID: Optional[str] = _ID
     POD_ID: str = _POD_ID
     LOG_PATH: list[str] = [
-        "/var/log/supervisor/gunicorn_stderr.log", 
+        "/var/log/supervisor/gunicorn_stderr.log",
         "/var/log/supervisor/gunicorn_stdout.log"
     ]
 
@@ -59,5 +62,15 @@ class MsgQueueConfig(BaseSettings):
     MQ_ROUTING_KEY_LOG: str = f'log.preprocessor.{_ID}.{_POD_ID}'
 
 
+class MinioConfig(BaseSettings):
+    class Config(BaseConfig):
+        pass
+
+    MINIO_ENDPOINT: str
+    MINIO_ACCESS_KEY: str
+    MINIO_SECRET_KEY: str
+
+
 settings = Settings()
 msg_queue_config = MsgQueueConfig()
+minio_config = MinioConfig()

--- a/genon/preprocessor/src/main.py
+++ b/genon/preprocessor/src/main.py
@@ -46,11 +46,12 @@ async def healthcheck() -> object:
     return {'status': 'ok'}
 
 
-download_resource_files(
-    bucket_name='preprocessor',
-    resource_id=settings.PREPROCESSOR_ID,
-    path='/app/resource',
-)
+if settings.PREPROCESSOR_ID:
+    download_resource_files(
+        bucket_name='preprocessor',
+        resource_id=settings.PREPROCESSOR_ID,
+        path='/app/resource',
+    )
 
 # 이 파일 마운트
 from preprocessor import DocumentProcessor

--- a/genon/preprocessor/src/main.py
+++ b/genon/preprocessor/src/main.py
@@ -1,13 +1,20 @@
-from fastapi import FastAPI, Request, Body
-from fastapi.exceptions import RequestValidationError
-
+import os
+import sys
 import traceback
 import time
+
+from fastapi import FastAPI, Request, Body
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
 from logger import Logger
 from utils import make_failure_response, make_success_response
 from config import cors_config
 from common.exception import GenosServiceException
-from fastapi.responses import JSONResponse
+from common.settings import settings
+from util.minio_resource import download_resource_files
+
+sys.path.append(os.path.dirname(__file__) + '/util')
 
 logger = Logger.getLogger(__name__)
 
@@ -38,6 +45,12 @@ async def exception_handler(request, exc: Exception):
 async def healthcheck() -> object:
     return {'status': 'ok'}
 
+
+download_resource_files(
+    bucket_name='preprocessor',
+    resource_id=settings.PREPROCESSOR_ID,
+    path='/app/resource',
+)
 
 # 이 파일 마운트
 from preprocessor import DocumentProcessor

--- a/genon/preprocessor/src/util/minio_resource.py
+++ b/genon/preprocessor/src/util/minio_resource.py
@@ -1,0 +1,104 @@
+from minio import Minio
+import os
+import time
+import errno
+import fcntl
+
+from common.settings import minio_config
+from common.logger import Logger
+
+logger = Logger.getLogger(__name__)
+
+
+class FileLock:
+    def __init__(self, lock_path: str, timeout_sec: int = 600, poll_interval: float = 0.2):
+        self.lock_path = lock_path
+        self.timeout_sec = timeout_sec
+        self.poll_interval = poll_interval
+        self._fd = None
+
+    def __enter__(self):
+        os.makedirs(os.path.dirname(self.lock_path), exist_ok=True)
+        self._fd = open(self.lock_path, "a+")
+
+        start = time.time()
+        while True:
+            try:
+                fcntl.flock(self._fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                self._fd.seek(0)
+                self._fd.truncate()
+                self._fd.write(f"pid={os.getpid()} acquired_at={time.time()}\n")
+                self._fd.flush()
+                return self
+            except OSError as e:
+                if e.errno not in (errno.EACCES, errno.EAGAIN):
+                    raise
+                if (time.time() - start) >= self.timeout_sec:
+                    raise TimeoutError(f"Timed out acquiring lock: {self.lock_path}")
+                time.sleep(self.poll_interval)
+
+    def __exit__(self, exc_type, exc, tb):
+        try:
+            if self._fd:
+                fcntl.flock(self._fd.fileno(), fcntl.LOCK_UN)
+        finally:
+            if self._fd:
+                self._fd.close()
+                self._fd = None
+
+
+def download_resource_files(bucket_name: str, resource_id: int, path: str):
+    os.makedirs(path, exist_ok=True)
+
+    lock_file = os.path.join(path, ".download_resource_files.lock")
+
+    with FileLock(lock_file, timeout_sec=3600):
+        logger.info(f'Acquired lock: {lock_file} (pid={os.getpid()})')
+
+        minio_client = Minio(
+            endpoint=minio_config.MINIO_ENDPOINT,
+            access_key=minio_config.MINIO_ACCESS_KEY,
+            secret_key=minio_config.MINIO_SECRET_KEY,
+            secure=False
+        )
+
+        prefix = f"{resource_id}/resource"
+        objects = list(minio_client.list_objects(bucket_name, prefix=prefix, recursive=True))
+
+        try:
+            logger.info(f'Downloading {len(objects)} resource files for {bucket_name} {resource_id}')
+
+            for i, obj in enumerate(objects):
+                if obj.is_dir:
+                    continue
+
+                rel_path = obj.object_name[len(prefix):].lstrip("/\\")
+                if not rel_path:
+                    continue
+
+                destination_file = os.path.join(path, rel_path)
+                os.makedirs(os.path.dirname(destination_file), exist_ok=True)
+
+                if os.path.exists(destination_file):
+                    logger.info(
+                        f'[SKIP {i+1}/{len(objects)}] "{destination_file}" already exists'
+                    )
+                    continue
+
+                logger.info(
+                    f'Downloading [{i+1}/{len(objects)}] "{obj.object_name}" '
+                    f'to "{destination_file}"...'
+                )
+
+                minio_client.fget_object(
+                    bucket_name=bucket_name,
+                    object_name=obj.object_name,
+                    file_path=destination_file
+                )
+
+            logger.info('Completed!')
+        except Exception as e:
+            logger.error(f'Failed to download resource files: {e}')
+            raise
+        finally:
+            logger.info(f'Releasing lock: {lock_file} (pid={os.getpid()})')

--- a/genon/preprocessor/tests/unit/test_minio_resource_unit.py
+++ b/genon/preprocessor/tests/unit/test_minio_resource_unit.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import fcntl
+import os
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_minio_env(monkeypatch):
+    """`common.settings.minio_config` import 시점의 env 검증을 우회."""
+    monkeypatch.setenv("MINIO_ENDPOINT", "test-endpoint:9000")
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "test-access")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "test-secret")
+    monkeypatch.setenv("HOSTNAME", "preprocessor-test-0")
+    monkeypatch.setenv("PREPROCESSOR_ID", "226")
+    monkeypatch.setenv("MQ_HOST", "x")
+    monkeypatch.setenv("MQ_PORT", "0")
+    monkeypatch.setenv("MQ_USER", "x")
+    monkeypatch.setenv("MQ_PASSWORD", "x")
+    monkeypatch.setenv("MQ_VHOST", "/")
+    monkeypatch.setenv("MQ_EXCHANGE_TYPE", "topic")
+    monkeypatch.setenv("MQ_EXCHANGE_NAME_LOG", "log")
+    monkeypatch.setenv("MQ_QUEUE_NAME_LOG", "log")
+    monkeypatch.setenv("MQ_QUEUE_BIND_ROUTING_KEY_LOG", "*.#")
+
+
+def _make_obj(object_name: str, is_dir: bool = False):
+    return SimpleNamespace(object_name=object_name, is_dir=is_dir)
+
+
+# ---------------------------------------------------------------------------
+# FileLock
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_file_lock_acquires_and_writes_pid(tmp_path: Path):
+    from util.minio_resource import FileLock
+
+    lock_file = tmp_path / "sub" / ".lock"
+
+    with FileLock(str(lock_file), timeout_sec=1, poll_interval=0.05):
+        assert lock_file.exists()
+        content = lock_file.read_text()
+        assert f"pid={os.getpid()}" in content
+
+    # __exit__ 후에도 파일 자체는 남아 있음(해제만 됨)
+    assert lock_file.exists()
+
+
+@pytest.mark.unit
+def test_file_lock_times_out_when_held_elsewhere(tmp_path: Path):
+    from util.minio_resource import FileLock
+
+    lock_file = tmp_path / ".lock"
+    lock_file.touch()
+
+    held = open(lock_file, "a+")
+    try:
+        fcntl.flock(held.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        start = time.time()
+        with pytest.raises(TimeoutError):
+            with FileLock(str(lock_file), timeout_sec=1, poll_interval=0.05):
+                pass
+        assert time.time() - start >= 1.0
+    finally:
+        fcntl.flock(held.fileno(), fcntl.LOCK_UN)
+        held.close()
+
+
+@pytest.mark.unit
+def test_file_lock_blocks_concurrent_acquire(tmp_path: Path):
+    from util.minio_resource import FileLock
+
+    lock_file = tmp_path / ".lock"
+    order: list[str] = []
+
+    def first():
+        with FileLock(str(lock_file), timeout_sec=5, poll_interval=0.05):
+            order.append("first-enter")
+            time.sleep(0.3)
+            order.append("first-exit")
+
+    def second():
+        time.sleep(0.05)
+        with FileLock(str(lock_file), timeout_sec=5, poll_interval=0.05):
+            order.append("second-enter")
+
+    t1 = threading.Thread(target=first)
+    t2 = threading.Thread(target=second)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert order == ["first-enter", "first-exit", "second-enter"]
+
+
+# ---------------------------------------------------------------------------
+# download_resource_files
+# ---------------------------------------------------------------------------
+
+def _patch_minio(monkeypatch, objects):
+    """`util.minio_resource.Minio`를 MagicMock으로 치환하고 반환."""
+    import util.minio_resource as mr
+
+    minio_mock = MagicMock()
+    minio_mock.list_objects.return_value = iter(objects)
+    client_factory = MagicMock(return_value=minio_mock)
+    monkeypatch.setattr(mr, "Minio", client_factory)
+    return minio_mock, client_factory
+
+
+@pytest.mark.unit
+def test_download_resource_files_downloads_all_objects(tmp_path: Path, monkeypatch):
+    from util.minio_resource import download_resource_files
+
+    dest = tmp_path / "resource"
+    objs = [
+        _make_obj("226/resource/a.txt"),
+        _make_obj("226/resource/sub/b.json"),
+    ]
+    minio_mock, factory = _patch_minio(monkeypatch, objs)
+
+    download_resource_files(bucket_name="preprocessor", resource_id=226, path=str(dest))
+
+    # 디렉터리 생성
+    assert dest.is_dir()
+
+    # list_objects 호출 인자 확인
+    minio_mock.list_objects.assert_called_once_with(
+        "preprocessor", prefix="226/resource", recursive=True
+    )
+
+    # fget_object 2회, 경로 정확
+    assert minio_mock.fget_object.call_count == 2
+    calls = {call.kwargs["object_name"]: call.kwargs for call in minio_mock.fget_object.call_args_list}
+    assert calls["226/resource/a.txt"]["file_path"] == str(dest / "a.txt")
+    assert calls["226/resource/a.txt"]["bucket_name"] == "preprocessor"
+    assert calls["226/resource/sub/b.json"]["file_path"] == str(dest / "sub" / "b.json")
+
+    # 하위 디렉터리 실제 생성되었는지 확인
+    assert (dest / "sub").is_dir()
+
+    # Minio 클라이언트는 한 번만 생성
+    assert factory.call_count == 1
+
+
+@pytest.mark.unit
+def test_download_resource_files_skips_existing(tmp_path: Path, monkeypatch):
+    from util.minio_resource import download_resource_files
+
+    dest = tmp_path / "resource"
+    dest.mkdir()
+    existing = dest / "a.txt"
+    existing.write_text("already here")
+
+    objs = [_make_obj("226/resource/a.txt")]
+    minio_mock, _ = _patch_minio(monkeypatch, objs)
+
+    download_resource_files(bucket_name="preprocessor", resource_id=226, path=str(dest))
+
+    minio_mock.fget_object.assert_not_called()
+    assert existing.read_text() == "already here"
+
+
+@pytest.mark.unit
+def test_download_resource_files_skips_directory_entries(tmp_path: Path, monkeypatch):
+    from util.minio_resource import download_resource_files
+
+    dest = tmp_path / "resource"
+    objs = [
+        _make_obj("226/resource/dir/", is_dir=True),
+        _make_obj("226/resource/a.txt"),
+    ]
+    minio_mock, _ = _patch_minio(monkeypatch, objs)
+
+    download_resource_files(bucket_name="preprocessor", resource_id=226, path=str(dest))
+
+    assert minio_mock.fget_object.call_count == 1
+    args = minio_mock.fget_object.call_args.kwargs
+    assert args["object_name"] == "226/resource/a.txt"
+
+
+@pytest.mark.unit
+def test_download_resource_files_empty_list(tmp_path: Path, monkeypatch):
+    from util.minio_resource import download_resource_files
+
+    dest = tmp_path / "resource"
+    minio_mock, _ = _patch_minio(monkeypatch, [])
+
+    download_resource_files(bucket_name="preprocessor", resource_id=226, path=str(dest))
+
+    assert dest.is_dir()
+    minio_mock.fget_object.assert_not_called()
+
+
+@pytest.mark.unit
+def test_download_resource_files_propagates_exception(tmp_path: Path, monkeypatch):
+    from util.minio_resource import download_resource_files
+
+    dest = tmp_path / "resource"
+    objs = [_make_obj("226/resource/a.txt")]
+    minio_mock, _ = _patch_minio(monkeypatch, objs)
+    minio_mock.fget_object.side_effect = RuntimeError("network down")
+
+    with pytest.raises(RuntimeError, match="network down"):
+        download_resource_files(bucket_name="preprocessor", resource_id=226, path=str(dest))
+
+
+@pytest.mark.unit
+def test_download_resource_files_ignores_empty_relative_path(tmp_path: Path, monkeypatch):
+    """prefix와 object_name이 정확히 일치해 rel_path가 비는 경우 스킵."""
+    from util.minio_resource import download_resource_files
+
+    dest = tmp_path / "resource"
+    objs = [
+        _make_obj("226/resource"),  # rel_path == ""
+        _make_obj("226/resource/a.txt"),
+    ]
+    minio_mock, _ = _patch_minio(monkeypatch, objs)
+
+    download_resource_files(bucket_name="preprocessor", resource_id=226, path=str(dest))
+
+    assert minio_mock.fget_object.call_count == 1
+    assert minio_mock.fget_object.call_args.kwargs["object_name"] == "226/resource/a.txt"


### PR DESCRIPTION
## 개요
전처리기 Pod 기동 시 MinIO에서 업로드된 리소스 파일을 `/app/resource`로 자동 다운로드하는 기능 추가. GenOS QA 이슈 [genonai/GenOS#9078](https://github.com/genonai/GenOS/issues/9078) 수정.

## 관련 이슈
- doc_parser: #175
- GenOS 상위: https://github.com/genonai/GenOS/issues/9078

---

## 배경

### 현상 (As-Is)
`doc_parser` 도커 이미지로 배포된 전처리기 Pod(예: `preprocessor-226-598d59564b-4r44g`)의 파일시스템에 `/app/resource` 폴더가 생성되지 않아, 관리자 페이지(`/admin/resource/preprocessor/detail/{id}`)에서 업로드한 리소스 파일(jpg·json·png·xlsx·py·html 등)이 Pod 내부로 동기화되지 않음. 결과적으로 전처리기 코드가 첨부 리소스를 참조할 수 없는 상태.

### 재현
1. GenPortal/Admin에서 전처리기 생성 (기본 전처리기 코드 사용)
2. 전처리기 상세 > 리소스 파일 목록에 파일 업로드 (MinIO `preprocessor` 버킷에 저장됨)
3. `doc_parser` 이미지로 Pod 배포
4. Pod 내부 `ls -al ~` → `resource/` 부재 확인

### 기대 동작 (To-Be)
Pod 기동 시 MinIO의 `preprocessor/{PREPROCESSOR_ID}/resource/` prefix를 `/app/resource` 하위에 자동 다운로드.

---

## 해결 방식

GenOS 동일 문제를 이미 해결한 `container-services/workflow`·`mcp-server`의 패턴을 `doc_parser` 전처리기에도 이식.

### 핵심 메커니즘
1. **MinIO 프리패치:** `Minio.list_objects(bucket=\"preprocessor\", prefix=\"{ID}/resource\", recursive=True)` → 각 오브젝트를 `fget_object()`로 다운로드, 원본 디렉터리 구조 유지.
2. **멀티 워커 경쟁 차단:** `gunicorn workers=5`에서 동시 다운로드 충돌 방지용 `fcntl.flock(LOCK_EX | LOCK_NB)` 기반 `FileLock`. 첫 워커만 실제 다운로드, 나머지는 락 대기 후 `os.path.exists()` 로 SKIP.
3. **멱등성:** 기존 파일 존재 시 `[SKIP i/N] already exists` 로그 후 넘김 → 재기동·재스케줄 시 중복 다운로드 없음.
4. **실패 전파:** MinIO 연결/인증/다운로드 실패는 re-raise — Pod 기동 실패로 이어져 k8s가 재시도하도록.

---

## 변경 파일

| 파일 | 종류 | 설명 |
|------|------|------|
| `src/common/settings.py` | 수정 | `Optional` import, `Settings.PREPROCESSOR_ID: Optional[str] = _ID`, `MinioConfig` 클래스 + `minio_config` 싱글턴 |
| `src/main.py` | 수정 | `os`·`sys`·`settings`·`download_resource_files` import, `DocumentProcessor()` 초기화 직전 프리패치 훅 호출 |
| `src/util/__init__.py` | 신규 | 패키지 선언(빈 파일) |
| `src/util/minio_resource.py` | 신규 | `FileLock` + `download_resource_files(bucket_name, resource_id, path)` (104줄, workflow 구현과 동일) |
| `tests/unit/test_minio_resource_unit.py` | 신규 | 단위 테스트 9종 |

### 주요 변경 포인트
```python
# main.py — @app.get('/healthcheck') 직후, DocumentProcessor 초기화 이전
download_resource_files(
    bucket_name='preprocessor',
    resource_id=settings.PREPROCESSOR_ID,
    path='/app/resource',
)
```

```python
# common/settings.py
class Settings(BaseSettings):
    PREPROCESSOR_ID: Optional[str] = _ID  # env var PREPROCESSOR_ID 매핑
    ...

class MinioConfig(BaseSettings):
    MINIO_ENDPOINT: str
    MINIO_ACCESS_KEY: str
    MINIO_SECRET_KEY: str

minio_config = MinioConfig()
```

---

## 사전 조건 (GenOS 측에서 이미 충족)

이 PR 단독으로 동작하는 것이 아니라 GenOS 오케스트레이션·인프라가 아래를 이미 주입하고 있음 — 그래서 doc_parser 측 변경만으로 해결됨.

- **`PREPROCESSOR_ID` env 주입:** admin-api가 Pod 생성 시 주입 (`admin-api/src/service/system/preprocessor_service.py:652`)
- **MinIO 접속 정보 주입:** 전처리기 k8s deployment template에 `envFrom: llmops-minio-client-configmap`·`llmops-minio-client-secret` 연결됨 (`orchestrator/src/k8s-manifest-templates/preprocessor/preprocessor-deployment.yaml`)
- **MinIO 버킷·업로드 경로:** `preprocessor` 버킷의 `{id}/resource/**` — admin-api 업로드 경로와 일치
- **의존성:** `minio==7.2.20` 이미 `pyproject.toml`에 선언됨

---

## 테스트

### 단위 테스트 결과
```
$ pytest tests/unit/test_minio_resource_unit.py -v
9 passed in 1.47s
```

| # | 테스트 | 커버 |
|---|--------|------|
| 1 | `test_file_lock_acquires_and_writes_pid` | FileLock 정상 획득·pid 기록 |
| 2 | `test_file_lock_times_out_when_held_elsewhere` | 외부 락 선점 시 `TimeoutError` |
| 3 | `test_file_lock_blocks_concurrent_acquire` | 스레드 간 순차 획득 보장 |
| 4 | `test_download_resource_files_downloads_all_objects` | 다중 오브젝트·하위 디렉터리 경로 정확성 |
| 5 | `test_download_resource_files_skips_existing` | 기존 파일 SKIP |
| 6 | `test_download_resource_files_skips_directory_entries` | `is_dir=True` 스킵 |
| 7 | `test_download_resource_files_empty_list` | 빈 리스트 정상 완료 |
| 8 | `test_download_resource_files_propagates_exception` | MinIO 예외 re-raise |
| 9 | `test_download_resource_files_ignores_empty_relative_path` | `rel_path == \"\"` 스킵 |

### 통합/수동 테스트 체크리스트
- [ ] 이미지 빌드 및 레지스트리 푸시
- [ ] QA 환경(`192.168.76.180:40908/admin/resource/preprocessor/detail/226`) 전처리기 재배포
- [ ] K9s shell 접속 후 `ls -al /app/resource` — 업로드된 파일 전체 확인
- [ ] `/var/log/supervisor/gunicorn_stdout.log` 에 `Acquired lock` / `Downloading [i/N]` / `Completed!` 로그
- [ ] gunicorn workers=5 상황에서 2개 이상 워커가 `[SKIP …] already exists` 출력
- [ ] `/run` 엔드포인트 호출 — 기존 전처리 회귀 없음
- [ ] 리소스 미업로드 전처리기 (`0 files`) 정상 기동

---

## 리스크·롤백

### 리스크
- **MinIO 접속 실패 시 Pod 기동 실패:** 의도된 동작. k8s `startupProbe` 가 healthcheck 를 기다리므로 MinIO 회복 전까지 CrashLoopBackOff 로 대기. 리소스 없이 조용히 기동되는 것보다 안전.
- **락 타임아웃(`timeout_sec=3600`):** 대량 파일 + 느린 MinIO 환경에서 1시간 초과 시 워커 기동 실패 가능. 실제 QA 데이터(수 MB ~ 수 백 MB) 기준으로는 여유.
- **디스크 사용:** `/app/resource`는 컨테이너 ephemeral storage. Pod 재시작 시 재다운로드(단, `os.path.exists` 스킵으로 재시작 자체 비용만).

### 롤백
- 이 PR revert 만으로 원복 가능(코드 변경 한정, 스키마·외부 시스템 변경 없음).

---

## 리뷰 요청 포인트

@claude 아래 관점에서 상세 리뷰 부탁드립니다:

1. **FileLock 구현 안전성**
   - `fcntl.flock` 은 프로세스 크래시 시 자동 해제되지만, `__exit__` 에서 `close()` 전 `flock(LOCK_UN)` 순서가 올바른지
   - `LOCK_NB` + 폴링 루프의 busy-wait 특성과 `poll_interval=0.2s` 의 적절성

2. **main.py import 순서·부작용**
   - module-level 에서 `download_resource_files()` 를 호출 — FastAPI app 이미 생성된 후이므로 healthcheck 에는 응답 가능. 하지만 gunicorn worker 부팅 중이면 `startupProbe` 실패 가능성. 현 `startupProbe failureThreshold=120, periodSeconds=5` (10분 한도)로 커버되는지
   - `sys.path.append(.../util)` 은 이미 `from util.minio_resource import ...` 가 동작하므로 사실상 불필요. 제거 가능한지

3. **Settings `PREPROCESSOR_ID` 필드명**
   - 이슈 가이드 원문은 `ID: Optional[str] = _ID` 였으나, main.py가 `settings.PREPROCESSOR_ID` 를 참조하도록 되어 있어 필드명을 env 변수와 동일하게 `PREPROCESSOR_ID` 로 통일. 이 선택이 적절한지

4. **테스트 커버리지**
   - autouse fixture 로 MinIO/MQ env 치환 — 실제 배포 환경 시뮬레이션 충분한지
   - FileLock 동시성은 threading 기반 — multiprocessing 시나리오(실제 gunicorn) 도 추가해야 하는지

5. **로깅·운영성**
   - 실패 시 로그 레벨·메시지가 QA 팀이 추적하기에 충분한지
   - `len(objects)` 기준 진행률 로그의 verbosity

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic MinIO-backed resource download at startup when configured.
  * New configurable MinIO connection settings and an optional preprocessor identifier.

* **Reliability**
  * Safer concurrent resource downloads via filesystem locking to prevent corruption/races.

* **Tests**
  * New unit tests covering resource download and file-locking behaviors.

* **Chores**
  * Updated ignore rules and minor cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->