### PR TITLE
[FIX] HWP→PDF 변환 PDF 저장 + vector 메타 file_path 갱신 (#200)

### DIFF
--- a/genon/preprocessor/facade/gitbook_doc/intelligent_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/intelligent_processor.md
@@ -636,6 +636,7 @@ class GenOSVectorMeta(BaseModel):
     title: str = None              # 문서 제목
     created_date: int = None       # 작성일 (YYYYMMDD 정수)
     appendix: str = None           # ◄── 고유 필드: 매칭된 부록 파일명
+    file_path: Optional[str] = None  # ◄── 비-PDF 변환 시 변환된 PDF 의 로컬 경로
 ```
 
 **세 전처리기의 필드 비교**:
@@ -674,14 +675,16 @@ class GenOSVectorMetaBuilder:
         # ... (기본 필드들)
         self.title: Optional[str] = None
         self.created_date: Optional[int] = None
-        self.appendix: Optional[str] = None  # ◄── intelligent 전용
+        self.appendix: Optional[str] = None    # ◄── intelligent 전용
+        self.file_path: Optional[str] = None   # ◄── 변환된 PDF 경로 (비-PDF 입력 시)
 
     def build(self) -> GenOSVectorMeta:
         return GenOSVectorMeta(
             # ... (기본 필드들)
             title=self.title,
             created_date=self.created_date,
-            appendix=self.appendix or ""      # None이면 빈 문자열로 변환
+            appendix=self.appendix or "",     # None이면 빈 문자열로 변환
+            file_path=self.file_path,
         )
 ```
 
@@ -1027,8 +1030,11 @@ standalone_patterns = re.findall(
 ### 7.7 벡터 조립 — `compose_vectors()`
 
 ```python
-async def compose_vectors(self, document, chunks, file_path, request, **kwargs):
+async def compose_vectors(self, document, chunks, file_path, request,
+                          converted_pdf_path: Optional[str] = None, **kwargs):
 ```
+
+> **`converted_pdf_path`** : `__call__` 진입부에서 비-PDF 입력이 PDF 로 변환된 경우, 변환된 PDF 의 로컬 경로가 전달됨. 전달되면 각 vector 의 `file_path` 필드에 이 경로를 set 함 (변환 안 일어난 경우 None → `file_path` 미설정).
 
 `convert_processor`의 `compose_vectors()`와 유사하지만, **부록 매칭** 로직이 추가되고 **`authors` 추출이 없습니다**.
 
@@ -1195,11 +1201,24 @@ async def __call__(self, request: Request, file_path: str, **kwargs: dict):
         document.add_text(label=DocItemLabel.TEXT, text=".", prov=prov)
         chunks = self.split_documents(document, **kwargs)
 
-    # ⑥ 벡터 조립
+    # ⑥ 벡터 조립 (변환된 경우 converted_pdf_path 전달 → vector 메타의 file_path 에 반영)
     if len(chunks) >= 1:
-        vectors = await self.compose_vectors(document, chunks, file_path, request, **kwargs)
+        vectors = await self.compose_vectors(
+            document, chunks, file_path, request,
+            converted_pdf_path=converted_pdf_path, **kwargs,
+        )
     else:
         raise GenosServiceException(1, f"chunk length is 0")
+
+    # ⑦ 변환된 PDF 를 minio 에 업로드 (시각화 fetch 대상).
+    #    object key 는 원본 file_name 의 stem + ".pdf" (예: 'sample.hwp' → '<doc_id>/sample.pdf')
+    if converted_pdf_path and upload_files:
+        original_name = kwargs.get('file_name') or os.path.basename(converted_pdf_path)
+        pdf_object_name = os.path.splitext(original_name)[0] + '.pdf'
+        await upload_files(
+            [{'path': converted_pdf_path, 'name': pdf_object_name}],
+            request=request,
+        )
 
     return vectors
 ```

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -1076,6 +1076,7 @@ class GenOSVectorMeta(BaseModel):
     title: str = None
     created_date: int = None
     appendix: str = None ## !! appendix feature (2025-09-30, geonhee kim) !!
+    file_path: Optional[str] = None
 
 
 class GenOSVectorMetaBuilder:
@@ -1098,6 +1099,7 @@ class GenOSVectorMetaBuilder:
         self.title: Optional[str] = None
         self.created_date: Optional[int] = None
         self.appendix: Optional[str] = None # !! appendix feature (2025-09-30, geonhee kim) !!
+        self.file_path: Optional[str] = None
 
     def set_text(self, text: str) -> "GenOSVectorMetaBuilder":
         """텍스트와 관련된 데이터를 설정"""
@@ -1176,7 +1178,8 @@ class GenOSVectorMetaBuilder:
             media_files=self.media_files,
             title=self.title,
             created_date=self.created_date,
-            appendix=self.appendix or "" # !! appendix feature (2025-09-30, geonhee kim) !!
+            appendix=self.appendix or "", # !! appendix feature (2025-09-30, geonhee kim) !!
+            file_path=self.file_path,
         )
 
 
@@ -1429,7 +1432,7 @@ class DocumentProcessor:
         document = enrich_document(document, self.enrichment_options, **kwargs)
         return document
 
-    async def compose_vectors(self, document: DoclingDocument, chunks: List[DocChunk], file_path: str, request: Request, **kwargs: dict) -> \
+    async def compose_vectors(self, document: DoclingDocument, chunks: List[DocChunk], file_path: str, request: Request, converted_pdf_path: Optional[str] = None, **kwargs: dict) -> \
             list[dict]:
         title = ""
         created_date = 0
@@ -1469,6 +1472,9 @@ class DocumentProcessor:
             created_date=created_date,
             title=title
         )
+        # 비-PDF 입력이 변환된 경우 vector 의 file_path 를 변환 PDF 경로로 set.
+        if converted_pdf_path:
+            global_metadata['file_path'] = converted_pdf_path
 
         current_page = None
         chunk_index_on_page = 0
@@ -1757,6 +1763,7 @@ class DocumentProcessor:
         # 입력이 PDF가 아닐 때 동작:
         # - auto_convert_to_pdf=True (default): PDF SDK/LibreOffice 로 자동 변환 후 진입
         # - auto_convert_to_pdf=False: 변환 없이 그대로 진행 (변경 전 동작; PDF 가정)
+        converted_pdf_path: Optional[str] = None
         if kwargs.get('auto_convert_to_pdf', True) and not _is_pdf(file_path):
             _log.info(f"[intelligent] Non-PDF input — auto-converting to PDF: {file_path}")
             use_sdk = kwargs.get('use_pdf_sdk', True)
@@ -1767,6 +1774,7 @@ class DocumentProcessor:
             if not converted or not os.path.exists(converted):
                 raise GenosServiceException(1, f"PDF 변환 실패: {file_path}")
             file_path = converted
+            converted_pdf_path = converted
             _log.info(f"[intelligent] Converted PDF: {file_path}")
 
         document: DoclingDocument = self.load_documents(file_path, **kwargs)
@@ -1824,9 +1832,22 @@ class DocumentProcessor:
 
         vectors = []
         if len(chunks) >= 1:
-            vectors: list[dict] = await self.compose_vectors(document, chunks, file_path, request, **kwargs)
+            vectors: list[dict] = await self.compose_vectors(
+                document, chunks, file_path, request,
+                converted_pdf_path=converted_pdf_path,
+                **kwargs,
+            )
         else:
             raise GenosServiceException(1, f"chunk length is 0")
+
+        # 변환된 PDF 를 minio 에 업로드 (시각화 fetch 대상). 원본 파일명 키 자리에 덮어씀.
+        # upload_files 가 업로드 후 로컬 파일을 os.remove 하므로 파싱이 모두 끝난 이 시점에 호출.
+        if converted_pdf_path and upload_files:
+            original_name = kwargs.get('file_name') or os.path.basename(converted_pdf_path)
+            await upload_files(
+                [{'path': converted_pdf_path, 'name': original_name}],
+                request=request,
+            )
 
         """
         # 미디어 파일 업로드 방법

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -1840,12 +1840,14 @@ class DocumentProcessor:
         else:
             raise GenosServiceException(1, f"chunk length is 0")
 
-        # 변환된 PDF 를 minio 에 업로드 (시각화 fetch 대상). 원본 파일명 키 자리에 덮어씀.
+        # 변환된 PDF 를 minio 에 업로드. object key 는 원본 파일명의 stem + ".pdf".
+        # (예: 원본 file_name='sample.hwp' → minio key='<doc_id>/sample.pdf')
         # upload_files 가 업로드 후 로컬 파일을 os.remove 하므로 파싱이 모두 끝난 이 시점에 호출.
         if converted_pdf_path and upload_files:
             original_name = kwargs.get('file_name') or os.path.basename(converted_pdf_path)
+            pdf_object_name = os.path.splitext(original_name)[0] + '.pdf'
             await upload_files(
-                [{'path': converted_pdf_path, 'name': original_name}],
+                [{'path': converted_pdf_path, 'name': pdf_object_name}],
                 request=request,
             )
 


### PR DESCRIPTION
## Summary
- 비-PDF(HWP 등) 입력이 PDF 로 변환된 경우, **변환된 PDF 를 minio 에 업로드** (object key 는 원본 파일명의 stem + `.pdf`)
- `GenOSVectorMeta` 에 `file_path: Optional[str]` 필드 추가, 변환된 경우 vector 메타의 `file_path` 를 변환 PDF 경로로 set (`file_name` 은 GenOS 주입값 그대로 유지)
- `intelligent_processor.md` 도 변경 사항 반영 (필드 정의, `compose_vectors` 시그니처, `__call__` 흐름)

## 작업 범위 한정
이 PR 은 **전처리기(preprocessor) 측에서 할 수 있는 변경만** 포함합니다. HWP 입력 후 시각화가 동작하려면 GenOS 호스트 측에서 `file_path` 등 default property 를 강제로 덮어쓰는 동작도 별도 조정이 필요한 것으로 보입니다 (GenOS 리포에 별도 이슈로 보고 예정).

## Test plan
- [ ] PDF 파일 업로드 → 기존과 동일하게 동작 (변환 분기 SKIP, 메타에 `file_path=None`, minio 업로드 안 함)
- [ ] HWP 파일 업로드 → 변환 발생 + vector 메타에 `file_path` 가 변환 PDF 경로로 채워짐 + minio 에 `<doc_id>/<원본명 stem>.pdf` 객체 생성
- [ ] Pydantic 검증 에러 (PDF 입력 시 `file_path=None` 에 대한 string_type 에러) 안 남


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced document processing to track converted PDF file paths from non-PDF source documents
  * Automatic upload of converted PDFs to storage when enabled

* **Documentation**
  * Updated documentation for the document processing workflow and metadata handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genonai/doc_parser/pull/201)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->