### PR TITLE
기존 기본 전처리기에 deprecate warning log 삽입 (#204)

### DIFF
--- a/genon/preprocessor/src/preprocessor.py
+++ b/genon/preprocessor/src/preprocessor.py
@@ -1,8 +1,16 @@
 """
     이 코드는 예시이며, 실제로는 DB의 값을 가져와서 사용한다.
     이 코드를 최초에 DB에 넣어야 한다.
+
+    [!!DEPRECATED!!]
+    이 기본 전처리기(preprocessor.py)는 더 이상 권장되지 않습니다.
+    대신 facade 디렉토리의 아래 전처리기 중 하나를 사용해 주세요:
+        - facade/attachment_processor.py
+        - facade/intelligent_processor.py
+        - facade/convert_processor.py
 """
 
+import logging
 import subprocess
 import os
 import shutil
@@ -11,6 +19,17 @@ import fitz
 import uuid
 
 from collections import defaultdict
+
+_log = logging.getLogger(__name__)
+
+_DEPRECATED_MSG = (
+    "[DEPRECATED] 기본 전처리기(preprocessor.py)는 더 이상 권장되지 않습니다. "
+    "facade/attachment_processor.py, facade/intelligent_processor.py, "
+    "facade/convert_processor.py 중 하나를 사용해 주세요."
+)
+
+_log.warning(_DEPRECATED_MSG)
+
 from datetime import datetime
 from fastapi import Request
 from pydantic import BaseModel
@@ -110,6 +129,7 @@ class HwpLoader:
         os.makedirs(self.output_dir, exist_ok=True)
 
     def load(self):
+        _log.warning(_DEPRECATED_MSG)
         try:
             subprocess.run(['hwp5html', self.file_path, '--output', self.output_dir], check=True, timeout=600)
 
@@ -135,6 +155,7 @@ class TextLoader:
         os.makedirs(self.output_dir, exist_ok=True)
 
     def load(self):
+        _log.warning(_DEPRECATED_MSG)
         try:
             with open(self.file_path, 'r', encoding='utf-8') as f:
                 content = f.read()
@@ -338,6 +359,7 @@ class DocumentProcessor:
         return vectors
 
     async def __call__(self, request: Request, file_path: str, **kwargs: dict):
+        _log.warning(_DEPRECATED_MSG)
         documents: list[Document] = self.load_documents(file_path, **kwargs)
         await assert_cancelled(request)
 

--- a/genon/preprocessor/src/preprocessor.py
+++ b/genon/preprocessor/src/preprocessor.py
@@ -10,26 +10,15 @@
         - facade/convert_processor.py
 """
 
-import logging
 import subprocess
 import os
 import shutil
 import json
 import fitz
 import uuid
+import warnings
 
 from collections import defaultdict
-
-_log = logging.getLogger(__name__)
-
-_DEPRECATED_MSG = (
-    "[DEPRECATED] 기본 전처리기(preprocessor.py)는 더 이상 권장되지 않습니다. "
-    "facade/attachment_processor.py, facade/intelligent_processor.py, "
-    "facade/convert_processor.py 중 하나를 사용해 주세요."
-)
-
-_log.warning(_DEPRECATED_MSG)
-
 from datetime import datetime
 from fastapi import Request
 from pydantic import BaseModel
@@ -49,6 +38,14 @@ from weasyprint import HTML
 
 from genos_utils import upload_files, merge_overlapping_bboxes
 import platform
+
+_DEPRECATED_MSG = (
+    "[DEPRECATED] 기본 전처리기(preprocessor.py)는 더 이상 권장되지 않습니다. "
+    "facade/attachment_processor.py, facade/intelligent_processor.py, "
+    "facade/convert_processor.py 중 하나를 사용해 주세요."
+)
+
+warnings.warn(_DEPRECATED_MSG, DeprecationWarning, stacklevel=2)
 
 # pdf 변환 대상 확장자
 CONVERTIBLE_EXTENSIONS = ['.hwp', '.txt', '.json', '.md']
@@ -129,7 +126,7 @@ class HwpLoader:
         os.makedirs(self.output_dir, exist_ok=True)
 
     def load(self):
-        _log.warning(_DEPRECATED_MSG)
+        warnings.warn(_DEPRECATED_MSG, DeprecationWarning, stacklevel=2)
         try:
             subprocess.run(['hwp5html', self.file_path, '--output', self.output_dir], check=True, timeout=600)
 
@@ -155,7 +152,7 @@ class TextLoader:
         os.makedirs(self.output_dir, exist_ok=True)
 
     def load(self):
-        _log.warning(_DEPRECATED_MSG)
+        warnings.warn(_DEPRECATED_MSG, DeprecationWarning, stacklevel=2)
         try:
             with open(self.file_path, 'r', encoding='utf-8') as f:
                 content = f.read()
@@ -359,7 +356,7 @@ class DocumentProcessor:
         return vectors
 
     async def __call__(self, request: Request, file_path: str, **kwargs: dict):
-        _log.warning(_DEPRECATED_MSG)
+        warnings.warn(_DEPRECATED_MSG, DeprecationWarning, stacklevel=2)
         documents: list[Document] = self.load_documents(file_path, **kwargs)
         await assert_cancelled(request)
 


### PR DESCRIPTION
## Summary
- 기본 전처리기 `genon/preprocessor/src/preprocessor.py`는 빌드 시 웹 UI 코드 칸에 그대로 표시되어 신규 사용자가 그대로 사용하는 사례가 잦음. facade 디렉토리의 신규 전처리기로 교체하도록 안내하기 위해 deprecate warning log 추가.
- 모듈 import 시점에 1회, 그리고 실제 진입점 `HwpLoader.load` / `TextLoader.load` / `DocumentProcessor.__call__`에서 `_log.warning(_DEPRECATED_MSG)` 호출.
- 파일 상단 docstring에도 `facade/attachment_processor.py`, `facade/intelligent_processor.py`, `facade/convert_processor.py`로 교체하라는 안내 문구 추가.

Closes #204

## Test plan
- [ ] 빌드 후 웹 UI 코드 칸에서 docstring 상단의 DEPRECATED 안내가 보이는지 확인
- [ ] 전처리 실행 시 로그에 `[DEPRECATED] 기본 전처리기(preprocessor.py)는 더 이상 권장되지 않습니다.` 경고가 출력되는지 확인 (import 시 1회, `__call__` 호출 시 1회, 그리고 hwp/txt/json/md 처리 시 loader.load에서 1회 추가)
- [ ] 기능적 동작에 회귀가 없는지 (warning 추가 외 로직 변경 없음) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Marked the legacy preprocessor as deprecated and added runtime warnings that appear on import and when using related loading/processing operations.
  * Users should migrate to the updated processor architecture; the legacy implementation will be removed in a future release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genonai/doc_parser/pull/214)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->