### PR TITLE
[Hotfix] HWP→PDF 변환 실패 수정 (사이냅 SDK 출력 파일명 미스매치)

### DIFF
--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -111,6 +111,8 @@ def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
 
 
 def _convert_to_pdf_sdk(file_path: str) -> str | None:
+    sdk_out_dir: Path | None = None
+    keep_out_dir = False  # 폴백 경로 리턴 시 임시 디렉토리 보존
     try:
         # 1. PDF_SDK_HOME 환경변수 (도커 환경) → 2. repo_root/pdf_sdk (로컬 실행)
         pdf_sdk_home = os.environ.get(
@@ -124,8 +126,19 @@ def _convert_to_pdf_sdk(file_path: str) -> str | None:
         os.makedirs(font_cache, exist_ok=True)
 
         in_path = Path(file_path).resolve()
-        out_dir = in_path.parent
-        pdf_path = in_path.with_suffix('.pdf')
+        # NFS 쓰기 권한 / 출력 파일명 추측 미스매치 회피를 위해 임시 디렉토리에 출력
+        sdk_out_dir = Path(tempfile.mkdtemp(prefix="pdfsdk_out_"))
+
+        _log.info(
+            f"[convert_to_pdf:sdk] preflight: "
+            f"binary_exists={os.path.exists(binary)} "
+            f"binary_x={os.access(binary, os.X_OK)} "
+            f"fonts_dir_exists={os.path.exists(fonts_dir)} "
+            f"moduledata_exists={os.path.exists(moduledata)} "
+            f"input_exists={in_path.exists()} "
+            f"input_size={in_path.stat().st_size if in_path.exists() else 'N/A'} "
+            f"sdk_out_dir={sdk_out_dir}"
+        )
 
         with tempfile.TemporaryDirectory() as tmp:
             # fontconfig conf 파일을 현재 SDK 경로 기준으로 패치 (원본은 건드리지 않음)
@@ -141,20 +154,53 @@ def _convert_to_pdf_sdk(file_path: str) -> str | None:
             cmd = [
                 binary,
                 "-i", str(in_path),
-                "-o", str(out_dir),
+                "-o", str(sdk_out_dir),
                 "-t", tmp,
                 "-f", fonts_dir,
                 "-e", "-1",
                 "-p", "1",
             ]
-            proc = subprocess.run(cmd, env=env, capture_output=True, text=True)
-            if proc.returncode == 0 and pdf_path.exists():
-                return str(pdf_path)
-            _log.warning(f"[convert_to_pdf:sdk] stderr: {proc.stderr.strip()}")
+            _log.info(f"[convert_to_pdf:sdk] cmd: {cmd}")
+            proc = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=600)
+
+            produced = sorted(p for p in sdk_out_dir.glob("*") if p.is_file())
+            _log.info(
+                f"[convert_to_pdf:sdk] returncode={proc.returncode} "
+                f"produced_files={[p.name for p in produced]}"
+            )
+            _log.info(f"[convert_to_pdf:sdk] stdout={proc.stdout!r}")
+            _log.info(f"[convert_to_pdf:sdk] stderr={proc.stderr!r}")
+
+            pdf_files = [p for p in produced if p.suffix.lower() == ".pdf"]
+            if proc.returncode == 0 and pdf_files:
+                produced_pdf = pdf_files[0]
+                target_pdf = in_path.with_suffix('.pdf')
+                try:
+                    shutil.copy2(produced_pdf, target_pdf)
+                    _log.info(f"[convert_to_pdf:sdk] success → {target_pdf}")
+                    return str(target_pdf)
+                except OSError as e:
+                    _log.warning(
+                        f"[convert_to_pdf:sdk] target copy failed ({e}); "
+                        f"using temp path: {produced_pdf}"
+                    )
+                    keep_out_dir = True
+                    return str(produced_pdf)
+
+            _log.warning(
+                f"[convert_to_pdf:sdk] FAILED — "
+                f"returncode={proc.returncode}, produced={[p.name for p in produced]}"
+            )
             return None
-    except Exception as e:
-        _log.error(f"[convert_to_pdf:sdk] error: {e}")
+    except subprocess.TimeoutExpired as e:
+        _log.error(f"[convert_to_pdf:sdk] timeout after {e.timeout}s for {file_path}")
         return None
+    except Exception as e:
+        _log.error(f"[convert_to_pdf:sdk] error: {e}", exc_info=True)
+        return None
+    finally:
+        if sdk_out_dir is not None and sdk_out_dir.exists() and not keep_out_dir:
+            shutil.rmtree(sdk_out_dir, ignore_errors=True)
 
 
 def _patch_fontconfig(fonts_dir: str, font_cache: str, tmp_dir: str) -> str:

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -145,6 +145,8 @@ def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
 
 
 def _convert_to_pdf_sdk(file_path: str) -> str | None:
+    sdk_out_dir: Path | None = None
+    keep_out_dir = False  # 폴백 경로 리턴 시 임시 디렉토리 보존
     try:
         # 1. PDF_SDK_HOME 환경변수 (도커 환경) → 2. repo_root/pdf_sdk (로컬 실행)
         pdf_sdk_home = os.environ.get(
@@ -158,8 +160,19 @@ def _convert_to_pdf_sdk(file_path: str) -> str | None:
         os.makedirs(font_cache, exist_ok=True)
 
         in_path = Path(file_path).resolve()
-        out_dir = in_path.parent
-        pdf_path = in_path.with_suffix('.pdf')
+        # NFS 쓰기 권한 / 출력 파일명 추측 미스매치 회피를 위해 임시 디렉토리에 출력
+        sdk_out_dir = Path(tempfile.mkdtemp(prefix="pdfsdk_out_"))
+
+        _log.info(
+            f"[convert_to_pdf:sdk] preflight: "
+            f"binary_exists={os.path.exists(binary)} "
+            f"binary_x={os.access(binary, os.X_OK)} "
+            f"fonts_dir_exists={os.path.exists(fonts_dir)} "
+            f"moduledata_exists={os.path.exists(moduledata)} "
+            f"input_exists={in_path.exists()} "
+            f"input_size={in_path.stat().st_size if in_path.exists() else 'N/A'} "
+            f"sdk_out_dir={sdk_out_dir}"
+        )
 
         with tempfile.TemporaryDirectory() as tmp:
             # fontconfig conf 파일을 현재 SDK 경로 기준으로 패치 (원본은 건드리지 않음)
@@ -175,20 +188,53 @@ def _convert_to_pdf_sdk(file_path: str) -> str | None:
             cmd = [
                 binary,
                 "-i", str(in_path),
-                "-o", str(out_dir),
+                "-o", str(sdk_out_dir),
                 "-t", tmp,
                 "-f", fonts_dir,
                 "-e", "-1",
                 "-p", "1",
             ]
-            proc = subprocess.run(cmd, env=env, capture_output=True, text=True)
-            if proc.returncode == 0 and pdf_path.exists():
-                return str(pdf_path)
-            _log.warning(f"[convert_to_pdf:sdk] stderr: {proc.stderr.strip()}")
+            _log.info(f"[convert_to_pdf:sdk] cmd: {cmd}")
+            proc = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=600)
+
+            produced = sorted(p for p in sdk_out_dir.glob("*") if p.is_file())
+            _log.info(
+                f"[convert_to_pdf:sdk] returncode={proc.returncode} "
+                f"produced_files={[p.name for p in produced]}"
+            )
+            _log.info(f"[convert_to_pdf:sdk] stdout={proc.stdout!r}")
+            _log.info(f"[convert_to_pdf:sdk] stderr={proc.stderr!r}")
+
+            pdf_files = [p for p in produced if p.suffix.lower() == ".pdf"]
+            if proc.returncode == 0 and pdf_files:
+                produced_pdf = pdf_files[0]
+                target_pdf = in_path.with_suffix('.pdf')
+                try:
+                    shutil.copy2(produced_pdf, target_pdf)
+                    _log.info(f"[convert_to_pdf:sdk] success → {target_pdf}")
+                    return str(target_pdf)
+                except OSError as e:
+                    _log.warning(
+                        f"[convert_to_pdf:sdk] target copy failed ({e}); "
+                        f"using temp path: {produced_pdf}"
+                    )
+                    keep_out_dir = True
+                    return str(produced_pdf)
+
+            _log.warning(
+                f"[convert_to_pdf:sdk] FAILED — "
+                f"returncode={proc.returncode}, produced={[p.name for p in produced]}"
+            )
             return None
-    except Exception as e:
-        _log.error(f"[convert_to_pdf:sdk] error: {e}")
+    except subprocess.TimeoutExpired as e:
+        _log.error(f"[convert_to_pdf:sdk] timeout after {e.timeout}s for {file_path}")
         return None
+    except Exception as e:
+        _log.error(f"[convert_to_pdf:sdk] error: {e}", exc_info=True)
+        return None
+    finally:
+        if sdk_out_dir is not None and sdk_out_dir.exists() and not keep_out_dir:
+            shutil.rmtree(sdk_out_dir, ignore_errors=True)
 
 
 def _patch_fontconfig(fonts_dir: str, font_cache: str, tmp_dir: str) -> str:

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -34,6 +34,8 @@ def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
 
 
 def _convert_to_pdf_sdk(file_path: str) -> str | None:
+    sdk_out_dir: Path | None = None
+    keep_out_dir = False  # 폴백 경로 리턴 시 임시 디렉토리 보존
     try:
         # 1. PDF_SDK_HOME 환경변수 (도커 환경) → 2. repo_root/pdf_sdk (로컬 실행)
         pdf_sdk_home = os.environ.get(
@@ -47,8 +49,19 @@ def _convert_to_pdf_sdk(file_path: str) -> str | None:
         os.makedirs(font_cache, exist_ok=True)
 
         in_path = Path(file_path).resolve()
-        out_dir = in_path.parent
-        pdf_path = in_path.with_suffix('.pdf')
+        # NFS 쓰기 권한 / 출력 파일명 추측 미스매치 회피를 위해 임시 디렉토리에 출력
+        sdk_out_dir = Path(tempfile.mkdtemp(prefix="pdfsdk_out_"))
+
+        _log.info(
+            f"[convert_to_pdf:sdk] preflight: "
+            f"binary_exists={os.path.exists(binary)} "
+            f"binary_x={os.access(binary, os.X_OK)} "
+            f"fonts_dir_exists={os.path.exists(fonts_dir)} "
+            f"moduledata_exists={os.path.exists(moduledata)} "
+            f"input_exists={in_path.exists()} "
+            f"input_size={in_path.stat().st_size if in_path.exists() else 'N/A'} "
+            f"sdk_out_dir={sdk_out_dir}"
+        )
 
         with tempfile.TemporaryDirectory() as tmp:
             patched_conf = _patch_fontconfig(fonts_dir, font_cache, tmp)
@@ -63,20 +76,53 @@ def _convert_to_pdf_sdk(file_path: str) -> str | None:
             cmd = [
                 binary,
                 "-i", str(in_path),
-                "-o", str(out_dir),
+                "-o", str(sdk_out_dir),
                 "-t", tmp,
                 "-f", fonts_dir,
                 "-e", "-1",
                 "-p", "1",
             ]
-            proc = subprocess.run(cmd, env=env, capture_output=True, text=True)
-            if proc.returncode == 0 and pdf_path.exists():
-                return str(pdf_path)
-            _log.warning(f"[convert_to_pdf:sdk] stderr: {proc.stderr.strip()}")
+            _log.info(f"[convert_to_pdf:sdk] cmd: {cmd}")
+            proc = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=600)
+
+            produced = sorted(p for p in sdk_out_dir.glob("*") if p.is_file())
+            _log.info(
+                f"[convert_to_pdf:sdk] returncode={proc.returncode} "
+                f"produced_files={[p.name for p in produced]}"
+            )
+            _log.info(f"[convert_to_pdf:sdk] stdout={proc.stdout!r}")
+            _log.info(f"[convert_to_pdf:sdk] stderr={proc.stderr!r}")
+
+            pdf_files = [p for p in produced if p.suffix.lower() == ".pdf"]
+            if proc.returncode == 0 and pdf_files:
+                produced_pdf = pdf_files[0]
+                target_pdf = in_path.with_suffix('.pdf')
+                try:
+                    shutil.copy2(produced_pdf, target_pdf)
+                    _log.info(f"[convert_to_pdf:sdk] success → {target_pdf}")
+                    return str(target_pdf)
+                except OSError as e:
+                    _log.warning(
+                        f"[convert_to_pdf:sdk] target copy failed ({e}); "
+                        f"using temp path: {produced_pdf}"
+                    )
+                    keep_out_dir = True
+                    return str(produced_pdf)
+
+            _log.warning(
+                f"[convert_to_pdf:sdk] FAILED — "
+                f"returncode={proc.returncode}, produced={[p.name for p in produced]}"
+            )
             return None
-    except Exception as e:
-        _log.error(f"[convert_to_pdf:sdk] error: {e}")
+    except subprocess.TimeoutExpired as e:
+        _log.error(f"[convert_to_pdf:sdk] timeout after {e.timeout}s for {file_path}")
         return None
+    except Exception as e:
+        _log.error(f"[convert_to_pdf:sdk] error: {e}", exc_info=True)
+        return None
+    finally:
+        if sdk_out_dir is not None and sdk_out_dir.exists() and not keep_out_dir:
+            shutil.rmtree(sdk_out_dir, ignore_errors=True)
 
 
 def _patch_fontconfig(fonts_dir: str, font_cache: str, tmp_dir: str) -> str:
@@ -1713,7 +1759,11 @@ class DocumentProcessor:
         # - auto_convert_to_pdf=False: 변환 없이 그대로 진행 (변경 전 동작; PDF 가정)
         if kwargs.get('auto_convert_to_pdf', True) and not _is_pdf(file_path):
             _log.info(f"[intelligent] Non-PDF input — auto-converting to PDF: {file_path}")
-            converted = convert_to_pdf(file_path, use_pdf_sdk=kwargs.get('use_pdf_sdk', True))
+            use_sdk = kwargs.get('use_pdf_sdk', True)
+            converted = convert_to_pdf(file_path, use_pdf_sdk=use_sdk)
+            if (not converted or not os.path.exists(converted)) and use_sdk:
+                _log.warning(f"[intelligent] SDK conversion failed → fallback to LibreOffice")
+                converted = convert_to_pdf(file_path, use_pdf_sdk=False)
             if not converted or not os.path.exists(converted):
                 raise GenosServiceException(1, f"PDF 변환 실패: {file_path}")
             file_path = converted


### PR DESCRIPTION
## 요약

2.0.0.3 배포 직후 발생한 **HWP 파일 처리 100% 실패** 핫픽스.

## 원인

`_convert_to_pdf_sdk` 가 사이냅 PDF SDK 출력 파일명을 잘못 추측:

| 입력 | 실제 SDK 출력 | 코드 기대값 |
|---|---|---|
| `Document-104918.hwp` | `Document-104918.hwp.pdf` | `Document-104918.pdf` |

코드: `pdf_path = in_path.with_suffix('.pdf')` 로 `.hwp` 를 `.pdf` 로 **교체** 가정.
실제 SDK: 입력 풀네임에 `.pdf` 를 **덧붙임**.

→ `pdf_path.exists()` 항상 False → 모든 HWP 가 `GenosServiceException(1, "PDF 변환 실패")` 로 강제 실패.
운영 컨테이너에서 `pdfConverter` 직접 실행으로 SDK 자체는 정상 (returncode=0, PDF 5MB 생성) 확인 — 순전히 호출 측 버그.

## 수정

`_convert_to_pdf_sdk` 를 세 facade 에서 동일하게 수정:

1. **임시 디렉토리에 출력** (`/tmp/pdfsdk_out_*/`) — 출력 파일명 추측에 의존하지 않고, NFS 쓰기 권한 의존도 제거
2. **glob 으로 PDF 회수** — 어떤 이름으로 떨어지든 잡을 수 있게
3. **의도한 위치 (`<basename>.pdf`) 로 `shutil.copy2`** — 다운스트림 호환 유지
4. **진단 로그 대폭 보강** — preflight 체크, `cmd`, `returncode`, `stdout`, `stderr`, `produced_files` 모두 기록 (이전엔 stderr 일부만)
5. **600초 타임아웃** 추가
6. `intelligent_processor.__call__` 에 SDK 실패 시 **LibreOffice 폴백** 추가 (방어선)

## 검증

운영 컨테이너에 웹 UI 핫리로드로 적용 후 `Document-104920.hwp` 재처리 → 성공:

```
[convert_to_pdf:sdk] returncode=0 produced_files=['Document-104920.hwp.pdf']
[convert_to_pdf:sdk] success → /nfs-root/docs/Document-104920.pdf
[intelligent] Converted PDF: /nfs-root/docs/Document-104920.pdf
...
Success: "/nfs-root/docs/Document-104920.hwp" (86.84 seconds)
```

## 변경 파일

- `genon/preprocessor/facade/intelligent_processor.py`
- `genon/preprocessor/facade/attachment_processor.py`
- `genon/preprocessor/facade/convert_processor.py`

## Test plan

- [ ] 머지 후 develop 기준으로 운영 핫픽스 코드와 동기 확인
- [ ] 실패했던 HWP (Document-104918, 104920) 재처리 성공 확인
- [ ] 회귀: PDF 직접 입력 / DOC / DOCX / PPT / PPTX / 이미지 1건씩 재처리 성공 확인
- [ ] 로그에 `returncode`, `produced_files` 정상 기록 확인

## 긴급도

**P0** — 2.0.0.3 머지된 상태에서 운영의 모든 HWP 파일 처리 막힘. 운영은 웹 UI 핫리로드로 임시 적용 중 (컨테이너 재시작 시 휘발). 이 PR 머지로 GitHub source-of-truth 와 운영 코드 동기화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced PDF conversion reliability with automatic fallback mechanism—if the primary conversion method fails, the system now automatically retries using an alternative approach
  * Improved file handling and cleanup for PDF conversion processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->