### PR TITLE
[PDF변환] 빌드시 추가 폰트 68개 설치 과정 적용

### DIFF
--- a/genon/preprocessor/docker/Dockerfile
+++ b/genon/preprocessor/docker/Dockerfile
@@ -156,7 +156,20 @@ RUN --mount=type=cache,target=${HF_HOME} \
     chmod +x /app/hwp_sdk/convtext
 
 ############################
-# 4-2) 모델 아티팩트
+# 4-2) 추가 폰트 아티팩트
+############################
+FROM builder AS font_artifacts
+
+RUN --mount=type=cache,target=${HF_HOME} \
+    echo "[INFO] Downloading extra fonts from HF (public)..." && \
+    mkdir -p /app/extra_fonts && \
+    huggingface-cli download HeechanKim-Genon/additional_fonts \
+      --repo-type dataset \
+      --local-dir /app/extra_fonts \
+      --local-dir-use-symlinks False
+
+############################
+# 4-3) 모델 아티팩트
 ############################
 FROM builder AS models_artifacts
 ARG APP_VENV
@@ -246,6 +259,10 @@ COPY ./genon/preprocessor/src /app/src
 
 # 🔴 HWP sdk 다운로드
 COPY --from=sdk_artifacts /app/hwp_sdk /app/hwp_sdk
+
+# 추가 폰트 설치
+COPY --from=font_artifacts /app/extra_fonts /usr/share/fonts/additional
+RUN fc-cache -f -v
 
 # ✅ 공통 venv 위치만 복사
 COPY --from=builder ${APP_VENV} ${APP_VENV}


### PR DESCRIPTION
## Summary
- 빌드시 LibreOffice 자동 설치 폰트 외에, 추가 폰트 68개 설치 과정 적용
- HuggingFace public repo(`HeechanKim-Genon/additional_fonts`)에서 다운로드 후 시스템 폰트 경로에 등록
- `font_artifacts` 스테이지 추가 → runtime 스테이지에서 `fc-cache`로 등록

## Changes
- `genon/preprocessor/docker/Dockerfile`: `font_artifacts` 스테이지 추가, runtime에 COPY + fc-cache 추가

## Test plan
- [ ] 빌드 후 컨테이너 내에서 `fc-list` 로 추가 폰트 68개 확인

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container runtime with additional system fonts to support expanded text rendering capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->