### PR TITLE
Bug/190-bug-pypdfium2-버전-업그레이드에-따른-함수-교체

### DIFF
--- a/docling/backend/pypdfium2_backend.py
+++ b/docling/backend/pypdfium2_backend.py
@@ -256,7 +256,7 @@ class PyPdfiumPageBackend(PdfPageBackend):
         page_size = self.get_size()
         with pypdfium2_lock:
             for obj in self._ppage.get_objects(filter=[pdfium_c.FPDF_PAGEOBJ_IMAGE]):
-                pos = obj.get_pos()
+                pos = obj.get_bounds()
                 cropbox = BoundingBox.from_tuple(
                     pos, origin=CoordOrigin.BOTTOMLEFT
                 ).to_top_left_origin(page_height=page_size.height)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     'docling-parse (>=4.0.0,<5.0.0)',
     "docling-ibm-models==3.10.3",
     'filetype (>=1.2.0,<2.0.0)',
-    'pypdfium2 (>=4.30.0, !=4.30.1, <6.0.0)',
+    'pypdfium2 (>=5.0.0, <6.0.0)',
     'pydantic-settings (>=2.3.0,<3.0.0)',
     'huggingface_hub (>=0.23,<1)',
     'requests (>=2.32.2,<3.0.0)',


### PR DESCRIPTION
### 📌 Summary
* PR [#163](https://github.com/genonai/doc_parser/pull/163#issue-4043444798)에서 진행된 `pypdfium2` 라이브러리 버전 업그레이드(4.30.0 → 5.6.0)로 인해 발생한 에러를 수정.
* 기존 `get_pos()` 메소드가 v5.x에서 삭제됨에 따라, 이를 최신 API인 `get_bounds()`로 교체.

### ⚙️ 주요 변경 사항
* **API 마이그레이션**: [[PR #163](https://github.com/genonai/doc_parser/pull/163#issue-4043444798)](https://github.com/genonai/doc_parser/pull/163#issue-4043444798)의 의존성 업데이트 결과, 더 이상 지원되지 않는 `PdfPageObject.get_pos()` 호출부를 `get_bounds()`로 수정.
* **호환성 확보**: `docling` 백엔드에서 PDF 객체의 좌표를 정상적으로 가져오지 못해 발생하던 `AttributeError`를 해결함.

### 🛠 코드 변경 내역 (Diff)
```diff
- pos = obj.get_pos()
+ pos = obj.get_bounds()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image bounds detection in PDF page processing to produce more accurate bitmaps and crops.
* **Chores**
  * Upgraded pypdfium2 dependency to the 5.x series for updated PDF handling and extraction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->