### PR TITLE
feat(hwp): extract SDK latex equations as FORMULA nodes (#195)

### DIFF
--- a/docling/backend/genos_hwp_backend.py
+++ b/docling/backend/genos_hwp_backend.py
@@ -367,10 +367,12 @@ class GenosHwpDocumentBackend(DeclarativeDocumentBackend):
         soup = BeautifulSoup(html_content, "html.parser")
         # SDK가 표 셀 HTML 안에 <latex value="<base64>"/> 형태로 임베드한 수식을
         # TableCell.text가 단순 문자열이라 별도 FORMULA 노드로 못 박는다.
-        # 대신 셀 텍스트 추출 전에 $<decoded latex>$ 텍스트 노드로 치환한다.
+        # 대신 셀 텍스트 추출 전에 <math>{decoded latex}</math> 텍스트 노드로 치환하여
+        # chandra OCR prompt의 inline 수식 컨벤션(<math>...</math>, KaTeX-compatible
+        # LaTeX 본문)과 정합을 맞춘다.
         for latex_tag in soup.find_all("latex"):
             decoded = self._decode_latex_b64(latex_tag.get("value", ""))
-            replacement = f"${decoded}$" if decoded else ""
+            replacement = f"<math>{decoded}</math>" if decoded else ""
             latex_tag.replace_with(NavigableString(replacement))
         table_tag = soup.find("table")
         if not table_tag:

--- a/docling/backend/genos_hwp_backend.py
+++ b/docling/backend/genos_hwp_backend.py
@@ -1,4 +1,5 @@
 import base64
+import binascii
 import json
 import logging
 import os
@@ -531,15 +532,16 @@ class GenosHwpDocumentBackend(DeclarativeDocumentBackend):
     def _decode_latex_b64(raw: str) -> Optional[str]:
         """SDK가 emit하는 base64 인코딩된 LaTeX 문자열을 디코드한다.
         긴 값은 SDK가 중간에 줄바꿈/공백을 끼울 수 있어 전처리 후 디코드한다.
-        실패 시 None 반환.
+        손상된 입력을 조용히 통과시키지 않도록 strict 모드로 검증하며,
+        실패 시 경고 로그를 남기고 None 반환.
         """
         if not raw:
             return None
-        # 공백/줄바꿈/HTML 잔여물 제거
+        # 공백/줄바꿈/HTML 잔여물 제거 (정상 SDK 출력의 line-wrap 흡수)
         cleaned = re.sub(r"\s+", "", raw)
         try:
-            decoded = base64.b64decode(cleaned, validate=False).decode("utf-8", errors="replace").strip()
-        except Exception as e:
+            decoded = base64.b64decode(cleaned, validate=True).decode("utf-8").strip()
+        except (binascii.Error, UnicodeDecodeError) as e:
             _log.warning(f"latex base64 디코드 실패: {e}; raw[:60]={raw[:60]!r}")
             return None
         return decoded or None

--- a/docling/backend/genos_hwp_backend.py
+++ b/docling/backend/genos_hwp_backend.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import logging
 import os
@@ -19,7 +20,7 @@ try:
 except ImportError:
     WAND_AVAILABLE = False
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, NavigableString
 from docling_core.types.doc import (
     DocItemLabel, DoclingDocument, DocumentOrigin, GroupLabel,
     ImageRef, NodeItem, ProvenanceItem, TableCell, TableData,
@@ -255,20 +256,36 @@ class GenosHwpDocumentBackend(DeclarativeDocumentBackend):
                     f"페이지 정보 로드 실패: {self.source_path.name}"
                 ) from e
 
-            # 6. SDK 결과를 hwp_data에 저장 (읽기 로직 단순화)
+            # 6. SDK 결과를 hwp_data에 저장
+            # SDK 출력은 두 가지 비정상 케이스가 있어 일반 line-by-line json.loads로는 깨진다:
+            #   (a) 긴 base64 value(latex 등)에 줄바꿈이 끼어 한 record가 여러 물리 줄에 걸침
+            #   (b) 표 셀 HTML 안에 <latex value="..."/>를 임베드하면서 inner "를 escape 안 함
+            #       → outer JSON 문자열이 그 지점에서 조기 종료되어 파싱 실패
+            # 정규화로 (b)를 보정한 뒤, (a)는 JSONDecoder.raw_decode 기반 stream 파싱으로 처리.
             hwp_data = []
             try:
                 with open(json_out, "r", encoding="utf-8") as f:
-                    for line in f:
-                        clean_line = line.strip()
-                        if not clean_line:
-                            continue
-                        try:
-                            batch = json.loads(clean_line, strict=False)
-                            hwp_data.append(batch) # SDK 결과는 항상 리스트이므로 바로 append
-                        except json.JSONDecodeError as e:
-                            _log.warning(f"파싱 실패 (스킵): {e}")
-                            continue
+                    text = f.read()
+                text = self._normalize_sdk_json_text(text)
+                decoder = json.JSONDecoder(strict=False)
+                pos = 0
+                n = len(text)
+                while pos < n:
+                    while pos < n and text[pos] in " \r\n\t":
+                        pos += 1
+                    if pos >= n:
+                        break
+                    try:
+                        batch, end = decoder.raw_decode(text, pos)
+                    except json.JSONDecodeError as e:
+                        _log.warning(f"파싱 실패 (스킵): pos={pos} err={e}")
+                        next_nl = text.find("\n", pos)
+                        if next_nl == -1:
+                            break
+                        pos = next_nl + 1
+                        continue
+                    hwp_data.append(batch)
+                    pos = end
             except OSError as e:
                 raise HwpConversionError(
                     f"SDK 결과 파일 읽기 실패: {json_out}"
@@ -327,6 +344,15 @@ class GenosHwpDocumentBackend(DeclarativeDocumentBackend):
                     # 이미지 핸들러 호출
                     self._handle_image(item, doc, page_no, parent=self.active_main_parent)
 
+                # 2-2. 수식(LaTeX) 처리
+                # SDK는 latex를 자체 batch에 단독으로 또는 텍스트 사이에 끼워서 emit할 수 있다.
+                # 이미지와 동일한 패턴으로, 누적된 텍스트를 먼저 flush한 뒤 FORMULA 노드로 추가한다.
+                elif i_type == "latex":
+                    if texts_in_batch:
+                        self._handle_paragraph(texts_in_batch, doc, page_no, parent=self.active_main_parent)
+                        texts_in_batch = []
+                    self._handle_latex(item, doc, page_no, parent=self.active_main_parent)
+
                 # 2-3. 텍스트 수집
                 elif i_type == "text":
                     texts_in_batch.append(item)
@@ -338,6 +364,13 @@ class GenosHwpDocumentBackend(DeclarativeDocumentBackend):
     def _handle_table(self, html_content: str, doc: DoclingDocument, page_no: int, parent: Any):
         """HTML 테이블을 분석하여 구조화된 Table 객체를 지정된 parent(body)에 추가합니다."""
         soup = BeautifulSoup(html_content, "html.parser")
+        # SDK가 표 셀 HTML 안에 <latex value="<base64>"/> 형태로 임베드한 수식을
+        # TableCell.text가 단순 문자열이라 별도 FORMULA 노드로 못 박는다.
+        # 대신 셀 텍스트 추출 전에 $<decoded latex>$ 텍스트 노드로 치환한다.
+        for latex_tag in soup.find_all("latex"):
+            decoded = self._decode_latex_b64(latex_tag.get("value", ""))
+            replacement = f"${decoded}$" if decoded else ""
+            latex_tag.replace_with(NavigableString(replacement))
         table_tag = soup.find("table")
         if not table_tag:
             return
@@ -474,6 +507,59 @@ class GenosHwpDocumentBackend(DeclarativeDocumentBackend):
                 caption=None,
                 prov=prov,
             )
+
+    # HWP SDK의 비정상 출력 보정용. 외부에서도 단위 테스트하기 좋게 staticmethod.
+    # 패턴: <latex value="<base64, 줄바꿈/공백 가능>"/>  (속성값 안의 "가 escape 없이 등장)
+    # JSON 문자열 안에 들어오면 outer string이 그 시점에서 종료된 것으로 파싱돼 record 손실.
+    # base64 charset(A-Z, a-z, 0-9, +, /, =)과 공백만 허용하여 다른 HTML 속성을 오인하지 않도록 한다.
+    _LATEX_ATTR_PATTERN = re.compile(
+        r'<latex\s+value="([A-Za-z0-9+/=\s]*?)"\s*/?>',
+        flags=re.DOTALL,
+    )
+
+    @classmethod
+    def _normalize_sdk_json_text(cls, text: str) -> str:
+        """SDK 결과 JSON에서 임베드된 <latex value="..."/> 속성의 inner "를 escape하고
+        base64 안의 공백/줄바꿈을 제거하여 JSON 파서가 outer 문자열을 끝까지 읽을 수 있도록 한다.
+        """
+        def _repl(m: "re.Match[str]") -> str:
+            b64 = re.sub(r"\s+", "", m.group(1))
+            return f'<latex value=\\"{b64}\\"/>'
+        return cls._LATEX_ATTR_PATTERN.sub(_repl, text)
+
+    @staticmethod
+    def _decode_latex_b64(raw: str) -> Optional[str]:
+        """SDK가 emit하는 base64 인코딩된 LaTeX 문자열을 디코드한다.
+        긴 값은 SDK가 중간에 줄바꿈/공백을 끼울 수 있어 전처리 후 디코드한다.
+        실패 시 None 반환.
+        """
+        if not raw:
+            return None
+        # 공백/줄바꿈/HTML 잔여물 제거
+        cleaned = re.sub(r"\s+", "", raw)
+        try:
+            decoded = base64.b64decode(cleaned, validate=False).decode("utf-8", errors="replace").strip()
+        except Exception as e:
+            _log.warning(f"latex base64 디코드 실패: {e}; raw[:60]={raw[:60]!r}")
+            return None
+        return decoded or None
+
+    def _handle_latex(self, item: Dict, doc: DoclingDocument, page_no: int, parent: Any):
+        """SDK의 latex 아이템을 base64 디코드 후 FORMULA 노드로 추가한다."""
+        latex = self._decode_latex_b64(item.get("value", ""))
+        if not latex:
+            return
+        prov = ProvenanceItem(
+            page_no=page_no,
+            bbox=BoundingBox(l=0, t=0, r=1, b=1, coord_origin=CoordOrigin.BOTTOMLEFT),
+            charspan=(0, len(latex))
+        )
+        doc.add_text(
+            label=DocItemLabel.FORMULA,
+            text=latex,
+            parent=parent,
+            prov=prov,
+        )
 
     def _handle_paragraph(self, paragraph_items: List[Dict], doc: DoclingDocument, page_no: int, parent: Any):
         """TOC(목차) 감지 로직이 추가된 버전입니다. 넘겨받은 parent에 텍스트를 추가합니다."""

--- a/genon/preprocessor/facade/gitbook_doc/attachment_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/attachment_processor.md
@@ -996,14 +996,14 @@ async def __call__(self, request, file_path, **kwargs):
 
 #### 수식(LaTeX) 추출 (이슈 #195)
 
-신규 HWP SDK가 수식 추출 기능을 지원하면서, `GenosHwpDocumentBackend`도 SDK가 emit하는 수식을 docling의 `DocItemLabel.FORMULA` 노드로 변환하도록 확장되었습니다. 사용자 입장에서는 별도 옵션 없이 기본 동작으로 활성화되며, 청크 출력에서는 docling 표준 직렬화 규칙에 따라 block 수식은 `$$...$$`로, 표 셀 내부의 inline 수식은 `$...$`로 나타납니다.
+신규 HWP SDK가 수식 추출 기능을 지원하면서, `GenosHwpDocumentBackend`도 SDK가 emit하는 수식을 docling의 `DocItemLabel.FORMULA` 노드로 변환하도록 확장되었습니다. 사용자 입장에서는 별도 옵션 없이 기본 동작으로 활성화되며, 청크 출력에서는 docling 표준 직렬화 규칙에 따라 block 수식은 `$$...$$`로, 표 셀 내부의 inline 수식은 `<math>...</math>`로 나타납니다. (인라인 표기는 chandra OCR prompt의 수식 컨벤션과 정합 — KaTeX-compatible LaTeX 본문을 `<math>` 태그로 wrap.)
 
 SDK는 두 가지 형태로 수식을 emit하며, 백엔드는 각각을 다음과 같이 처리합니다:
 
 | SDK 출력 형태 | 등장 위치 | 백엔드 처리 |
 |---------------|----------|-------------|
 | `{"item": "latex", "value": "<base64>", ...}` 단독 batch | 본문/리스트 등 paragraph 흐름 | base64 디코드 후 `DoclingDocument`에 `DocItemLabel.FORMULA` 노드로 추가 |
-| `<latex value="<base64>"/>` HTML 태그 | 표 셀 HTML(`{"item":"table"}`) 내부 | `TableCell.text`가 단순 문자열이라 별도 노드로 못 박기에, BeautifulSoup로 태그를 찾아 디코드 후 `$<decoded>$`로 셀 텍스트에 치환 |
+| `<latex value="<base64>"/>` HTML 태그 | 표 셀 HTML(`{"item":"table"}`) 내부 | `TableCell.text`가 단순 문자열이라 별도 노드로 못 박기에, BeautifulSoup로 태그를 찾아 디코드 후 `<math>{decoded}</math>`로 셀 텍스트에 치환 (chandra 컨벤션 정합) |
 
 SDK 출력에는 두 가지 비정상 패턴이 있어 백엔드가 정규화/stream 파싱으로 대응합니다 (이 두 가지를 처리하지 않으면 record 일부가 손실됨):
 - **base64 줄바꿈**: 긴 latex value를 SDK가 RFC 4648 line-wrap으로 출력하여 한 record가 여러 물리 줄에 걸침 → `JSONDecoder.raw_decode` 기반 stream 파싱으로 처리

--- a/genon/preprocessor/facade/gitbook_doc/attachment_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/attachment_processor.md
@@ -994,6 +994,21 @@ async def __call__(self, request, file_path, **kwargs):
 | 페이지 카운트 관리 | `self.page_chunk_counts` (인스턴스 상태) | `page_chunk_counts` (요청 단위 로컬 변수) |
 | 나머지 로직 | 동일 | 동일 |
 
+#### 수식(LaTeX) 추출 (이슈 #195)
+
+신규 HWP SDK가 수식 추출 기능을 지원하면서, `GenosHwpDocumentBackend`도 SDK가 emit하는 수식을 docling의 `DocItemLabel.FORMULA` 노드로 변환하도록 확장되었습니다. 사용자 입장에서는 별도 옵션 없이 기본 동작으로 활성화되며, 청크 출력에서는 docling 표준 직렬화 규칙에 따라 block 수식은 `$$...$$`로, 표 셀 내부의 inline 수식은 `$...$`로 나타납니다.
+
+SDK는 두 가지 형태로 수식을 emit하며, 백엔드는 각각을 다음과 같이 처리합니다:
+
+| SDK 출력 형태 | 등장 위치 | 백엔드 처리 |
+|---------------|----------|-------------|
+| `{"item": "latex", "value": "<base64>", ...}` 단독 batch | 본문/리스트 등 paragraph 흐름 | base64 디코드 후 `DoclingDocument`에 `DocItemLabel.FORMULA` 노드로 추가 |
+| `<latex value="<base64>"/>` HTML 태그 | 표 셀 HTML(`{"item":"table"}`) 내부 | `TableCell.text`가 단순 문자열이라 별도 노드로 못 박기에, BeautifulSoup로 태그를 찾아 디코드 후 `$<decoded>$`로 셀 텍스트에 치환 |
+
+SDK 출력에는 두 가지 비정상 패턴이 있어 백엔드가 정규화/stream 파싱으로 대응합니다 (이 두 가지를 처리하지 않으면 record 일부가 손실됨):
+- **base64 줄바꿈**: 긴 latex value를 SDK가 RFC 4648 line-wrap으로 출력하여 한 record가 여러 물리 줄에 걸침 → `JSONDecoder.raw_decode` 기반 stream 파싱으로 처리
+- **표 셀 내 임베드 `<latex value="..."/>`의 inner `"` 미escape**: outer JSON 문자열이 그 지점에서 조기 종료되어 파싱 실패 → 정규식 정규화로 inner `"`를 `\"`로 escape
+
 ---
 
 ### 8.3 `DocumentProcessor` (메인 엔트리포인트)

--- a/genon/preprocessor/facade/gitbook_doc/parser_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/parser_processor.md
@@ -234,6 +234,8 @@ output:
 - 모든 백엔드 실패 시 LibreOffice로 PDF 변환 후 PDF 경로로 재처리
 - **Python 패키지:** `docling`(hwp 백엔드 포함)
 
+**수식(LaTeX) 추출 (이슈 #195):** 신규 HWP SDK가 수식 추출 기능을 지원합니다. `GenosHwpDocumentBackend`는 SDK가 emit하는 base64 인코딩 LaTeX를 디코드하여 docling의 `DocItemLabel.FORMULA` 노드로 변환하며, 표 셀 HTML 내부에 임베드된 `<latex>` 태그는 셀 텍스트에 `$<decoded>$`로 인라인 치환합니다. 별도 파라미터 없이 기본 동작입니다. 자세한 처리 흐름은 [`attachment_processor.md` §8.2](attachment_processor.md#82-hwpprocessor) 참고.
+
 **폴백 순서:**
 ```
 GenosHwpDocumentBackend  →  HwpDocumentBackend/HwpxDocumentBackend  →  LibreOffice PDF 변환 → PDF 경로로 재처리

--- a/genon/preprocessor/facade/gitbook_doc/parser_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/parser_processor.md
@@ -234,7 +234,7 @@ output:
 - 모든 백엔드 실패 시 LibreOffice로 PDF 변환 후 PDF 경로로 재처리
 - **Python 패키지:** `docling`(hwp 백엔드 포함)
 
-**수식(LaTeX) 추출 (이슈 #195):** 신규 HWP SDK가 수식 추출 기능을 지원합니다. `GenosHwpDocumentBackend`는 SDK가 emit하는 base64 인코딩 LaTeX를 디코드하여 docling의 `DocItemLabel.FORMULA` 노드로 변환하며, 표 셀 HTML 내부에 임베드된 `<latex>` 태그는 셀 텍스트에 `$<decoded>$`로 인라인 치환합니다. 별도 파라미터 없이 기본 동작입니다. 자세한 처리 흐름은 [`attachment_processor.md` §8.2](attachment_processor.md#82-hwpprocessor) 참고.
+**수식(LaTeX) 추출 (이슈 #195):** 신규 HWP SDK가 수식 추출 기능을 지원합니다. `GenosHwpDocumentBackend`는 SDK가 emit하는 base64 인코딩 LaTeX를 디코드하여 docling의 `DocItemLabel.FORMULA` 노드로 변환하며, 표 셀 HTML 내부에 임베드된 `<latex>` 태그는 셀 텍스트에 `<math>{decoded}</math>`로 인라인 치환합니다 (chandra OCR prompt 컨벤션 정합). 별도 파라미터 없이 기본 동작입니다. 자세한 처리 흐름은 [`attachment_processor.md` §8.2](attachment_processor.md#82-hwpprocessor) 참고.
 
 **폴백 순서:**
 ```

--- a/genon/preprocessor/tests/unit/test_hwpx_backend_unit.py
+++ b/genon/preprocessor/tests/unit/test_hwpx_backend_unit.py
@@ -56,3 +56,163 @@ def test_genos_hwp_backend_valid():
 
     assert in_doc.valid is True
     assert in_doc._backend.is_valid() is True
+
+
+# ---------------------------------------------------------------------------
+# Issue #195: HWP SDK 수식(latex) 추출 → Docling 연결
+# ---------------------------------------------------------------------------
+# SDK가 emit하는 두 가지 수식 형태에 대한 처리를 격리 검증한다.
+#   (1) 최상위 {"item": "latex", "value": "<base64>"} → DocItemLabel.FORMULA 노드
+#   (2) 표 셀 HTML 안에 <latex value="<base64>"/> → 셀 텍스트 $<decoded>$로 치환
+# 추가로 SDK가 base64 value에 줄바꿈을 끼우거나, <latex> 속성의 inner "를
+# escape하지 않아 발생하는 비정상 JSON에 대한 보정 로직도 함께 검증한다.
+
+def _make_backend_no_io():
+    """SDK 실행/파일 I/O 없이 핸들러만 호출하기 위한 최소 초기화 인스턴스."""
+    from pathlib import Path as _Path
+    from docling.backend.genos_hwp_backend import GenosHwpDocumentBackend
+
+    inst = GenosHwpDocumentBackend.__new__(GenosHwpDocumentBackend)
+    inst.valid = True
+    inst.source_path = _Path("/tmp/dummy.hwp")
+    inst.original_path = inst.source_path
+    inst.temp_input_path = None
+    inst.include_wmf = False
+    inst.save_images = False
+    inst.dump_sdk_output = False
+    inst._processed_hashes = set()
+    inst.max_levels = 10
+    inst.parents = {i: None for i in range(-1, inst.max_levels)}
+    inst.history = {"names": [None], "levels": [None], "page_nos": [1]}
+    inst.current_img_dir = None
+    return inst
+
+
+def _make_doc():
+    from docling_core.types.doc import DoclingDocument, DocumentOrigin
+    origin = DocumentOrigin(filename="test.hwp", mimetype="application/x-hwp", binary_hash=0)
+    return DoclingDocument(name="test", origin=origin)
+
+
+@pytest.mark.unit
+def test_genos_hwp_backend_decode_latex_b64_basic():
+    """base64로 인코딩된 latex value 가 LaTeX 원본으로 디코드된다."""
+    from docling.backend.genos_hwp_backend import GenosHwpDocumentBackend
+
+    # base64("\\sum_{x=0}^{\\infty}")
+    raw = "XHN1bV97eD0wfV57XGluZnR5fQ=="
+    assert GenosHwpDocumentBackend._decode_latex_b64(raw) == r"\sum_{x=0}^{\infty}"
+
+
+@pytest.mark.unit
+def test_genos_hwp_backend_decode_latex_b64_with_embedded_newlines():
+    """SDK가 긴 base64 value에 줄바꿈을 끼워도 디코드가 정상 동작한다."""
+    from docling.backend.genos_hwp_backend import GenosHwpDocumentBackend
+
+    # 동일한 base64를 임의 위치에서 줄바꿈으로 쪼갬
+    wrapped = "XHN1bV97e\nD0wfV57XGlu\nZnR5fQ=="
+    assert GenosHwpDocumentBackend._decode_latex_b64(wrapped) == r"\sum_{x=0}^{\infty}"
+
+
+@pytest.mark.unit
+def test_genos_hwp_backend_normalize_sdk_json_escapes_latex_attr_quotes():
+    """SDK 결과 JSON 안에 임베드된 <latex value="..."/> 의 inner "가 \"로 escape되고
+    base64 안의 공백/줄바꿈이 제거되어, json.JSONDecoder가 outer 문자열을
+    끝까지 파싱할 수 있도록 정규화된다.
+    """
+    import json
+    from docling.backend.genos_hwp_backend import GenosHwpDocumentBackend
+
+    # 정규화 전: outer JSON string 안에 <latex value="..."/>의 "가 raw로 들어 있어
+    # 일반 json.loads로는 파싱 실패한다.
+    raw = (
+        '[{"item": "table", "value": "<table><tr><td>'
+        '<latex value="XHN1bV97e\nD0wfV57XGlu\nZnR5fQ=="/>'
+        '</td></tr></table>", "page": 1}]'
+    )
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(raw)
+
+    normalized = GenosHwpDocumentBackend._normalize_sdk_json_text(raw)
+    parsed = json.loads(normalized)
+    assert isinstance(parsed, list) and len(parsed) == 1
+    cell_html = parsed[0]["value"]
+    # inner "는 escape 되고 base64는 한 줄로 합쳐졌어야 한다.
+    assert '<latex value="XHN1bV97eD0wfV57XGluZnR5fQ=="/>' in cell_html
+
+
+@pytest.mark.unit
+def test_genos_hwp_backend_handle_latex_creates_formula_node():
+    """최상위 {"item":"latex"} 아이템이 DocItemLabel.FORMULA 노드로 추가된다."""
+    from docling_core.types.doc import DocItemLabel
+
+    backend = _make_backend_no_io()
+    doc = _make_doc()
+
+    item = {
+        "item": "latex",
+        "value": "XHN1bV97eD0wfV57XGluZnR5fQ==",
+        "font": {"name": "함초롬바탕", "size": 10.0},
+        "page": 1,
+    }
+    before = len(doc.texts)
+    backend._handle_latex(item, doc, page_no=1, parent=doc.body)
+    added = doc.texts[before:]
+
+    assert len(added) == 1
+    assert added[0].label == DocItemLabel.FORMULA
+    assert added[0].text == r"\sum_{x=0}^{\infty}"
+
+
+@pytest.mark.unit
+def test_genos_hwp_backend_handle_table_substitutes_embedded_latex():
+    """표 셀 HTML 안의 <latex value="..."/> 가 $<decoded>$로 치환되어 cell text에 포함된다."""
+    backend = _make_backend_no_io()
+    doc = _make_doc()
+    backend.active_main_parent = doc.body
+
+    # base64("\\bar y_{T}") = "XGJhciB5X3tUfQ=="
+    html = (
+        "<table cols=2 rows=2>"
+        "<tr><td>head1</td><td>head2</td></tr>"
+        "<tr><td colspan=2 rowspan=1>"
+        "(적률) <p style='font-size:13.0pt;'><latex value=\"XGJhciB5X3tUfQ==\"/></p> : T연도 소득"
+        "</td></tr></table>"
+    )
+    before = len(doc.tables)
+    backend._handle_table(html, doc, page_no=1, parent=doc.body)
+    added = doc.tables[before:]
+
+    assert len(added) == 1
+    cell_with_latex = [
+        c for c in added[0].data.table_cells if "T연도" in c.text
+    ]
+    assert len(cell_with_latex) == 1
+    assert "$\\bar y_{T}$" in cell_with_latex[0].text
+
+
+@pytest.mark.unit
+def test_genos_hwp_backend_walk_emits_formula_for_top_level_latex_batch():
+    """_walk_hwp_data가 latex 단독 batch를 만나면 FORMULA 노드를 만들고,
+    이미지와 동일하게 누적된 텍스트 batch를 먼저 flush한다.
+    """
+    from docling_core.types.doc import DocItemLabel
+
+    backend = _make_backend_no_io()
+    doc = _make_doc()
+
+    batches = [
+        # 1) 일반 텍스트 paragraph
+        [{"item": "text", "value": "수식 앞 문단", "font": {"size": 10.0}, "page": 1}],
+        # 2) latex 단독 batch (실 SDK 출력의 전형적인 형태)
+        [{"item": "latex", "value": "XHN1bV97eD0wfV57XGluZnR5fQ==",
+          "font": {"size": 10.0}, "page": 1}],
+        # 3) 일반 텍스트 paragraph
+        [{"item": "text", "value": "수식 뒤 문단", "font": {"size": 10.0}, "page": 1}],
+    ]
+    backend._walk_hwp_data(batches, doc)
+
+    labels = [t.label for t in doc.texts]
+    assert labels.count(DocItemLabel.FORMULA) == 1
+    formula = next(t for t in doc.texts if t.label == DocItemLabel.FORMULA)
+    assert formula.text == r"\sum_{x=0}^{\infty}"

--- a/genon/preprocessor/tests/unit/test_hwpx_backend_unit.py
+++ b/genon/preprocessor/tests/unit/test_hwpx_backend_unit.py
@@ -196,7 +196,10 @@ def test_genos_hwp_backend_handle_latex_creates_formula_node():
 
 @pytest.mark.unit
 def test_genos_hwp_backend_handle_table_substitutes_embedded_latex():
-    """표 셀 HTML 안의 <latex value="..."/> 가 $<decoded>$로 치환되어 cell text에 포함된다."""
+    """표 셀 HTML 안의 <latex value="..."/> 가 <math>{decoded}</math>로 치환되어 cell text에 포함된다.
+
+    chandra OCR prompt의 inline 수식 컨벤션(<math>...</math>, KaTeX-compatible LaTeX 본문)에 정합.
+    """
     backend = _make_backend_no_io()
     doc = _make_doc()
     backend.active_main_parent = doc.body
@@ -218,7 +221,7 @@ def test_genos_hwp_backend_handle_table_substitutes_embedded_latex():
         c for c in added[0].data.table_cells if "T연도" in c.text
     ]
     assert len(cell_with_latex) == 1
-    assert "$\\bar y_{T}$" in cell_with_latex[0].text
+    assert "<math>\\bar y_{T}</math>" in cell_with_latex[0].text
 
 
 @pytest.mark.unit

--- a/genon/preprocessor/tests/unit/test_hwpx_backend_unit.py
+++ b/genon/preprocessor/tests/unit/test_hwpx_backend_unit.py
@@ -115,6 +115,36 @@ def test_genos_hwp_backend_decode_latex_b64_with_embedded_newlines():
 
 
 @pytest.mark.unit
+def test_genos_hwp_backend_decode_latex_b64_rejects_malformed_inputs(caplog):
+    """손상된 입력은 garbage를 뱉지 않고 None + 경고 로그로 명시적 실패해야 한다.
+
+    validate=False + errors="replace"로 관대하게 처리하면 깨진 base64나 깨진 UTF-8이
+    조용히 통과되어 사일런트 버그가 되므로, strict 모드로 검증한다는 계약을 고정.
+    """
+    import base64
+    import logging
+    from docling.backend.genos_hwp_backend import GenosHwpDocumentBackend
+
+    # 빈 입력 → None (경고 없음)
+    assert GenosHwpDocumentBackend._decode_latex_b64("") is None
+    assert GenosHwpDocumentBackend._decode_latex_b64(None) is None  # type: ignore[arg-type]
+
+    # 1) base64 알파벳에 없는 문자가 섞인 입력
+    with caplog.at_level(logging.WARNING, logger="docling.backend.genos_hwp_backend"):
+        caplog.clear()
+        assert GenosHwpDocumentBackend._decode_latex_b64("not_valid_base64!!!@@@") is None
+        assert any("디코드 실패" in r.message for r in caplog.records)
+
+    # 2) base64로는 디코드되지만 결과 바이트가 UTF-8이 아닌 경우
+    # 0xFF, 0xFE 같은 단독 바이트는 UTF-8 시퀀스의 시작이 될 수 없다.
+    invalid_utf8_b64 = base64.b64encode(b"\xff\xfe\xfd").decode("ascii")
+    with caplog.at_level(logging.WARNING, logger="docling.backend.genos_hwp_backend"):
+        caplog.clear()
+        assert GenosHwpDocumentBackend._decode_latex_b64(invalid_utf8_b64) is None
+        assert any("디코드 실패" in r.message for r in caplog.records)
+
+
+@pytest.mark.unit
 def test_genos_hwp_backend_normalize_sdk_json_escapes_latex_attr_quotes():
     """SDK 결과 JSON 안에 임베드된 <latex value="..."/> 의 inner "가 \"로 escape되고
     base64 안의 공백/줄바꿈이 제거되어, json.JSONDecoder가 outer 문자열을


### PR DESCRIPTION
## Summary
- 신규 HWP SDK가 emit하는 수식(latex)을 `GenosHwpDocumentBackend`에서 디코드하여 `DocItemLabel.FORMULA` 노드로 변환. 표 셀 HTML에 임베드된 `<latex>` 태그는 `$<decoded>$`로 인라인 치환.
- 부수 fix: SDK 출력의 multi-line record(긴 base64 line-wrap)와 표 셀 임베드 `<latex>` 속성의 inner `\"` 미escape 문제를 정규화 + stream 파싱으로 보정. 이거 없이는 수식 record가 일부 손실됨.
- 단위 테스트 6개 신규 추가 + gitbook_doc/attachment_processor.md §8.2 / parser_processor.md HWP 섹션 갱신.

Resolves #195.

## What changed (요약)
| 영역 | 변경 |
|---|---|
| `docling/backend/genos_hwp_backend.py` | `_handle_latex` 신설, `_walk_hwp_data`에 latex 분기, `_handle_table`에 임베드 `<latex>` 치환, `_normalize_sdk_json_text` + stream parse |
| 단위 테스트 | `test_hwpx_backend_unit.py`에 6개 추가 (decode/normalize/handle/walk 커버) |
| 문서 | `attachment_processor.md` §8.2에 수식 추출 하위 섹션, `parser_processor.md` HWP/HWPX 섹션에 안내 + 상호 링크 |

## Why the SDK output normalization is bundled here
신규 SDK 출력의 두 가지 비정상 패턴 — (a) 긴 base64 value의 줄바꿈, (b) 표 셀 임베드 `<latex value=\"...\"/>`의 inner `\"` 미escape — 는 둘 다 수식 record를 잃게 만들어서, latex 추출 기능과 분리해 머지하면 의미가 없습니다. 별도 이슈로 빼지 않고 195번에 묶은 이유.

## Test plan
- [x] 단위 테스트 8/8 통과 (`pytest genon/preprocessor/tests/unit/test_hwpx_backend_unit.py`) — 기존 2 + 신규 6.
- [x] 통합 검증 (호스트의 `docparser_dev` 컨테이너에서 직접 수행):
  - 신한참좋은치아보험.hwp (top-level `{\"item\":\"latex\"}` 37개) → DocumentConverter → DoclingDocument에 FORMULA 노드 37개 → HybridChunker 통과 시 `\$\$...\$\$` 직렬화 확인.
  - 핵심이슈 가계금리.hwp (모든 latex가 표 셀 안 `<latex>` 태그) → DoclingDocument의 table cell text에 `\$<decoded>\$` 21개 인라인 → chunker 출력에 latex 청크 16개.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LaTeX formula extraction for HWP/HWPX: formulas become formula nodes and decoded formulas are inlined in tables.

* **Bug Fixes**
  * More resilient SDK output handling and normalization to prevent record loss from embedded formulas, unescaped quotes, or line breaks.
  * Improved table processing to reliably substitute embedded formula markup.

* **Documentation**
  * Updated docs describing formula extraction and processing rules.

* **Tests**
  * Added tests for decoding, normalization, node creation, and table substitution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genonai/doc_parser/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->