### PR TITLE
chore(2.1.5): facade 버전 스탬프 + Dockerfile rhwp 브랜치 정정 + PDF preview 회귀 픽스

### DIFF
--- a/.github/workflows/update_facade_version.yml
+++ b/.github/workflows/update_facade_version.yml
@@ -15,13 +15,19 @@ on:
 jobs:
   bump-version-comment:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
+      - name: Mint GitHub App token (ruleset bypass)
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v5
         with:
           ref: develop
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Resolve tag and date
         id: meta
@@ -72,9 +78,10 @@ jobs:
       - name: Commit and push
         env:
           TAG: ${{ steps.meta.outputs.tag }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
           git add \
             genon/preprocessor/facade/attachment_processor.py \
             genon/preprocessor/facade/convert_processor.py \

--- a/genon/preprocessor/docker/Dockerfile.enterprise
+++ b/genon/preprocessor/docker/Dockerfile.enterprise
@@ -25,7 +25,7 @@ ARG HW_VARIANT=gpu
 ARG TORCH_CPU_INDEX_URL=https://download.pytorch.org/whl/cpu
 # 이슈 #199 후속 — rhwp 바이너리를 컨테이너에 직접 빌드해 넣기 위한 git ref
 ARG RHWP_GIT_URL=https://github.com/genonai/genos-rhwp.git
-ARG RHWP_GIT_REF=main
+ARG RHWP_GIT_REF=genos/main
 
 ############################
 # 1) Base (APT + LibreOffice)

--- a/genon/preprocessor/docker/Dockerfile.opensource
+++ b/genon/preprocessor/docker/Dockerfile.opensource
@@ -26,7 +26,7 @@ ARG HW_VARIANT=gpu
 ARG TORCH_CPU_INDEX_URL=https://download.pytorch.org/whl/cpu
 # 이슈 #199 후속 — rhwp 바이너리를 컨테이너에 직접 빌드해 넣기 위한 git ref
 ARG RHWP_GIT_URL=https://github.com/genonai/genos-rhwp.git
-ARG RHWP_GIT_REF=main
+ARG RHWP_GIT_REF=genos/main
 
 ############################
 # 1) Base (APT + LibreOffice)

--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -106,22 +106,24 @@ def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
     PDF 변환을 시도한다. 실패해도 예외를 던지지 않고 None을 반환한다.
 
     chain (HWP/HWPX 입력):
-      use_pdf_sdk=True  → pdf_sdk → rhwp → libreoffice
-      use_pdf_sdk=False → rhwp → libreoffice
+      use_pdf_sdk=True  → pdf_sdk → libreoffice → rhwp
+      use_pdf_sdk=False → libreoffice → rhwp
     chain (그 외 입력, 예: docx/pptx):
       use_pdf_sdk=True  → pdf_sdk → libreoffice
       use_pdf_sdk=False → libreoffice
 
-    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않음.
+    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않으며, 표/글상자
+    텍스트 누락 이슈(upstream rhwp #816 등) 가 남아있어 현재는 최후순위 fallback
+    으로만 둔다. (upstream 에서 표 렌더 안정화되면 우선순위 상향 검토)
     내부 구현은 `genon.preprocessor.converters.hwp_to_pdf` 모듈에 통합되어 있다.
     """
     from genon.preprocessor.converters.hwp_to_pdf import convert_hwp_to_pdf
     ext = os.path.splitext(file_path)[1].lower()
     is_hwp = ext in (".hwp", ".hwpx")
     if use_pdf_sdk:
-        order = ["pdf_sdk", "rhwp", "libreoffice"] if is_hwp else ["pdf_sdk", "libreoffice"]
+        order = ["pdf_sdk", "libreoffice", "rhwp"] if is_hwp else ["pdf_sdk", "libreoffice"]
     else:
-        order = ["rhwp", "libreoffice"] if is_hwp else ["libreoffice"]
+        order = ["libreoffice", "rhwp"] if is_hwp else ["libreoffice"]
     return convert_hwp_to_pdf(file_path, order=order)
 
 

--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -1,4 +1,4 @@
-# 첨부용 전처리기 v.2.1.0 (2026-05-11 Release)
+# 첨부용 전처리기 v.2.1.5 (2026-05-21 Release)
 from __future__ import annotations
 
 from collections import defaultdict

--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -103,15 +103,26 @@ CONVERTIBLE_EXTENSIONS = ['.hwp', '.txt', '.json', '.md', '.ppt', '.pptx', '.doc
 
 def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
     """
-    PDF 변환을 시도한다. use_pdf_sdk=True면 PDF SDK, False면 LibreOffice.
-    실패해도 예외를 던지지 않고 None을 반환한다.
+    PDF 변환을 시도한다. 실패해도 예외를 던지지 않고 None을 반환한다.
 
+    chain (HWP/HWPX 입력):
+      use_pdf_sdk=True  → pdf_sdk → rhwp → libreoffice
+      use_pdf_sdk=False → rhwp → libreoffice
+    chain (그 외 입력, 예: docx/pptx):
+      use_pdf_sdk=True  → pdf_sdk → libreoffice
+      use_pdf_sdk=False → libreoffice
+
+    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않음.
     내부 구현은 `genon.preprocessor.converters.hwp_to_pdf` 모듈에 통합되어 있다.
-    기존 호출 동작 보존을 위해 단일 backend만 시도하도록 `disable_fallback=True` 사용.
     """
     from genon.preprocessor.converters.hwp_to_pdf import convert_hwp_to_pdf
-    primary = "pdf_sdk" if use_pdf_sdk else "libreoffice"
-    return convert_hwp_to_pdf(file_path, primary=primary, disable_fallback=True)
+    ext = os.path.splitext(file_path)[1].lower()
+    is_hwp = ext in (".hwp", ".hwpx")
+    if use_pdf_sdk:
+        order = ["pdf_sdk", "rhwp", "libreoffice"] if is_hwp else ["pdf_sdk", "libreoffice"]
+    else:
+        order = ["rhwp", "libreoffice"] if is_hwp else ["libreoffice"]
+    return convert_hwp_to_pdf(file_path, order=order)
 
 
 

--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -112,9 +112,9 @@ def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
       use_pdf_sdk=True  → pdf_sdk → libreoffice
       use_pdf_sdk=False → libreoffice
 
-    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않으며, 표/글상자
-    텍스트 누락 이슈(upstream rhwp #816 등) 가 남아있어 현재는 최후순위 fallback
-    으로만 둔다. (upstream 에서 표 렌더 안정화되면 우선순위 상향 검토)
+    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않는다. 또한 도입
+    초기 단계라 안정성 검증 전까지는 최후순위 fallback 으로만 두며, 검증 후
+    우선순위 상향을 검토한다.
     내부 구현은 `genon.preprocessor.converters.hwp_to_pdf` 모듈에 통합되어 있다.
     """
     from genon.preprocessor.converters.hwp_to_pdf import convert_hwp_to_pdf

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -1,4 +1,4 @@
-# 변환용 전처리기 v.2.1.0 (2026-05-11 Release)
+# 변환용 전처리기 v.2.1.5 (2026-05-21 Release)
 from __future__ import annotations
 
 import json

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -146,9 +146,9 @@ def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
       use_pdf_sdk=True  → pdf_sdk → libreoffice
       use_pdf_sdk=False → libreoffice
 
-    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않으며, 표/글상자
-    텍스트 누락 이슈(upstream rhwp #816 등) 가 남아있어 현재는 최후순위 fallback
-    으로만 둔다. (upstream 에서 표 렌더 안정화되면 우선순위 상향 검토)
+    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않는다. 또한 도입
+    초기 단계라 안정성 검증 전까지는 최후순위 fallback 으로만 두며, 검증 후
+    우선순위 상향을 검토한다.
     내부 구현은 `genon.preprocessor.converters.hwp_to_pdf` 모듈에 통합되어 있다.
     """
     from genon.preprocessor.converters.hwp_to_pdf import convert_hwp_to_pdf

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -140,22 +140,24 @@ def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
     PDF 변환을 시도한다. 실패해도 예외를 던지지 않고 None을 반환한다.
 
     chain (HWP/HWPX 입력):
-      use_pdf_sdk=True  → pdf_sdk → rhwp → libreoffice
-      use_pdf_sdk=False → rhwp → libreoffice
+      use_pdf_sdk=True  → pdf_sdk → libreoffice → rhwp
+      use_pdf_sdk=False → libreoffice → rhwp
     chain (그 외 입력, 예: docx/pptx):
       use_pdf_sdk=True  → pdf_sdk → libreoffice
       use_pdf_sdk=False → libreoffice
 
-    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않음.
+    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않으며, 표/글상자
+    텍스트 누락 이슈(upstream rhwp #816 등) 가 남아있어 현재는 최후순위 fallback
+    으로만 둔다. (upstream 에서 표 렌더 안정화되면 우선순위 상향 검토)
     내부 구현은 `genon.preprocessor.converters.hwp_to_pdf` 모듈에 통합되어 있다.
     """
     from genon.preprocessor.converters.hwp_to_pdf import convert_hwp_to_pdf
     ext = os.path.splitext(file_path)[1].lower()
     is_hwp = ext in (".hwp", ".hwpx")
     if use_pdf_sdk:
-        order = ["pdf_sdk", "rhwp", "libreoffice"] if is_hwp else ["pdf_sdk", "libreoffice"]
+        order = ["pdf_sdk", "libreoffice", "rhwp"] if is_hwp else ["pdf_sdk", "libreoffice"]
     else:
-        order = ["rhwp", "libreoffice"] if is_hwp else ["libreoffice"]
+        order = ["libreoffice", "rhwp"] if is_hwp else ["libreoffice"]
     return convert_hwp_to_pdf(file_path, order=order)
 
 def _get_pdf_path(file_path: str) -> str:

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -137,15 +137,26 @@ CONVERTIBLE_EXTENSIONS = ['.txt', '.json', '.md', '.docx', '.ppt', '.pptx']
 
 def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
     """
-    PDF 변환을 시도한다. use_pdf_sdk=True면 PDF SDK, False면 LibreOffice.
-    실패해도 예외를 던지지 않고 None을 반환한다.
+    PDF 변환을 시도한다. 실패해도 예외를 던지지 않고 None을 반환한다.
 
+    chain (HWP/HWPX 입력):
+      use_pdf_sdk=True  → pdf_sdk → rhwp → libreoffice
+      use_pdf_sdk=False → rhwp → libreoffice
+    chain (그 외 입력, 예: docx/pptx):
+      use_pdf_sdk=True  → pdf_sdk → libreoffice
+      use_pdf_sdk=False → libreoffice
+
+    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않음.
     내부 구현은 `genon.preprocessor.converters.hwp_to_pdf` 모듈에 통합되어 있다.
-    기존 호출 동작 보존을 위해 단일 backend만 시도하도록 `disable_fallback=True` 사용.
     """
     from genon.preprocessor.converters.hwp_to_pdf import convert_hwp_to_pdf
-    primary = "pdf_sdk" if use_pdf_sdk else "libreoffice"
-    return convert_hwp_to_pdf(file_path, primary=primary, disable_fallback=True)
+    ext = os.path.splitext(file_path)[1].lower()
+    is_hwp = ext in (".hwp", ".hwpx")
+    if use_pdf_sdk:
+        order = ["pdf_sdk", "rhwp", "libreoffice"] if is_hwp else ["pdf_sdk", "libreoffice"]
+    else:
+        order = ["rhwp", "libreoffice"] if is_hwp else ["libreoffice"]
+    return convert_hwp_to_pdf(file_path, order=order)
 
 def _get_pdf_path(file_path: str) -> str:
     """

--- a/genon/preprocessor/facade/gitbook_doc/attachment_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/attachment_processor.md
@@ -189,7 +189,7 @@ def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
 | 그 외 (`.docx`/`.pptx`/이미지 등) | `pdf_sdk → libreoffice` | `libreoffice` |
 
 - 내부적으로 `convert_hwp_to_pdf(file_path, order=[...])` 로 위임되며, chain 의 backend 가 순서대로 시도되다 첫 성공에서 종료됩니다.
-- `rhwp` 는 HWP/HWPX 전용이라 비-HWP 입력 chain 에는 포함되지 않습니다. 또한 표/글상자 텍스트 누락 이슈(upstream rhwp #816 등)가 남아있어 현재는 **최후순위 fallback** 으로만 둡니다 (upstream 표 렌더 안정화 시 우선순위 상향 검토).
+- `rhwp` 는 HWP/HWPX 전용이라 비-HWP 입력 chain 에는 포함되지 않습니다. 또한 도입 초기 단계라 안정성 검증 전까지는 **최후순위 fallback** 으로만 둡니다 (검증 후 우선순위 상향 검토).
 
 **Backend 경로/가용성 결정**:
 - `pdf_sdk`: `PDF_SDK_HOME` (도커 `/app/pdf_sdk`) → fallback `<repo_root>/pdf_sdk`. 바이너리 실행권한 있을 때만 활성. 엔터프라이즈 빌드에만 자산 포함.

--- a/genon/preprocessor/facade/gitbook_doc/attachment_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/attachment_processor.md
@@ -110,7 +110,7 @@ HWP/HWPX 파일은 변환 실패 시 단계적으로 폴백을 시도합니다.
                                    .hwpx → HwpxDocumentBackend
                                            │ 실패
                                            ▼
-                                ③ PDF 변환 (PDF SDK / LibreOffice) ── 성공 ──► compose_vectors()
+                                ③ PDF 변환 (HWP: PDF SDK→LibreOffice→rhwp) ─ 성공 ──► compose_vectors()
                                            │ 실패
                                            ▼
                                         에러 반환
@@ -181,24 +181,27 @@ def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
 
 **목적**: 다양한 문서 포맷(PPT, DOCX, 이미지 등)을 PDF로 변환합니다. 시그니처와 동작 정책(실패 시 예외 없이 `None` 반환)은 보존하면서, 실제 변환 로직은 `genon.preprocessor.converters.hwp_to_pdf` 모듈로 일원화되어 있습니다 (이슈 #199).
 
-| `use_pdf_sdk` | 위임되는 backend | 비고 |
-|---|---|---|
-| `True` (기본값) | `pdf_sdk` (`PdfSdkConverter`) | PDF 변환 SDK (Linux 전용 바이너리, `pdf_sdk/pdfConverter`). 엔터프라이즈 빌드에만 자산이 포함됨. |
-| `False` | `libreoffice` (`LibreOfficeConverter`) | LibreOffice (`soffice --headless`) 사용. 오픈소스 빌드의 기본 fallback. |
+**변환 chain** (입력 확장자 + `use_pdf_sdk` 로 결정. 앞 backend 실패 시 다음으로 자동 fallback):
 
-호출부에서는 `convert_hwp_to_pdf(file_path, primary=..., disable_fallback=True)` 형태로 단일 backend만 시도하도록 위임되어 기존 동작이 보존됩니다.
+| 입력 | `use_pdf_sdk=True` (엔터프라이즈) | `use_pdf_sdk=False` (오픈소스) |
+|---|---|---|
+| `.hwp` / `.hwpx` | `pdf_sdk → libreoffice → rhwp` | `libreoffice → rhwp` |
+| 그 외 (`.docx`/`.pptx`/이미지 등) | `pdf_sdk → libreoffice` | `libreoffice` |
+
+- 내부적으로 `convert_hwp_to_pdf(file_path, order=[...])` 로 위임되며, chain 의 backend 가 순서대로 시도되다 첫 성공에서 종료됩니다.
+- `rhwp` 는 HWP/HWPX 전용이라 비-HWP 입력 chain 에는 포함되지 않습니다. 또한 표/글상자 텍스트 누락 이슈(upstream rhwp #816 등)가 남아있어 현재는 **최후순위 fallback** 으로만 둡니다 (upstream 표 렌더 안정화 시 우선순위 상향 검토).
 
 **Backend 경로/가용성 결정**:
-- `PDF_SDK_HOME` 환경변수 (도커: `/app/pdf_sdk`) → fallback `<repo_root>/pdf_sdk`. 바이너리 실행권한이 있을 때만 활성.
-- LibreOffice는 `shutil.which("soffice")` 로 판정.
+- `pdf_sdk`: `PDF_SDK_HOME` (도커 `/app/pdf_sdk`) → fallback `<repo_root>/pdf_sdk`. 바이너리 실행권한 있을 때만 활성. 엔터프라이즈 빌드에만 자산 포함.
+- `libreoffice`: `shutil.which("soffice")` 로 판정.
+- `rhwp`: `RHWP_BIN` (기본 `/usr/local/bin/rhwp`) 바이너리 존재 + 실행권한으로 판정.
 
-자세한 backend별 동작 흐름(fontconfig 패치, subprocess 인자, 한글 파일명 ASCII 복사 등)은 `genon/preprocessor/converters/hwp_to_pdf/{pdf_sdk,libreoffice}.py` 본체를 참고합니다.
+자세한 backend별 동작 흐름(fontconfig 패치, subprocess 인자, 한글 파일명 ASCII 복사 등)은 `genon/preprocessor/converters/hwp_to_pdf/{pdf_sdk,libreoffice,rhwp}.py` 본체를 참고합니다.
 
 **핵심 포인트**:
-- 실패해도 **예외를 던지지 않고** `None` 반환 (방어적 설계, 양 엔진 동일).
+- 실패해도 **예외를 던지지 않고** `None` 반환 (방어적 설계, 모든 backend 동일).
 - 호출부는 `kwargs.get('use_pdf_sdk', True)` 패턴 그대로 사용 가능 (Genos 측 config로 제어).
 - `LANG=C.UTF-8` / `LC_ALL=C.UTF-8` 환경 변수로 한글 파일명 / 컨텐츠 처리 보장.
-- chain 기반 fallback(rhwp 추가, 다중 backend 자동 전환)이 필요한 신규 호출처는 `convert_hwp_to_pdf()` 를 직접 사용.
 
 ---
 

--- a/genon/preprocessor/facade/gitbook_doc/convert_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/convert_processor.md
@@ -179,14 +179,16 @@ def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
 
 > **왜 세 모듈에 같은 wrapper가 있나?** Genos 웹 UI 환경은 facade 코드를 단일 파일로 다루기 때문에, 다른 facade 모듈에서 `import` 하면 깨짐. 그래서 세 facade 모두 같은 시그니처의 wrapper 함수를 자체적으로 둠. 실제 변환 로직은 `converters/hwp_to_pdf/` 모듈 한 곳에만 존재.
 
-| `use_pdf_sdk` | 위임되는 backend | 비고 |
+**변환 chain** (입력 확장자 + `use_pdf_sdk` 로 결정. 앞 backend 실패 시 다음으로 자동 fallback):
+
+| 입력 | `use_pdf_sdk=True` (엔터프라이즈) | `use_pdf_sdk=False` (오픈소스) |
 |---|---|---|
-| `True` (기본값) | `pdf_sdk` (`PdfSdkConverter`) | PDF 변환 SDK (Linux 전용 바이너리). 엔터프라이즈 빌드에만 자산 포함. |
-| `False` | `libreoffice` (`LibreOfficeConverter`) | LibreOffice (`soffice --headless`) 사용. 오픈소스 빌드의 기본 fallback. |
+| `.hwp` / `.hwpx` | `pdf_sdk → libreoffice → rhwp` | `libreoffice → rhwp` |
+| 그 외 (`.docx`/`.pptx` 등) | `pdf_sdk → libreoffice` | `libreoffice` |
 
-`disable_fallback=True` 로 호출되어 단일 backend만 시도하므로 기존 동작이 그대로 보존됩니다.
+`convert_hwp_to_pdf(file_path, order=[...])` 로 위임되며, chain 의 backend 를 순서대로 시도하다 첫 성공에서 종료합니다. `rhwp` 는 HWP/HWPX 전용 + 표/글상자 텍스트 누락 이슈(upstream rhwp #816 등)로 현재는 최후순위 fallback.
 
-> 자세한 backend별 동작 흐름은 [attachment_processor.md §4.1](attachment_processor.md#41-convert_to_pdf) 참고. 그리고 `genon/preprocessor/converters/hwp_to_pdf/{pdf_sdk,libreoffice}.py` 본체에 실제 구현.
+> 자세한 backend별 동작 흐름은 [attachment_processor.md §4.1](attachment_processor.md#41-convert_to_pdf) 참고. 그리고 `genon/preprocessor/converters/hwp_to_pdf/{pdf_sdk,libreoffice,rhwp}.py` 본체에 실제 구현.
 
 ---
 

--- a/genon/preprocessor/facade/gitbook_doc/convert_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/convert_processor.md
@@ -186,7 +186,7 @@ def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
 | `.hwp` / `.hwpx` | `pdf_sdk → libreoffice → rhwp` | `libreoffice → rhwp` |
 | 그 외 (`.docx`/`.pptx` 등) | `pdf_sdk → libreoffice` | `libreoffice` |
 
-`convert_hwp_to_pdf(file_path, order=[...])` 로 위임되며, chain 의 backend 를 순서대로 시도하다 첫 성공에서 종료합니다. `rhwp` 는 HWP/HWPX 전용 + 표/글상자 텍스트 누락 이슈(upstream rhwp #816 등)로 현재는 최후순위 fallback.
+`convert_hwp_to_pdf(file_path, order=[...])` 로 위임되며, chain 의 backend 를 순서대로 시도하다 첫 성공에서 종료합니다. `rhwp` 는 HWP/HWPX 전용이며 도입 초기 단계라 현재는 최후순위 fallback.
 
 > 자세한 backend별 동작 흐름은 [attachment_processor.md §4.1](attachment_processor.md#41-convert_to_pdf) 참고. 그리고 `genon/preprocessor/converters/hwp_to_pdf/{pdf_sdk,libreoffice,rhwp}.py` 본체에 실제 구현.
 

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -1686,12 +1686,17 @@ class DocumentProcessor:
 
         # 변환된 PDF 를 minio 에 업로드. object key 는 원본 파일명의 stem + ".pdf".
         # (예: 원본 file_name='sample.hwp' → minio key='<doc_id>/sample.pdf')
-        # upload_files 가 업로드 후 로컬 파일을 os.remove 하므로 파싱이 모두 끝난 이 시점에 호출.
+        # upload_files 가 finally 에서 org_path 를 os.remove 하는데, 변환 PDF 의
+        # NFS 원본은 GenOS UI 의 PDF preview 가 직접 참조하므로 보존 필요.
+        # → 임시 사본을 만들어 그것만 업로드시키고 NFS 원본은 그대로 둔다.
         if converted_pdf_path and upload_files:
             original_name = kwargs.get('file_name') or os.path.basename(converted_pdf_path)
             pdf_object_name = os.path.splitext(original_name)[0] + '.pdf'
+            with tempfile.NamedTemporaryFile(delete=False, suffix='.pdf') as _tmp:
+                shutil.copy(converted_pdf_path, _tmp.name)
+                _tmp_upload_path = _tmp.name
             await upload_files(
-                [{'path': converted_pdf_path, 'name': pdf_object_name}],
+                [{'path': _tmp_upload_path, 'name': pdf_object_name}],
                 request=request,
             )
 

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -26,15 +26,26 @@ import unicodedata
 
 def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
     """
-    PDF 변환을 시도한다. use_pdf_sdk=True면 PDF SDK, False면 LibreOffice.
-    실패해도 예외를 던지지 않고 None을 반환한다.
+    PDF 변환을 시도한다. 실패해도 예외를 던지지 않고 None을 반환한다.
 
+    chain (HWP/HWPX 입력):
+      use_pdf_sdk=True  → pdf_sdk → rhwp → libreoffice
+      use_pdf_sdk=False → rhwp → libreoffice
+    chain (그 외 입력, 예: docx/pptx):
+      use_pdf_sdk=True  → pdf_sdk → libreoffice
+      use_pdf_sdk=False → libreoffice
+
+    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않음.
     내부 구현은 `genon.preprocessor.converters.hwp_to_pdf` 모듈에 통합되어 있다.
-    기존 호출 동작 보존을 위해 단일 backend만 시도하도록 `disable_fallback=True` 사용.
     """
     from genon.preprocessor.converters.hwp_to_pdf import convert_hwp_to_pdf
-    primary = "pdf_sdk" if use_pdf_sdk else "libreoffice"
-    return convert_hwp_to_pdf(file_path, primary=primary, disable_fallback=True)
+    ext = os.path.splitext(file_path)[1].lower()
+    is_hwp = ext in (".hwp", ".hwpx")
+    if use_pdf_sdk:
+        order = ["pdf_sdk", "rhwp", "libreoffice"] if is_hwp else ["pdf_sdk", "libreoffice"]
+    else:
+        order = ["rhwp", "libreoffice"] if is_hwp else ["libreoffice"]
+    return convert_hwp_to_pdf(file_path, order=order)
 
 def _is_pdf(file_path: str) -> bool:
     """파일이 PDF 매직 헤더로 시작하는지 확인 (확장자 무관)."""

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -1,4 +1,4 @@
-# 적재용(지능형) 전처리기 v.2.1.0 (2026-05-11 Release)
+# 적재용(지능형) 전처리기 v.2.1.5 (2026-05-21 Release)
 from __future__ import annotations
 
 import json

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -29,22 +29,24 @@ def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
     PDF 변환을 시도한다. 실패해도 예외를 던지지 않고 None을 반환한다.
 
     chain (HWP/HWPX 입력):
-      use_pdf_sdk=True  → pdf_sdk → rhwp → libreoffice
-      use_pdf_sdk=False → rhwp → libreoffice
+      use_pdf_sdk=True  → pdf_sdk → libreoffice → rhwp
+      use_pdf_sdk=False → libreoffice → rhwp
     chain (그 외 입력, 예: docx/pptx):
       use_pdf_sdk=True  → pdf_sdk → libreoffice
       use_pdf_sdk=False → libreoffice
 
-    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않음.
+    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않으며, 표/글상자
+    텍스트 누락 이슈(upstream rhwp #816 등) 가 남아있어 현재는 최후순위 fallback
+    으로만 둔다. (upstream 에서 표 렌더 안정화되면 우선순위 상향 검토)
     내부 구현은 `genon.preprocessor.converters.hwp_to_pdf` 모듈에 통합되어 있다.
     """
     from genon.preprocessor.converters.hwp_to_pdf import convert_hwp_to_pdf
     ext = os.path.splitext(file_path)[1].lower()
     is_hwp = ext in (".hwp", ".hwpx")
     if use_pdf_sdk:
-        order = ["pdf_sdk", "rhwp", "libreoffice"] if is_hwp else ["pdf_sdk", "libreoffice"]
+        order = ["pdf_sdk", "libreoffice", "rhwp"] if is_hwp else ["pdf_sdk", "libreoffice"]
     else:
-        order = ["rhwp", "libreoffice"] if is_hwp else ["libreoffice"]
+        order = ["libreoffice", "rhwp"] if is_hwp else ["libreoffice"]
     return convert_hwp_to_pdf(file_path, order=order)
 
 def _is_pdf(file_path: str) -> bool:

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -35,9 +35,9 @@ def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
       use_pdf_sdk=True  → pdf_sdk → libreoffice
       use_pdf_sdk=False → libreoffice
 
-    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않으며, 표/글상자
-    텍스트 누락 이슈(upstream rhwp #816 등) 가 남아있어 현재는 최후순위 fallback
-    으로만 둔다. (upstream 에서 표 렌더 안정화되면 우선순위 상향 검토)
+    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않는다. 또한 도입
+    초기 단계라 안정성 검증 전까지는 최후순위 fallback 으로만 두며, 검증 후
+    우선순위 상향을 검토한다.
     내부 구현은 `genon.preprocessor.converters.hwp_to_pdf` 모듈에 통합되어 있다.
     """
     from genon.preprocessor.converters.hwp_to_pdf import convert_hwp_to_pdf


### PR DESCRIPTION
## Summary

다섯 가지를 함께 처리:

1. **즉시 stamp** — 3개 facade 첫 줄 버전 주석을 v.2.1.5 (2026-05-21 Release) 로 갱신 (자동화 우회 이슈로 인한 수동 stamp)
2. **자동화 본격 수정** — 워크플로우가 기본 `GITHUB_TOKEN` 대신 별도 GitHub App 의 installation token 으로 push 하도록 변경
3. **Dockerfile rhwp 클론 브랜치 정정** — `Dockerfile.opensource` / `Dockerfile.enterprise` 의 `RHWP_GIT_REF` 기본값을 `main` → `genos/main` 으로. fork 의 default branch 가 `genos/main` 인데 `main` 으로 박혀 있어 fork 자체 패치(hwpml, 분할 표, 폰트/이미지 fix 등) 가 이미지에 반영되지 않던 문제 수정.
4. **변환 PDF preview 회귀 픽스** — `intelligent_processor.__call__` 끝에서 변환 PDF 를 minio 에 업로드할 때, `upload_files`(genos_utils) 의 `finally: os.remove(org_path)` 가 NFS 의 변환 PDF (`/nfs-root/docs/Document-<id>.pdf`) 까지 삭제해, GenOS UI 의 PDF preview 가 "Failed to load PDF file" 로 깨지던 회귀. 업로드 직전에 `tempfile.NamedTemporaryFile` 로 사본을 만들어 그 사본 경로를 `upload_files` 에 넘기도록 변경 → minio 업로드 유지 + NFS 원본 보존.
5. **HWP→PDF 변환 chain 정리** — `convert_to_pdf` wrapper 를 단일 backend(`disable_fallback`) 에서 입력 확장자 기반 chain 으로 변경. HWP/HWPX 는 `pdf_sdk → libreoffice → rhwp`(enterprise) / `libreoffice → rhwp`(opensource), 그 외 포맷은 기존대로 `pdf_sdk → libreoffice` / `libreoffice`. rhwp 는 HWP/HWPX 전용이며 도입 초기 단계라 최후순위 fallback 으로 둠.

## 변경

- `genon/preprocessor/facade/{attachment,convert,intelligent}_processor.py` — 버전 주석 v.2.1.0 (2026-05-11) → v.2.1.5 (2026-05-21)
- `.github/workflows/update_facade_version.yml` — `actions/create-github-app-token@v2` 로 App token 발급 → checkout/push 에 사용. git user identity 도 App bot 으로 변경.
- `genon/preprocessor/docker/Dockerfile.opensource` / `Dockerfile.enterprise` — `ARG RHWP_GIT_REF=main` → `genos/main`
- `genon/preprocessor/facade/intelligent_processor.py` — `__call__` 의 converted_pdf_path 업로드 직전에 임시 사본 생성 후 사본 경로로 업로드
- `genon/preprocessor/facade/{intelligent,convert,attachment}_processor.py` — `convert_to_pdf` wrapper 를 확장자 기반 chain(`order=[...]`) 으로 변경 (rhwp 는 HWP/HWPX 최후순위 fallback)
- `genon/preprocessor/facade/gitbook_doc/{attachment,convert}_processor.md` — 변환 chain 설명 갱신

## 머지 전 필요한 admin 사전 작업

워크플로우가 실제로 동작하려면 ruleset Bypass list 에 GitHub App 등록이 선행되어야 함.

### Step 1. GitHub App 생성 (org admin)

https://github.com/organizations/genonai/settings/apps → New GitHub App
- Name: `genonai-release-bot` (예시)
- Homepage URL: 아무거나
- Webhook: Active 체크 해제
- Repository permissions:
  - **Contents: Read and write** (필수)
  - 나머지 No access
- Where can this app be installed: `Only on this account`
- Create → 생성 후 페이지에서 **App ID** 메모, **Generate a private key** 클릭해 .pem 다운로드

### Step 2. App 을 doc_parser 에 install

App 설정 좌측 **Install App** → genonai 옆 **Install** → **Only select repositories** → `doc_parser` 선택

### Step 3. doc_parser repo 에 credentials 등록

https://github.com/genonai/doc_parser/settings/secrets/actions
- **Variables 탭** → `RELEASE_BOT_APP_ID` = App ID 번호
- **Secrets 탭** → `RELEASE_BOT_APP_PRIVATE_KEY` = .pem 파일 전체 내용

### Step 4. ruleset Bypass list 에 App 추가

https://github.com/genonai/doc_parser/rules/8147505 → Edit → Bypass list → Add bypass
- Integration 카테고리에서 `genonai-release-bot` 검색해 추가
- Bypass mode: **Always**
- Save

## 머지 후 검증

Step 1~4 완료된 상태에서 이 PR 머지 → Actions 탭에서 `Update facade version comment on release` 수동 실행 (tag: 2.1.5, published_at: 2026-05-22 등) → develop 에 stamp commit 자동 생성되는지 확인.

## 배경

- (자동화) #216 의 자동화는 원래 기본 `GITHUB_TOKEN` 으로 develop 에 push 하도록 만들었는데, develop 보호 ruleset 이 봇 push 를 차단함. GitHub 보안 설계상 기본 `github-actions[bot]` 은 ruleset Bypass list 의 대상이 될 수 없어서, 표준 패턴인 "별도 GitHub App + create-github-app-token" 으로 전환.
- (Dockerfile) fork(`genonai/genos-rhwp`)의 default branch 가 `genos/main` 임을 확인 안 한 채 `main` 으로 박혀 있었고, `main` 은 upstream sync 전용이라 fork 자체 작업(hwpml 파서, 분할 표, PDF 폰트 대체, 플로팅 이미지 등)이 머지 안 돼있음.
- (PDF preview) GenOS UI 의 `download?prefer_pdf=true` 가 minio 가 아닌 NFS 의 변환 PDF 를 fetch 한다는 것이 직접 검증됨. 현재 코드는 minio 업로드 직후 NFS PDF 를 `os.remove` 로 지워, UI 가 PDF 를 못 찾아 HWP fallback → pdf.js 가 OLE 바이너리를 PDF 로 파싱 실패 → "Failed to load PDF file" 출력. 사본 업로드로 분리.

## Test plan

- [ ] CI 통과
- [ ] 머지 후 develop 의 3개 facade 첫 줄에 v.2.1.5 (2026-05-21) 박혀있는지 확인
- [ ] (admin 사전 작업 완료 후) 워크플로우 수동 실행해서 봇 commit 정상 push 되는지 검증
- [ ] 머지 후 재빌드된 이미지에서 `rhwp --version` 호출 결과 + 빌드 로그상 `genos/main` 브랜치가 클론됐는지 확인
- [ ] HWP 파일을 적재용(intelligent) 전처리기로 처리 후 GenOS UI 의 PDF preview 가 정상 표시되는지 확인 (NFS 의 변환 PDF 가 남아있어야 함)
- [ ] HWP/HWPX 변환이 chain 순서(enterprise: pdf_sdk→libreoffice→rhwp / opensource: libreoffice→rhwp)대로 동작하는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped preprocessor component version from v2.1.0 (2026-05-11) to v2.1.5 (2026-05-21).
  * Defaultized image build to use the genos/main Git reference.
  * Updated automation to mint an app token for repository checkout and to use that app-derived identity when committing and pushing automated facade version updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genonai/doc_parser/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
