### PR TITLE
[CI] Slack 알림 GitHub Actions 워크플로우 추가

### DIFF
--- a/.github/workflows/issue_slack.yml
+++ b/.github/workflows/issue_slack.yml
@@ -1,0 +1,91 @@
+name: "Message Issue to slack"
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  send-messages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run github variable preprocess
+        uses: jannekem/run-python-script-action@v1
+        id: preprocess
+        with:
+          created_time: ${{ github.event.issue.created_at }}
+          script: |
+            def convert_time_to_kr(time_utc):
+              curtime = time_utc
+              date, time = curtime.split("T")
+              year, month, day = date.split("-")
+              day = int(day)
+              h, m, s = time.split(":")
+              h = int(h)
+              h += 9
+              if h >= 24:
+                h -= 24
+                day += 1
+              h = str(h)
+              day = str(day)
+              date = year + '-' + month + '-' + day
+              time = h + ':' + m + ':' + s
+
+              return date + " " + time[:-1]
+            created_time = get_input("created_time")
+            output = convert_time_to_kr(created_time)
+            set_output("time", output)
+      - name: Create Slack payload
+        id: create_payload
+        run: |
+          # jq를 사용하여 안전한 JSON 생성
+          jq -n \
+            --arg title "$ISSUE_TITLE" \
+            --arg number "$ISSUE_NUMBER" \
+            --arg url "$ISSUE_URL" \
+            --arg user "$ISSUE_USER" \
+            --arg avatar "$ISSUE_AVATAR" \
+            --arg time "$CREATED_TIME" \
+            '{
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*새로운 Issue가 생성되었습니다* :fire: \n\n *\($title)* #\($number) \n Link: <\($url)> "
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Username:* \n \($user)"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Created at:* \n \($time)"
+                    }
+                  ],
+                  "accessory": {
+                    "type": "image",
+                    "image_url": $avatar,
+                    "alt_text": "profile_image"
+                  }
+                }
+              ]
+            }' > payload.json
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_USER: ${{ github.event.issue.user.login }}
+          ISSUE_AVATAR: ${{ github.event.issue.user.avatar_url }}
+          CREATED_TIME: ${{ steps.preprocess.outputs.time }}
+      - name: Send Issue created message to Slack
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload-file-path: "./payload.json"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/issue_slack.yml
+++ b/.github/workflows/issue_slack.yml
@@ -14,26 +14,14 @@ jobs:
         with:
           created_time: ${{ github.event.issue.created_at }}
           script: |
-            def convert_time_to_kr(time_utc):
-              curtime = time_utc
-              date, time = curtime.split("T")
-              year, month, day = date.split("-")
-              day = int(day)
-              h, m, s = time.split(":")
-              h = int(h)
-              h += 9
-              if h >= 24:
-                h -= 24
-                day += 1
-              h = str(h)
-              day = str(day)
-              date = year + '-' + month + '-' + day
-              time = h + ':' + m + ':' + s
-
-              return date + " " + time[:-1]
-            created_time = get_input("created_time")
-            output = convert_time_to_kr(created_time)
-            set_output("time", output)
+        from datetime import datetime, timedelta, timezone
+        kst = timezone(timedelta(hours=9))
+        created_time = get_input("created_time")
+        # GitHub timestamps end with 'Z' (UTC); fromisoformat in 3.11+ accepts it,
+        # but normalize for older runtimes too.
+        iso = created_time.replace("Z", "+00:00")
+        dt_kst = datetime.fromisoformat(iso).astimezone(kst)
+        set_output("time", dt_kst.strftime("%Y-%m-%d %H:%M:%S"))
       - name: Create Slack payload
         id: create_payload
         run: |

--- a/.github/workflows/mention-comment-notify.yml
+++ b/.github/workflows/mention-comment-notify.yml
@@ -1,0 +1,111 @@
+name: "Mention Comment Notify to Slack"
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  mention-comment-notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse Mentions in Comment
+        id: parse-comment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            // 'core', 'github', 'context'는 github-script 액션에서 자동으로 주입됨.
+
+            // 1) GitHub Secrets로부터 멘션 매핑(JSON) 읽기
+            const userMapJson = process.env.GENOS_MAP_JSON || "{}";
+            const userMap = JSON.parse(userMapJson);
+
+            // 2) 봇 코멘트 무시 (coderabbitai[bot] 등 GitHub bot 계정)
+            const commentUser = context.payload.comment?.user?.login || "";
+            const commentUserType = context.payload.comment?.user?.type || "";
+            if (commentUserType === "Bot") {
+              console.log("Skipping bot comment from:", commentUser);
+              core.setOutput("shouldSend", "false");
+              return;
+            }
+
+            // 3) 이슈 코멘트 본문
+            const commentBody = context.payload.comment?.body || "";
+            const mentionRegex = /@([a-zA-Z0-9-_]+)/g;
+            let transformed = commentBody;
+            let hasMention = false;
+            let match;
+
+            console.log("commentBody =", commentBody);
+            console.log("userMap =", userMap);
+            // 3) GitHub 멘션 → Slack 멘션 치환
+            while ((match = mentionRegex.exec(commentBody)) !== null) {
+              console.log("Found mention:", match[1]);
+              const ghId = match[1];     // @ 뒤의 GitHub ID
+
+              // Skip copilot mentions as they are for AI instructions, not human notifications
+              if (ghId.toLowerCase() === "copilot") {
+                console.log("Skipping copilot mention");
+                continue;
+              }
+
+              // Explicitly set hasMention only for valid (non-copilot) mentions
+              hasMention = true;
+              if (userMap[ghId]) {
+                // Slack 유저 ID로 치환 (ex: @명대우 -> <@UABC12345>)
+                transformed = transformed.replace(`@${ghId}`, `<@${userMap[ghId]}>`);
+              }
+            }
+
+            // 멘션이 전혀 없으면 Slack 보낼 필요 X
+            if (!hasMention) {
+              core.setOutput("shouldSend", "false");
+              return;
+            }
+
+            // 4) Slack에 표시할 정보
+            const issueUrl = context.payload.issue?.html_url || "";
+            const issueNumber = context.payload.issue?.number || "";
+            const issueTitle = context.payload.issue?.title || "";
+
+            // 5) Slack Blocks 구조를 JavaScript 객체로 생성
+            const blocks = [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": `*이슈 댓글에 멘션이 발생했습니다!* \n\n` +
+                          `이슈: <${issueUrl}|#${issueNumber} - ${issueTitle}> \n` +
+                          `*코멘트 내용:* ${transformed}`
+                }
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "mrkdwn",
+                    "text": `By: ${commentUser}`
+                  }
+                ]
+              }
+            ];
+
+            // 6) Slack에 보낼 최종 Payload
+            const payloadObj = {
+              blocks: blocks
+            };
+
+            // 7) JSON 문자열로 변환 + GitHub Actions output에 저장
+            core.setOutput("shouldSend", "true");
+            core.setOutput("payload", JSON.stringify(payloadObj));
+        env:
+          GENOS_MAP_JSON: ${{ secrets.GENOS_MAP_JSON }}
+
+      - name: Send Slack Notification
+        if: steps.parse-comment.outputs.shouldSend == 'true'
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          # 바로 위 단계에서 만든 payload 그대로 사용
+          payload: ${{ steps.parse-comment.outputs.payload }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/mention-comment-notify.yml
+++ b/.github/workflows/mention-comment-notify.yml
@@ -30,7 +30,8 @@ jobs:
 
             // 3) 이슈 코멘트 본문
             const commentBody = context.payload.comment?.body || "";
-            const mentionRegex = /@([a-zA-Z0-9-_]+)/g;
+            // GitHub usernames: alphanumeric and single hyphens, max 39 chars.
+            const mentionRegex = /(?<![A-Za-z0-9_])@([A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))/g;
             let transformed = commentBody;
             let hasMention = false;
             let match;

--- a/.github/workflows/milestone-changed.yml
+++ b/.github/workflows/milestone-changed.yml
@@ -1,0 +1,122 @@
+name: "Milestone Change Notify to Slack"
+
+on:
+  issues:
+    types: [milestoned, demilestoned]
+  pull_request:
+    types: [milestoned, demilestoned]
+
+env:
+  # ▼ 필요에 맞게 수정하세요 (쉼표로 여러 개 가능)
+  TARGET_IN_MILESTONES: "v2.1.0 05/07 운영망 배포, v2.2.0 05/21 운영망 배포"
+  TARGET_FROM_MILESTONES: "v2.1.0 05/07 운영망 배포, v2.2.0 05/21 운영망 배포"
+  TIMEZONE_OFFSET_KST_HOURS: "9" # KST(+9)
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Slack payload (filter by milestone rules)
+        id: build
+        uses: actions/github-script@v6
+        env:
+          TARGET_IN_MILESTONES: ${{ env.TARGET_IN_MILESTONES }}
+          TARGET_FROM_MILESTONES: ${{ env.TARGET_FROM_MILESTONES }}
+          TIMEZONE_OFFSET_KST_HOURS: ${{ env.TIMEZONE_OFFSET_KST_HOURS }}
+        with:
+          script: |
+            // github-script 환경에서는 context/core/github 가 이미 주입되어 있습니다.
+            const act = context.payload.action; // 'milestoned' | 'demilestoned'
+            const isIssue = !!context.payload.issue;
+            const obj = isIssue ? context.payload.issue : context.payload.pull_request;
+            const typeLabel = isIssue ? 'Issue' : 'PR';
+
+            // fork에서 온 PR은 repo 시크릿 접근 불가 → 슬랙 전송 단계 스킵하도록 플래그 설정
+            const isForkPR = !isIssue && !!context.payload.pull_request?.head?.repo?.fork;
+
+            const msTitle = (obj?.milestone?.title || '').trim();
+            const repo = `${context.repo.owner}/${context.repo.repo}`;
+            const actor = context.actor;
+            const number = obj?.number;
+            const title = obj?.title || '';
+            const html_url = obj?.html_url || '';
+            const eventTime = obj?.updated_at || obj?.created_at || new Date().toISOString();
+
+            // 간단 KST 변환 (+offset hours)
+            const toLocal = (iso, offsetHours) => {
+              try {
+                const dt = new Date(iso);
+                const ms = dt.getTime() + (parseInt(offsetHours || '0', 10) * 3600 * 1000);
+                const d = new Date(ms);
+                const p = (n) => String(n).padStart(2, '0');
+                return `${d.getUTCFullYear()}-${p(d.getUTCMonth()+1)}-${p(d.getUTCDate())} ${p(d.getUTCHours())}:${p(d.getUTCMinutes())}:${p(d.getUTCSeconds())}`;
+              } catch {
+                return iso;
+              }
+            };
+            const eventTimeKST = toLocal(eventTime, process.env.TIMEZONE_OFFSET_KST_HOURS);
+
+            const inTargets = (process.env.TARGET_IN_MILESTONES || '')
+              .split(',').map(s => s.trim()).filter(Boolean);
+            const fromTargets = (process.env.TARGET_FROM_MILESTONES || '')
+              .split(',').map(s => s.trim()).filter(Boolean);
+
+            core.info(`action=${act} type=${typeLabel} number=${number} milestone='${msTitle}'`);
+            core.info(`IN targets=[${inTargets.join(', ')}], FROM targets=[${fromTargets.join(', ')}]`);
+            if (isForkPR) core.info('Fork PR detected -> will skip Slack (secrets not available)');
+
+            let shouldSend = false;
+            let variant = ''; // 'IN' | 'FROM'
+
+            if (act === 'milestoned' && inTargets.includes(msTitle)) {
+              shouldSend = true;
+              variant = 'IN';
+            }
+            if (act === 'demilestoned' && fromTargets.includes(msTitle)) {
+              shouldSend = true;
+              variant = 'FROM';
+            }
+
+            if (!shouldSend) {
+              core.setOutput('shouldSend', 'false');
+              core.setOutput('skipSlack', isForkPR ? 'true' : 'false');
+              return;
+            }
+
+            const headline =
+              variant === 'IN'
+                ? `*:triangular_flag_on_post: ${typeLabel} #${number}* 가 *'${msTitle}'* 마일스톤으로 설정되었습니다.`
+                : `*:arrow_right: ${typeLabel} #${number}* 가 *'${msTitle}'* 마일스톤에서 제거되었습니다.`;
+
+            const blocks = [
+              {
+                type: "section",
+                text: { type: "mrkdwn", text: `*[${repo}]* ${typeLabel} <${html_url}|#${number}>` }
+              },
+              {
+                type: "section",
+                text: { type: "mrkdwn", text: `*제목*: ${title}\n${headline}` }
+              },
+              {
+                type: "section",
+                fields: [
+                  { type: "mrkdwn", text: `*액션*\n${act}` },
+                  { type: "mrkdwn", text: `*변경자*\n${actor}` },
+                  { type: "mrkdwn", text: `*마일스톤*\n${msTitle || '-'}` },
+                  { type: "mrkdwn", text: `*시각(KST)*\n${eventTimeKST}` }
+                ]
+              }
+            ];
+
+            core.setOutput('shouldSend', 'true');
+            core.setOutput('skipSlack', isForkPR ? 'true' : 'false');
+            core.setOutput('payload', JSON.stringify({ blocks }));
+
+      - name: Send Slack
+        if: steps.build.outputs.shouldSend == 'true' && steps.build.outputs.skipSlack != 'true'
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: ${{ steps.build.outputs.payload }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/pr_slack.yml
+++ b/.github/workflows/pr_slack.yml
@@ -1,0 +1,81 @@
+name: "Message PR to slack"
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  send-messages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run github variable preprocess
+        uses: jannekem/run-python-script-action@v1
+        id: preprocess
+        with:
+          created_time: ${{ github.event.pull_request.created_at }}
+          script: |
+            def convert_time_to_kr(time_utc):
+              curtime = time_utc
+              date, time = curtime.split("T")
+              year, month, day = date.split("-")
+              day = int(day)
+              h, m, s = time.split(":")
+              h = int(h)
+              h += 9
+              if h >= 24:
+                h -= 24
+                day += 1
+              h = str(h)
+              day = str(day)
+              date = year + '-' + month + '-' + day
+              time = h + ':' + m + ':' + s
+
+              return date + " " + time[:-1]
+            created_time = get_input("created_time")
+            output = convert_time_to_kr(created_time)
+            set_output("time", output)
+      - name: Send PR created message to Slack
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+                "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*새로운 PR이 생성되었습니다* :fire: \n\n *${{ github.event.pull_request.title }}* #${{ github.event.pull_request.number }} \n branch: `${{ github.head_ref }}` >> `${{ github.base_ref }}` \n Link: <${{ github.event.pull_request.html_url }}> "
+                    }
+                },
+                {
+                    "type": "section",
+                    "fields": [
+                      {
+                          "type": "mrkdwn",
+                          "text": "*Username:* \n ${{ github.event.pull_request.user.login }}"
+                      },
+                      {
+                          "type": "mrkdwn",
+                          "text": "*Created at:* \n ${{ steps.preprocess.outputs.time }}"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Updated at:* \n ${{ github.event.pull_request.updated_at }}"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Status:* \n ${{ github.event.pull_request.state }}"
+                      }
+                    ],
+                    "accessory": {
+                      "type": "image",
+                      "image_url": "${{ github.event.pull_request.user.avatar_url }}",
+                      "alt_text": "profile_image"
+                    }
+                }
+                ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## Summary

- 이슈 생성, PR 생성, 댓글 멘션, 마일스톤 변경 4가지 이벤트를 `#genos-지능형전처리기` Slack 채널로 알림
- GenOS의 동일한 워크플로우 기반, `ubuntu-latest` runner로 조정
- `GENOS_MAP_JSON` organization secret(All repositories) 재사용 — 별도 등록 불필요
- 마일스톤 `v2.1.0 05/07 운영망 배포` / `v2.2.0 05/21 운영망 배포` (2주 단위) 동시 등록

## 추가된 파일

| 파일 | 트리거 | 비고 |
|---|---|---|
| `.github/workflows/issue_slack.yml` | `issues: [opened]` | jq로 payload 생성 |
| `.github/workflows/pr_slack.yml` | `pull_request: [opened]` | branch/status 포함 |
| `.github/workflows/mention-comment-notify.yml` | `issue_comment: [created]` | `GENOS_MAP_JSON`으로 GitHub→Slack ID 매핑 |
| `.github/workflows/milestone-changed.yml` | `issues/PR: [milestoned, demilestoned]` | v2.1.0·v2.2.0 대상 |

- [x] `SLACK_WEBHOOK_URL` repository secret 등록 — doc_parser → Settings → Secrets and variables → Actions (노출된 URL은 먼저 Slack App 페이지에서 Revoke 후 재발급)

## 검증 방법 (머지 후)

1. 테스트 이슈 생성 → `#genos-지능형전처리기`에 알림 도달 확인
2. 본인 GitHub ID로 멘션 댓글 → Slack 멘션 포함 확인
3. 이슈에 `v2.1.0 05/07 운영망 배포` 마일스톤 부여 → 알림 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated Slack notifications for new issues, new pull requests, milestone assignments/removals, and @mentions in issue comments to improve team communication and workflow visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->