### PR TITLE
k8s 내부 통신 기반 모델 호출 시 api key 없이 동작되도록 수정

### DIFF
--- a/docling/prompts/prompt_manager.py
+++ b/docling/prompts/prompt_manager.py
@@ -222,7 +222,7 @@ class PromptManager:
         try:
             # 요청 헤더 구성
             headers = {"Content-Type": "application/json"}
-            if "api_key" in api_config:
+            if api_config.get("api_key"):
                 headers["Authorization"] = f"Bearer {api_config['api_key']}"
 
             # 요청 본문 구성
@@ -382,10 +382,10 @@ class PromptManager:
         if api_config is None:
             return None
 
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {api_config['api_key']}"
-        }
+        headers = {"Content-Type": "application/json"}
+        if api_config.get("api_key"):
+            headers["Authorization"] = f"Bearer {api_config['api_key']}"
+
         base_url = api_config.get("api_base_url", api_config.get("base_url"))
         api_url = base_url if base_url.endswith("/chat/completions") else f"{base_url}/chat/completions"
 

--- a/docling/prompts/prompt_manager.py
+++ b/docling/prompts/prompt_manager.py
@@ -221,10 +221,9 @@ class PromptManager:
 
         try:
             # 요청 헤더 구성
-            headers = {
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {api_config['api_key']}"
-            }
+            headers = {"Content-Type": "application/json"}
+            if "api_key" in api_config:
+                headers["Authorization"] = f"Bearer {api_config['api_key']}"
 
             # 요청 본문 구성
             payload = {

--- a/genon/preprocessor/facade/gitbook_doc/parser_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/parser_processor.md
@@ -126,9 +126,9 @@ layout:
   layout_model_type: "genos_layout"
   genos_layout:
     # <LAYOUT_SERVING_ID>: Genos에 등록한 layout 모델서빙 ID로 변경 필요
-    # <LAYOUT_API_KEY>: Genos, layout 모델서빙에서 발급받은 인증키로 변경 필요
+    # api_key는 k8s 내부 통신 기반 모델 호출 시 불필요.
     endpoint: "http://llmops-gateway-api-service:8080/rep/serving/<LAYOUT_SERVING_ID>/v1/chat/completions"
-    api_key: "<LAYOUT_API_KEY>"
+    api_key: ""
     page_batch_size: 32
 
 # ───────────────────────────────────────────────
@@ -139,9 +139,9 @@ enrichment:
   do_metadata: true
 
   # <ENRICHMENT_SERVING_ID>: Genos에 등록한 enrichment 모델서빙 ID로 변경 필요
-  # <ENRICHMENT_API_KEY>: Genos, enrichment 모델서빙에서 발급받은 인증키로 변경 필요
+  # api_key는 k8s 내부 통신 기반 모델 호출 시 불필요.
   api_url: "http://llmops-gateway-api-service:8080/rep/serving/<ENRICHMENT_SERVING_ID>/v1/chat/completions"
-  api_key: "<ENRICHMENT_API_KEY>"
+  api_key: ""
   model: "model"
   toc:
     temperature: 0.0
@@ -191,10 +191,8 @@ output:
   - endpoint: `<OCR_ENDPOINT>` 는 ocr server 를 서비스 하는 주소로 변경해야 합니다.
 - layout.genos_layout
   - endpoint: `<LAYOUT_SERVING_ID>` 는 Genos에 등록한 layout 모델서빙 ID 로 변경해야 합니다.
-  - api_key: `<LAYOUT_API_KEY>`는 Genos layout 모델서빙에서 발급받은 인증키로 변경해야 합니다.
 - enrichment
   - api_url: `<ENRICHMENT_SERVING_ID>`는 Genos에 등록한 enrichment 모델서빙 ID로 변경해야 합니다.
-  - api_key: `<ENRICHMENT_API_KEY>`는 Genos enrichment 모델서빙에서 발급받은 인증키로 변경해야 합니다.
 
 ---
 

--- a/genon/preprocessor/resource/parser_processor_config.yaml
+++ b/genon/preprocessor/resource/parser_processor_config.yaml
@@ -8,18 +8,19 @@ layout:
   layout_model_type: "genos_layout" # "genos_layout"(default) or "docling_layout"
   genos_layout:
     # <LAYOUT_SERVING_ID>: Genos에 등록한 layout 모델서빙 ID로 변경 필요
-    # <LAYOUT_API_KEY>: Genos, layout 모델서빙에서 발급받은 인증키로 변경 필요
+    # api_key는 k8s 내부 통신 기반 모델 호출 시 불필요.
     endpoint: "http://llmops-gateway-api-service:8080/rep/serving/<LAYOUT_SERVING_ID>/v1/chat/completions"
-    api_key: "<LAYOUT_API_KEY>"
+    api_key: ""
     page_batch_size: 32
 
 enrichment:
   do_toc: true
   do_metadata: true
+
   # <ENRICHMENT_SERVING_ID>: Genos에 등록한 enrichment 모델서빙 ID로 변경 필요
-  # <ENRICHMENT_API_KEY>: Genos, enrichment 모델서빙에서 발급받은 인증키로 변경 필요
+  # api_key는 k8s 내부 통신 기반 모델 호출 시 불필요.
   api_url: "http://llmops-gateway-api-service:8080/rep/serving/<ENRICHMENT_SERVING_ID>/v1/chat/completions"
-  api_key: "<ENRICHMENT_API_KEY>"
+  api_key: ""
   model: "model"
   toc:
     temperature: 0.0


### PR DESCRIPTION
이 Pull Request는 레이아웃(layout) 및 인리치먼트(enrichment) 모델 서빙 시 API Key 처리 방식을 수정하여, Kubernetes(k8s) 내부 네트워크에서 모델을 호출할 경우 API Key가 필요하지 않음을 명확하게 반영합니다. 이를 위해 코드와 설정 파일이 업데이트되었으며, API Key 기본값을 빈 문자열로 설정하고 Authorization 헤더 포함 로직도 함께 개선되었습니다.

## 구성 및 문서 업데이트:

* parser_processor.md 및 parser_processor_config.yaml 파일을 수정하여, k8s 내부 통신에서는 api_key가 필요하지 않음을 명시하고, layout 및 enrichment 서비스의 api_key 값을 빈 문자열("")로 변경했습니다.
* 기존에 layout 및 enrichment 서비스에 API Key를 설정하도록 안내하던 문서 내용을 제거했습니다. 현재 설명된 배포 환경에서는 더 이상 필요하지 않기 때문입니다.

## 코드 로직 개선:

* prompt_manager.py의 call_ai_model 함수를 수정하여, 설정에 API Key가 존재하는 경우에만 Authorization 헤더를 포함하도록 변경했습니다.
* 이를 통해 API Key가 필요 없는 환경에서도 정상적으로 동작할 수 있도록 지원합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * API key configuration is now optional for internal Kubernetes deployments, streamlining setup requirements for internal model calls.

* **Documentation**
  * Updated configuration examples and guidance to reflect optional API key handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genonai/doc_parser/pull/218)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->