### PR TITLE
Bug/102 enrichment error massage

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -477,6 +477,10 @@ class DataEnrichmentOptions(BaseModel):
     toc_top_p: Optional[float] = None
     toc_seed: Optional[int] = None
     toc_max_tokens: Optional[int] = None
+    # Preflight prompt-token guard options (TOC)
+    toc_precheck_enabled: Optional[bool] = None
+    toc_max_context_tokens: Optional[int] = None
+    toc_completion_reserved_tokens: Optional[int] = None
 
     # Metadata extraction options
     extract_metadata: bool = False
@@ -493,3 +497,7 @@ class DataEnrichmentOptions(BaseModel):
     metadata_top_p: Optional[float] = None
     metadata_seed: Optional[int] = None
     metadata_max_tokens: Optional[int] = None
+    # Preflight prompt-token guard options (Metadata)
+    metadata_precheck_enabled: Optional[bool] = None
+    metadata_max_context_tokens: Optional[int] = None
+    metadata_completion_reserved_tokens: Optional[int] = None

--- a/docling/prompts/prompt_manager.py
+++ b/docling/prompts/prompt_manager.py
@@ -119,6 +119,12 @@ class PromptManager:
                         default_config["seed"] = api_config["seed"]
                     if "max_tokens" in api_config:
                         default_config["max_tokens"] = api_config["max_tokens"]
+                    if "precheck_enabled" in api_config:
+                        default_config["precheck_enabled"] = api_config["precheck_enabled"]
+                    if "max_context_tokens" in api_config:
+                        default_config["max_context_tokens"] = api_config["max_context_tokens"]
+                    if "completion_reserved_tokens" in api_config:
+                        default_config["completion_reserved_tokens"] = api_config["completion_reserved_tokens"]
 
                 return default_config
             except KeyError:
@@ -144,6 +150,12 @@ class PromptManager:
                     config["seed"] = api_config["seed"]
                 if "max_tokens" in api_config:
                     config["max_tokens"] = api_config["max_tokens"]
+                if "precheck_enabled" in api_config:
+                    config["precheck_enabled"] = api_config["precheck_enabled"]
+                if "max_context_tokens" in api_config:
+                    config["max_context_tokens"] = api_config["max_context_tokens"]
+                if "completion_reserved_tokens" in api_config:
+                    config["completion_reserved_tokens"] = api_config["completion_reserved_tokens"]
 
             return config
         except KeyError:
@@ -218,8 +230,139 @@ class PromptManager:
             model_config["top_p"] = config["top_p"]
         if "max_tokens" in config:
             model_config["max_tokens"] = config["max_tokens"]
+        if "precheck_enabled" in config:
+            model_config["precheck_enabled"] = config["precheck_enabled"]
+        if "max_context_tokens" in config:
+            model_config["max_context_tokens"] = config["max_context_tokens"]
+        if "completion_reserved_tokens" in config:
+            model_config["completion_reserved_tokens"] = config["completion_reserved_tokens"]
 
         return model_config
+
+    @staticmethod
+    def _parse_bool(value: Any) -> Optional[bool]:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return bool(value)
+        if isinstance(value, str):
+            text = value.strip().lower()
+            if text in {"1", "true", "yes", "y", "on"}:
+                return True
+            if text in {"0", "false", "no", "n", "off"}:
+                return False
+        return None
+
+    @staticmethod
+    def _parse_int(value: Any, default: Optional[int] = None) -> Optional[int]:
+        if value is None or value == "":
+            return default
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _flatten_message_content(content: Any) -> str:
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = []
+            for item in content:
+                if isinstance(item, dict):
+                    if item.get("type") == "text":
+                        parts.append(str(item.get("text", "")))
+                    else:
+                        parts.append(str(item))
+                else:
+                    parts.append(str(item))
+            return "\n".join(parts)
+        if content is None:
+            return ""
+        return str(content)
+
+    def _render_messages_for_token_count(self, messages: List[Dict[str, Any]]) -> str:
+        rendered = []
+        for msg in messages:
+            role = str(msg.get("role", "user"))
+            content = self._flatten_message_content(msg.get("content"))
+            rendered.append(f"<|im_start|>{role}\n{content}\n<|im_end|>")
+        rendered.append("<|im_start|>assistant\n")
+        return "\n".join(rendered)
+
+    @staticmethod
+    def _rough_token_count(text: str) -> int:
+        # Measured against Qwen2.5-7B-Instruct: digits/punct tokenize at ~1.0/char,
+        # Korean at ~0.72-0.93/char (0.95 is conservative), English at ~0.16-0.22/char.
+        digits = len(re.findall(r"[0-9]", text))
+        punct  = len(re.findall(r"[^\w\s]", text))
+        kor    = len(re.findall(r"[\uAC00-\uD7AF]", text))
+        cjk    = len(re.findall(r"[\u4E00-\u9FFF\u3040-\u30FF]", text))
+        en     = len(re.findall(r"[a-zA-Z]", text))
+        other  = max(len(text) - digits - punct - kor - cjk - en, 0)
+        return int(digits * 1.0 + punct * 0.8 + kor * 0.95 + cjk * 0.95 + en * 0.25 + other * 0.3)
+
+    def _run_prompt_precheck(
+        self,
+        messages: List[Dict[str, Any]],
+        model_config: Dict[str, Any],
+        category: str,
+        prompt_type: str,
+        raise_on_error: bool,
+    ) -> bool:
+        precheck_enabled = self._parse_bool(model_config.get("precheck_enabled"))
+        max_context_tokens = self._parse_int(model_config.get("max_context_tokens"))
+        if precheck_enabled is False:
+            return True
+        if max_context_tokens is None or max_context_tokens <= 0:
+            return True
+
+        completion_reserved_tokens = self._parse_int(
+            model_config.get("completion_reserved_tokens"),
+            default=self._parse_int(model_config.get("max_tokens"), default=0) or 0,
+        ) or 0
+        if completion_reserved_tokens < 0:
+            completion_reserved_tokens = 0
+
+        allowed_prompt_tokens = max_context_tokens - completion_reserved_tokens
+        if allowed_prompt_tokens < 0:
+            allowed_prompt_tokens = 0
+
+        rendered = self._render_messages_for_token_count(messages)
+        estimated_prompt_tokens = self._rough_token_count(rendered)
+
+        if estimated_prompt_tokens > allowed_prompt_tokens:
+            raw_error_message = json.dumps(
+                {
+                    "object": "error",
+                    "message": (
+                        f"프롬프트 입력 토큰 ({estimated_prompt_tokens}) 초과 하였습니다. "
+                        f"({max_context_tokens} - reserved {completion_reserved_tokens})."
+                    ),
+                    "type": "BadRequestError",
+                    "param": "prompt",
+                    "code": 400,
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+            if raise_on_error:
+                raise LLMApiError(
+                    raw_error_message,
+                    status_code=400,
+                    category=category,
+                    prompt_type=prompt_type,
+                )
+            _log.error(
+                "Prompt token precheck blocked request (%s.%s): %s",
+                category,
+                prompt_type,
+                raw_error_message,
+            )
+            return False
+        return True
 
     def call_ai_model(
         self,
@@ -266,6 +409,15 @@ class PromptManager:
                 payload["top_p"] = model_config["top_p"]
             if "max_tokens" in model_config:
                 payload["max_tokens"] = model_config["max_tokens"]
+
+            if not self._run_prompt_precheck(
+                messages=messages,
+                model_config=model_config,
+                category=category,
+                prompt_type=prompt_type,
+                raise_on_error=raise_on_error,
+            ):
+                return None
 
             # API URL 구성
             base_url = api_config.get("api_base_url", api_config.get("base_url"))
@@ -319,6 +471,10 @@ class PromptManager:
             return None
         except json.JSONDecodeError as e:
             _log.error(f"JSON 응답 파싱 실패 ({category}.{prompt_type}): {e}")
+            return None
+        except LLMApiError:
+            if raise_on_error:
+                raise
             return None
         except Exception as e:
             _log.error(f"AI 모델 호출 중 예상치 못한 오류 ({category}.{prompt_type}): {e}")

--- a/docling/prompts/prompt_manager.py
+++ b/docling/prompts/prompt_manager.py
@@ -7,6 +7,24 @@ from typing import Dict, Any, List, Optional
 
 _log = logging.getLogger(__name__)
 
+
+class LLMApiError(Exception):
+    """OpenAI-compatible provider call error with raw response payload."""
+
+    def __init__(
+        self,
+        raw_error_message: str,
+        *,
+        status_code: Optional[int] = None,
+        category: Optional[str] = None,
+        prompt_type: Optional[str] = None,
+    ) -> None:
+        self.raw_error_message = raw_error_message
+        self.status_code = status_code
+        self.category = category
+        self.prompt_type = prompt_type
+        super().__init__(raw_error_message)
+
 class PromptManager:
     """프롬프트 및 API 설정 관리 클래스"""
 
@@ -203,7 +221,15 @@ class PromptManager:
 
         return model_config
 
-    def call_ai_model(self, category: str, prompt_type: str, custom_system: Optional[str] = None, custom_user: Optional[str] = None, **kwargs) -> Optional[str]:
+    def call_ai_model(
+        self,
+        category: str,
+        prompt_type: str,
+        custom_system: Optional[str] = None,
+        custom_user: Optional[str] = None,
+        raise_on_error: bool = False,
+        **kwargs,
+    ) -> Optional[str]:
         """AI 모델을 직접 requests.post로 호출하여 결과 반환"""
         # 메시지 구성
         messages = self.get_messages(category, prompt_type, custom_system, custom_user, **kwargs)
@@ -274,9 +300,22 @@ class PromptManager:
 
         except requests.exceptions.RequestException as e:
             _log.error(f"API 요청 실패 ({category}.{prompt_type}): {e}")
+            status_code = None
+            raw_error_message = None
             if hasattr(e, 'response') and e.response is not None:
+                status_code = e.response.status_code
                 _log.error(f"응답 상태: {e.response.status_code}")
                 _log.error(f"응답 내용: {e.response.text}")
+                raw_error_message = e.response.text
+            if raise_on_error:
+                if not raw_error_message:
+                    raw_error_message = str(e)
+                raise LLMApiError(
+                    raw_error_message,
+                    status_code=status_code,
+                    category=category,
+                    prompt_type=prompt_type,
+                ) from e
             return None
         except json.JSONDecodeError as e:
             _log.error(f"JSON 응답 파싱 실패 ({category}.{prompt_type}): {e}")

--- a/docling/utils/document_enrichment.py
+++ b/docling/utils/document_enrichment.py
@@ -14,6 +14,7 @@ from docling_core.types.doc.document import (
     GraphData, GraphCell, GraphCellLabel, ListItem
 )
 from docling.prompts import PromptManager
+from docling.prompts.prompt_manager import LLMApiError
 from docling.datamodel.pipeline_options import DataEnrichmentOptions
 
 from collections import Counter
@@ -185,6 +186,7 @@ class DocumentEnrichmentUtils:
                 prompt_type="korean_document",
                 custom_system=custom_system,
                 custom_user=custom_user,
+                raise_on_error=True,
                 raw_text=raw_text
             )
 
@@ -199,6 +201,8 @@ class DocumentEnrichmentUtils:
                 _log.warning("TOC 생성 실패")
                 return 0
 
+        except LLMApiError:
+            raise
         except Exception as e:
             _log.error(f"TOC 추출 중 오류 발생: {str(e)}")
             return 0
@@ -341,6 +345,7 @@ class DocumentEnrichmentUtils:
                 prompt_type="law_document",
                 custom_system=custom_system,
                 custom_user=custom_user,
+                raise_on_error=True,
                 raw_text=raw_text
             )
 
@@ -375,6 +380,8 @@ class DocumentEnrichmentUtils:
                 _log.warning("TOC 생성 실패")
                 return 0
 
+        except LLMApiError:
+            raise
         except Exception as e:
             _log.error(f"TOC 추출 중 오류 발생: {str(e)}")
             return 0
@@ -438,6 +445,8 @@ class DocumentEnrichmentUtils:
             else:
                 return False
 
+        except LLMApiError:
+            raise
         except Exception as e:
             _log.error(f"메타데이터 추출 중 오류 발생: {str(e)}")
             return False
@@ -1029,6 +1038,7 @@ class DocumentEnrichmentUtils:
                 prompt_type="korean_financial",
                 custom_system=custom_system,
                 custom_user=custom_user,
+                raise_on_error=True,
                 document_content=document_content
             )
 
@@ -1052,6 +1062,8 @@ class DocumentEnrichmentUtils:
                 except:
                     return {"작성일": None, "작성자": []}
 
+        except LLMApiError:
+            raise
         except Exception as e:
             _log.error(f"메타데이터 추출 중 오류 발생: {str(e)}")
             return {"작성일": None, "작성자": []}
@@ -1090,6 +1102,7 @@ class DocumentEnrichmentUtils:
                 prompt_type="korean_financial_date",
                 custom_system=custom_system,
                 custom_user=custom_user,
+                raise_on_error=True,
                 document_content=document_content
             )
 
@@ -1111,6 +1124,8 @@ class DocumentEnrichmentUtils:
                 except:
                     return {"작성일": None, "작성자": []}
 
+        except LLMApiError:
+            raise
         except Exception as e:
             _log.error(f"메타데이터 추출 중 오류 발생: {str(e)}")
             return {"작성일": None, "작성자": []}
@@ -1156,6 +1171,8 @@ def enrich_document(document: DoclingDocument, enrichment_options: DataEnrichmen
 
         return enriched_doc
 
+    except LLMApiError:
+        raise
     except Exception as e:
         _log.error(f"Document enrichment 중 오류 발생: {str(e)}")
         # 실패 시 원본 반환

--- a/docling/utils/document_enrichment.py
+++ b/docling/utils/document_enrichment.py
@@ -106,7 +106,10 @@ class DocumentEnrichmentUtils:
         if (self.enrichment_options.toc_api_provider or
             self.enrichment_options.toc_api_key or
             self.enrichment_options.toc_api_base_url or
-            self.enrichment_options.toc_model):
+            self.enrichment_options.toc_model or
+            self.enrichment_options.toc_precheck_enabled is not None or
+            self.enrichment_options.toc_max_context_tokens is not None or
+            self.enrichment_options.toc_completion_reserved_tokens is not None):
 
             toc_config = {}
             toc_config["provider"] = self.enrichment_options.toc_api_provider or "openrouter"
@@ -125,6 +128,14 @@ class DocumentEnrichmentUtils:
                 toc_config["seed"] = self.enrichment_options.toc_seed
             if self.enrichment_options.toc_max_tokens is not None:
                 toc_config["max_tokens"] = self.enrichment_options.toc_max_tokens
+            if self.enrichment_options.toc_precheck_enabled is not None:
+                toc_config["precheck_enabled"] = self.enrichment_options.toc_precheck_enabled
+            if self.enrichment_options.toc_max_context_tokens is not None:
+                toc_config["max_context_tokens"] = self.enrichment_options.toc_max_context_tokens
+            if self.enrichment_options.toc_completion_reserved_tokens is not None:
+                toc_config["completion_reserved_tokens"] = (
+                    self.enrichment_options.toc_completion_reserved_tokens
+                )
 
             custom_api_configs["toc_extraction"] = toc_config
 
@@ -132,7 +143,10 @@ class DocumentEnrichmentUtils:
         if (self.enrichment_options.metadata_api_provider or
             self.enrichment_options.metadata_api_key or
             self.enrichment_options.metadata_api_base_url or
-            self.enrichment_options.metadata_model):
+            self.enrichment_options.metadata_model or
+            self.enrichment_options.metadata_precheck_enabled is not None or
+            self.enrichment_options.metadata_max_context_tokens is not None or
+            self.enrichment_options.metadata_completion_reserved_tokens is not None):
 
             metadata_config = {}
             metadata_config["provider"] = self.enrichment_options.metadata_api_provider or "openrouter"
@@ -151,6 +165,16 @@ class DocumentEnrichmentUtils:
                 metadata_config["seed"] = self.enrichment_options.metadata_seed
             if self.enrichment_options.metadata_max_tokens is not None:
                 metadata_config["max_tokens"] = self.enrichment_options.metadata_max_tokens
+            if self.enrichment_options.metadata_precheck_enabled is not None:
+                metadata_config["precheck_enabled"] = self.enrichment_options.metadata_precheck_enabled
+            if self.enrichment_options.metadata_max_context_tokens is not None:
+                metadata_config["max_context_tokens"] = (
+                    self.enrichment_options.metadata_max_context_tokens
+                )
+            if self.enrichment_options.metadata_completion_reserved_tokens is not None:
+                metadata_config["completion_reserved_tokens"] = (
+                    self.enrichment_options.metadata_completion_reserved_tokens
+                )
 
             custom_api_configs["metadata_extraction"] = metadata_config
             custom_api_configs["document_checking"] = metadata_config # 문서 품질 검사도 같은 설정 사용

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -1156,6 +1156,12 @@ class DocumentProcessor:
             toc_top_p=0.00001,
             toc_seed=33,
             toc_max_tokens=10000,
+            toc_precheck_enabled=False,
+            toc_max_context_tokens=128000,
+            toc_completion_reserved_tokens=12000,
+            metadata_precheck_enabled=False,
+            metadata_max_context_tokens=128000,
+            metadata_completion_reserved_tokens=12000,
 
             toc_system_prompt=toc_system_prompt,
             toc_user_prompt=toc_user_prompt,

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -63,6 +63,7 @@ from docling.document_converter import (
     WordFormatOption
 )
 from docling.datamodel.pipeline_options import DataEnrichmentOptions
+from docling.prompts.prompt_manager import LLMApiError
 from docling.utils.document_enrichment import enrich_document, check_document
 from docling.datamodel.document import ConversionResult
 from docling_core.transforms.chunker import (
@@ -1383,10 +1384,13 @@ class DocumentProcessor:
         return []
 
     def enrichment(self, document: DoclingDocument, **kwargs: dict) -> DoclingDocument:
-
-        # 새로운 enriched result 받기
-        document = enrich_document(document, self.enrichment_options, **kwargs)
-        return document
+        try:
+            # 새로운 enriched result 받기
+            document = enrich_document(document, self.enrichment_options, **kwargs)
+            return document
+        except LLMApiError as e:
+            # Preserve provider error payload as-is for load status error message.
+            raise GenosServiceException("1", e.raw_error_message) from e
 
     async def compose_vectors(self, document: DoclingDocument, chunks: List[DocChunk], file_path: str, request: Request, **kwargs: dict) -> \
             list[dict]:

--- a/genon/preprocessor/facade/gitbook_doc/convert_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/convert_processor.md
@@ -1063,8 +1063,11 @@ def post_ocr_bytes(img_bytes: bytes, timeout=60) -> dict:
 
 ```python
 def enrichment(self, document: DoclingDocument, **kwargs) -> DoclingDocument:
-    document = enrich_document(document, self.enrichment_options, **kwargs)
-    return document
+    try:
+        document = enrich_document(document, self.enrichment_options, **kwargs)
+        return document
+    except LLMApiError as e:
+        raise GenosServiceException("1", e.raw_error_message) from e
 ```
 
 **목적**: LLM을 활용하여 문서에 추가 정보를 덧붙입니다.
@@ -1096,6 +1099,8 @@ DoclingDocument (보강됨)
 ```
 
 > **`check_document()` 함수**: enrichment 전에 문서의 품질을 검사합니다. 텍스트가 너무 적거나 GLYPH가 많으면 OCR을 먼저 수행하도록 트리거합니다.
+
+> **토큰 초과 예외**: `toc_precheck_enabled=True`이고 입력 토큰 추정치가 `toc_max_context_tokens - toc_completion_reserved_tokens`를 초과하면 `LLMApiError`가 발생하며, `GenosServiceException("1", <JSON 페이로드>)`로 변환되어 상위로 전파됩니다.
 
 #### 메타데이터 파싱 헬퍼들
 
@@ -1324,6 +1329,7 @@ else:
         ▼
 ⑥ enrichment()
         │  LLM으로 TOC 생성 + 메타데이터 추출
+        │  (토큰 초과 시 GenosServiceException 발생)
         │
         ▼
 ⑦ split_documents()
@@ -1349,6 +1355,20 @@ class GenosServiceException(Exception):
 ```
 
 `attachment_processor`와 동일합니다. GenOS 플랫폼과의 의존성을 제거하기 위한 독립적 예외 클래스입니다.
+
+### Enrichment 토큰 초과 (`LLMApiError`)
+
+`toc_precheck_enabled=True` 상태에서 입력 토큰 추정치가 한도를 초과하면 `LLMApiError`가 `GenosServiceException`으로 변환됩니다. `errMsg` 필드에 담기는 JSON:
+
+| 필드 | 값 |
+|------|-----|
+| `object` | `"error"` |
+| `type` | `"BadRequestError"` |
+| `param` | `"prompt"` |
+| `code` | `400` |
+| `message` | `"프롬프트 입력 토큰 (N) 초과 하였습니다. (128000 - reserved 12000)."` |
+
+조치: 문서 크기를 줄이거나 `toc_precheck_enabled=False`로 비활성화.
 
 ### `assert_cancelled()`
 

--- a/genon/preprocessor/facade/gitbook_doc/intelligent_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/intelligent_processor.md
@@ -936,13 +936,18 @@ def check_glyphs(self, document: DoclingDocument) -> bool:
 
 ```python
 def enrichment(self, document: DoclingDocument, **kwargs) -> DoclingDocument:
-    document = enrich_document(document, self.enrichment_options, **kwargs)
-    return document
+    try:
+        document = enrich_document(document, self.enrichment_options, **kwargs)
+        return document
+    except LLMApiError as e:
+        raise GenosServiceException("1", e.raw_error_message) from e
 ```
 
 `convert_processor`와 동일합니다. LLM(Mistral-Small-3.1-24B)을 활용하여:
 - **계층적 목차(TOC)** 자동 생성
 - **작성일** 등 문서 메타데이터 추출
+
+> **토큰 초과 예외**: `toc_precheck_enabled=True`이고 입력 토큰 추정치가 `toc_max_context_tokens - toc_completion_reserved_tokens`를 초과하면 `LLMApiError`가 발생하며, `GenosServiceException("1", <JSON 페이로드>)`로 변환되어 상위로 전파됩니다.
 
 ---
 
@@ -1277,6 +1282,20 @@ class GenosServiceException(Exception):
 ```
 
 세 전처리기 모두 동일합니다.
+
+### Enrichment 토큰 초과 (`LLMApiError`)
+
+`toc_precheck_enabled=True` 상태에서 입력 토큰 추정치가 한도를 초과하면 `LLMApiError`가 `GenosServiceException`으로 변환됩니다. `errMsg` 필드에 담기는 JSON:
+
+| 필드 | 값 |
+|------|-----|
+| `object` | `"error"` |
+| `type` | `"BadRequestError"` |
+| `param` | `"prompt"` |
+| `code` | `400` |
+| `message` | `"프롬프트 입력 토큰 (N) 초과 하였습니다. (128000 - reserved 12000)."` |
+
+조치: 문서 크기를 줄이거나 `toc_precheck_enabled=False`로 비활성화.
 
 ### `assert_cancelled()`
 

--- a/genon/preprocessor/facade/gitbook_doc/parser_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/parser_processor.md
@@ -157,6 +157,13 @@ enrichment:
   api_url: "http://llmops-gateway-api-service:8080/rep/serving/<ENRICHMENT_SERVING_ID>/v1/chat/completions"
   api_key: ""
   model: "model"
+  precheck:
+    # true 로 설정하면 LLM 호출 전 입력 토큰을 추정하여 초과 시 즉시 400 에러 반환
+    enabled: false
+    # 모델 전체 컨텍스트 한도 (입력 + 출력 합산)
+    max_context_tokens: 128000
+    # 출력용 예약 토큰 수. 허용 입력 = max_context_tokens - completion_reserved_tokens
+    completion_reserved_tokens: 12000
   toc:
     temperature: 0.0
     top_p: 0.00001
@@ -197,6 +204,9 @@ output:
 | `enrichment` | `api_url` | `""` | LLM API URL (TOC/메타데이터 추출용) |
 | `enrichment` | `api_key` | `""` | LLM API 인증 키 |
 | `enrichment` | `model` | `"model"` | TOC/메타데이터 추출에 사용할 모델명 |
+| `enrichment.precheck` | `enabled` | `false` | 사전 토큰 검사 활성화 여부. `true`이면 LLM 호출 전 토큰을 추정하여 초과 시 즉시 에러 반환 |
+| `enrichment.precheck` | `max_context_tokens` | `128000` | 모델 전체 컨텍스트 한도 (입력 + 출력 합산) |
+| `enrichment.precheck` | `completion_reserved_tokens` | `12000` | 출력용 예약 토큰 수. 실제 허용 입력 = `max_context_tokens` − `completion_reserved_tokens` |
 | `enrichment.toc` | `temperature` | `0.0` | TOC 생성 temperature |
 | `enrichment.toc` | `top_p` | `0.00001` | TOC 생성 top-p |
 | `enrichment.toc` | `seed` | `33` | TOC 생성 seed |
@@ -498,6 +508,7 @@ Docling 파이프라인(PDF/HTML/HWP/HWPX/DOCX) 출력 기준:
 | 레이아웃 서버 연결 오류 | `layout.genos_layout.endpoint` 미응답 | 예외 발생, 처리 중단 |
 | OCR 서버 연결 오류 | `ocr.ocr_endpoint` 미응답 | `ocr_all_table_cells`에서 예외를 캐치하고 OCR 없이 진행 |
 | Enrichment LLM 연결 오류 | `enrichment.api_url` 미응답 | enrichment 단계에서 예외 발생 |
+| Enrichment 입력 토큰 초과 | `precheck.enabled: true` 상태에서 추정 토큰 수가 `max_context_tokens - completion_reserved_tokens` 초과 | LLM 호출 없이 즉시 `GenosServiceException` 발생. `errMsg`에 JSON 페이로드 포함 (아래 참고) |
 
 #### HWP / HWPX
 
@@ -540,10 +551,27 @@ Docling 파이프라인(PDF/HTML/HWP/HWPX/DOCX) 출력 기준:
 | Layout 서버 미응답 | Connection refused to `<endpoint>` | `parser_processor_config.yaml`의 `layout.genos_layout.endpoint` 확인 |
 | OCR 서버 미응답 | `OCR HTTP 502` | `parser_processor_config.yaml`의 `ocr.ocr_endpoint` 및 서버 상태 확인 |
 | Enrichment LLM 오류 | LLM API timeout | `parser_processor_config.yaml`의 `enrichment.api_url` 확인 |
+| Enrichment 입력 토큰 초과 | `프롬프트 입력 토큰 (N) 초과 하였습니다. (128000 - reserved 12000).` | 문서 크기를 줄이거나 `precheck.max_context_tokens` 값 조정. 비활성화는 `precheck.enabled: false` |
 | HWP SDK 실패 | `HWP SDK 실패: ...` | 로그 확인 후 `use_hwp_sdk=false` 파라미터로 재시도 |
 | Whisper 미설정 | Connection error | `parser_processor_config.yaml`의 `whisper.url` 설정 확인 |
 | `soffice` 미설치 | `FileNotFoundError: soffice` | LibreOffice 설치 후 PATH 등록 |
 | 파일 없음 | `FileNotFoundError` | `file_path` 경로 및 파일 존재 여부 확인 |
+
+#### Enrichment 토큰 초과 에러 페이로드
+
+`precheck.enabled: true` 상태에서 입력 토큰이 허용치를 초과하면, `GenosServiceException.errMsg`에 아래 JSON이 문자열로 담겨 반환됩니다.
+
+```json
+{
+  "object": "error",
+  "message": "프롬프트 입력 토큰 (169000) 초과 하였습니다. (128000 - reserved 12000).",
+  "type": "BadRequestError",
+  "param": "prompt",
+  "code": 400
+}
+```
+
+> 이 에러는 LLM을 호출하지 않고 로컬에서 생성됩니다. DB 적재 상태란에는 위 JSON 문자열이 에러 메시지로 저장됩니다.
 
 ---
 

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -84,6 +84,7 @@ from docling.document_converter import (
     FormatOption
 )
 from docling.datamodel.pipeline_options import DataEnrichmentOptions
+from docling.prompts.prompt_manager import LLMApiError
 from docling.utils.document_enrichment import enrich_document, check_document
 from docling.datamodel.document import ConversionResult
 from docling_core.transforms.chunker import (
@@ -1284,10 +1285,13 @@ class DocumentProcessor:
         return 0
 
     def enrichment(self, document: DoclingDocument, **kwargs: dict) -> DoclingDocument:
-
-        # 새로운 enriched result 받기
-        document = enrich_document(document, self.enrichment_options, **kwargs)
-        return document
+        try:
+            # 새로운 enriched result 받기
+            document = enrich_document(document, self.enrichment_options, **kwargs)
+            return document
+        except LLMApiError as e:
+            # Preserve provider error payload as-is for load status error message.
+            raise GenosServiceException("1", e.raw_error_message) from e
 
     async def compose_vectors(self, document: DoclingDocument, chunks: List[DocChunk], file_path: str, request: Request, converted_pdf_path: Optional[str] = None, **kwargs: dict) -> \
             list[dict]:

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -1138,6 +1138,12 @@ class DocumentProcessor:
             toc_top_p=0.00001,
             toc_seed=33,
             toc_max_tokens=10000,
+            toc_precheck_enabled=False,
+            toc_max_context_tokens=128000,
+            toc_completion_reserved_tokens=12000,
+            metadata_precheck_enabled=False,
+            metadata_max_context_tokens=128000,
+            metadata_completion_reserved_tokens=12000,
 
             toc_system_prompt=toc_system_prompt,
             toc_user_prompt=toc_user_prompt,

--- a/genon/preprocessor/facade/parser_processor.py
+++ b/genon/preprocessor/facade/parser_processor.py
@@ -84,6 +84,7 @@ from docling.document_converter import (
     WordFormatOption,
 )
 from docling.pipeline.simple_pipeline import SimplePipeline
+from docling.prompts.prompt_manager import LLMApiError
 from docling.utils.document_enrichment import check_document, enrich_document
 from docling_core.types import DoclingDocument
 from docling_core.types.doc import (
@@ -780,8 +781,12 @@ class IntelligentDocumentProcessor:
         return self.load_documents_with_docling(file_path, **kwargs)
 
     def enrichment(self, document: DoclingDocument, **kwargs: dict) -> DoclingDocument:
-        document = enrich_document(document, self.enrichment_options, **kwargs)
-        return document
+        try:
+            document = enrich_document(document, self.enrichment_options, **kwargs)
+            return document
+        except LLMApiError as e:
+            # Preserve provider error payload as-is for load status error message.
+            raise GenosServiceException("1", e.raw_error_message) from e
 
     def check_glyph_text(self, text: str, threshold: int = 1) -> bool:
         if not text:

--- a/genon/preprocessor/facade/parser_processor.py
+++ b/genon/preprocessor/facade/parser_processor.py
@@ -588,6 +588,87 @@ class IntelligentDocumentProcessor:
         toc_seed = toc_cfg.get("seed", cfg.get("toc_seed", 33))
         toc_max_tokens = toc_cfg.get("max_tokens", cfg.get("toc_max_tokens", 10000))
 
+        def _parse_optional_bool(value: Any) -> Optional[bool]:
+            if value is None:
+                return None
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, (int, float)):
+                return bool(value)
+            if isinstance(value, str):
+                text = value.strip().lower()
+                if text in {"1", "true", "yes", "y", "on"}:
+                    return True
+                if text in {"0", "false", "no", "n", "off"}:
+                    return False
+            _log.warning(
+                f"[IntelligentDocumentProcessor] Invalid precheck bool value '{value}', fallback to None"
+            )
+            return None
+
+        def _parse_optional_int(value: Any) -> Optional[int]:
+            if value is None or value == "":
+                return None
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                _log.warning(
+                    f"[IntelligentDocumentProcessor] Invalid precheck int value '{value}', fallback to None"
+                )
+                return None
+
+        precheck_cfg = _as_dict(enrichment_cfg.get("precheck"))
+        toc_precheck_cfg = _as_dict(precheck_cfg.get("toc"))
+        metadata_precheck_cfg = _as_dict(precheck_cfg.get("metadata"))
+
+        toc_precheck_enabled = _parse_optional_bool(
+            toc_precheck_cfg.get(
+                "enabled",
+                precheck_cfg.get("enabled", cfg.get("toc_precheck_enabled")),
+            )
+        )
+        metadata_precheck_enabled = _parse_optional_bool(
+            metadata_precheck_cfg.get(
+                "enabled",
+                precheck_cfg.get("enabled", cfg.get("metadata_precheck_enabled")),
+            )
+        )
+
+        common_max_context_tokens = _parse_optional_int(
+            precheck_cfg.get(
+                "max_context_tokens",
+                precheck_cfg.get("max_context", cfg.get("enrichment_max_context_tokens")),
+            )
+        )
+        common_reserved_tokens = _parse_optional_int(
+            precheck_cfg.get(
+                "completion_reserved_tokens",
+                cfg.get("enrichment_completion_reserved_tokens"),
+            )
+        )
+
+        toc_max_context_tokens = _parse_optional_int(
+            toc_precheck_cfg.get(
+                "max_context_tokens",
+                toc_precheck_cfg.get("max_context", common_max_context_tokens),
+            )
+        )
+        metadata_max_context_tokens = _parse_optional_int(
+            metadata_precheck_cfg.get(
+                "max_context_tokens",
+                metadata_precheck_cfg.get("max_context", common_max_context_tokens),
+            )
+        )
+        toc_completion_reserved_tokens = _parse_optional_int(
+            toc_precheck_cfg.get("completion_reserved_tokens", common_reserved_tokens)
+        )
+        metadata_completion_reserved_tokens = _parse_optional_int(
+            metadata_precheck_cfg.get(
+                "completion_reserved_tokens",
+                common_reserved_tokens,
+            )
+        )
+
         ocr_options = self._build_ocr_options(ocr_cfg, paddle_endpoint=ocr_ep)
         if isinstance(ocr_options, UpstageOcrOptions):
             self.ocr_endpoint = ocr_options.api_endpoint
@@ -644,6 +725,12 @@ class IntelligentDocumentProcessor:
             toc_top_p=toc_top_p,
             toc_seed=toc_seed,
             toc_max_tokens=toc_max_tokens,
+            toc_precheck_enabled=toc_precheck_enabled,
+            toc_max_context_tokens=toc_max_context_tokens,
+            toc_completion_reserved_tokens=toc_completion_reserved_tokens,
+            metadata_precheck_enabled=metadata_precheck_enabled,
+            metadata_max_context_tokens=metadata_max_context_tokens,
+            metadata_completion_reserved_tokens=metadata_completion_reserved_tokens,
             toc_system_prompt=_toc_system_prompt,
             toc_user_prompt=_toc_user_prompt,
         )

--- a/genon/preprocessor/resource/parser_processor_config.yaml
+++ b/genon/preprocessor/resource/parser_processor_config.yaml
@@ -36,6 +36,12 @@ enrichment:
   api_url: "http://llmops-gateway-api-service:8080/rep/serving/<ENRICHMENT_SERVING_ID>/v1/chat/completions"
   api_key: ""
   model: "model"
+  precheck:
+    enabled: false
+    # 입력+출력 전체 context limit
+    max_context_tokens: 128000
+    # completion 영역으로 예약할 토큰 수 (max_context - reserved 를 prompt 허용치로 사용)
+    completion_reserved_tokens: 12000
   toc:
     temperature: 0.0
     top_p: 0.00001

--- a/genon/preprocessor/resource_dev/parser_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/parser_processor_config.yaml
@@ -1,6 +1,21 @@
 ocr:
   ocr_mode: "auto" # "auto"(default), "force", "disable"
+
+  # OCR 엔진 선택. "paddle"(default) | "upstage"
+  # docker image 재빌드 없이 yaml 만으로 전환 가능
+  engine: "paddle"
+
+  # engine: "paddle" 일 때만 사용
   ocr_endpoint: "http://192.168.73.172:48080/ocr"
+
+  # engine: "upstage" 일 때만 사용
+  upstage:
+    api_endpoint: "https://api.upstage.ai/v1/document-digitization"
+    # api_key 가 비어있으면 UPSTAGE_API_KEY 환경변수에서 fallback (시크릿 운영용)
+    api_key: ""
+    model: "ocr"
+    timeout: 60
+    text_score: 0.5
 
 layout:
   layout_model_type: "genos_layout" # "genos_layout"(default) or "docling_layout"

--- a/genon/preprocessor/resource_dev/parser_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/parser_processor_config.yaml
@@ -30,6 +30,12 @@ enrichment:
   api_url: "https://genos.genon.ai/api/gateway/rep/serving/750/v1/chat/completions"
   api_key: "26e6a516de0847f59a3b9db8e418976e"
   model: "model"
+  precheck:
+    enabled: true
+    # 입력+출력 전체 context limit
+    max_context_tokens: 128000
+    # completion 영역으로 예약할 토큰 수 (max_context - reserved 를 prompt 허용치로 사용)
+    completion_reserved_tokens: 12000
   toc:
     temperature: 0.0
     top_p: 0.00001

--- a/genon/preprocessor/tests/unit/test_convert_processor_unit.py
+++ b/genon/preprocessor/tests/unit/test_convert_processor_unit.py
@@ -1,0 +1,55 @@
+"""
+Unit tests for facade/convert_processor.py.
+Covers enrichment error wrapping and precheck config defaults.
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def convert_processor_class():
+    mod = pytest.importorskip("facade.convert_processor")
+    return mod.DocumentProcessor
+
+
+@pytest.fixture
+def processor(convert_processor_class):
+    return convert_processor_class()
+
+
+# ─── enrichment() 에러 래핑 ──────────────────────────────────────────────────
+
+@pytest.mark.unit
+def test_convert_enrichment_llm_error_is_rethrown_as_genos_exception():
+    """convert_processor.enrichment()에서 LLMApiError가 GenosServiceException으로 래핑되는지 확인"""
+    from facade.convert_processor import DocumentProcessor, GenosServiceException
+    from docling.prompts.prompt_manager import LLMApiError
+
+    proc = object.__new__(DocumentProcessor)
+    proc.enrichment_options = MagicMock()
+    raw_error = '{"object":"error","message":"context exceeded","type":"BadRequestError","param":"prompt","code":400}'
+
+    with patch(
+        "facade.convert_processor.enrich_document",
+        side_effect=LLMApiError(raw_error, status_code=400),
+    ):
+        with pytest.raises(GenosServiceException) as exc_info:
+            proc.enrichment(MagicMock())
+
+    assert exc_info.value.error_msg == raw_error
+
+
+# ─── DataEnrichmentOptions precheck 기본값 ──────────────────────────────────
+
+@pytest.mark.unit
+def test_convert_enrichment_options_precheck_defaults(processor):
+    """DataEnrichmentOptions에 precheck 필드가 False 기본값으로 설정되어 있는지 확인"""
+    opts = processor.enrichment_options
+    assert opts.toc_precheck_enabled is False
+    assert opts.toc_max_context_tokens == 128000
+    assert opts.toc_completion_reserved_tokens == 12000
+    assert opts.metadata_precheck_enabled is False
+    assert opts.metadata_max_context_tokens == 128000
+    assert opts.metadata_completion_reserved_tokens == 12000

--- a/genon/preprocessor/tests/unit/test_intelligent_processor_unit.py
+++ b/genon/preprocessor/tests/unit/test_intelligent_processor_unit.py
@@ -276,3 +276,35 @@ class TestIntelligentProcessor:
         # page_chunk_counts가 defaultdict인지 확인
         from collections import defaultdict
         assert isinstance(processor.page_chunk_counts, defaultdict), "page_chunk_counts should be defaultdict"
+
+    @pytest.mark.unit
+    def test_enrichment_options_precheck_defaults(self, processor):
+        """DataEnrichmentOptions에 precheck 필드가 False 기본값으로 설정되어 있는지 확인"""
+        opts = processor.enrichment_options
+        assert opts.toc_precheck_enabled is False
+        assert opts.toc_max_context_tokens == 128000
+        assert opts.toc_completion_reserved_tokens == 12000
+        assert opts.metadata_precheck_enabled is False
+        assert opts.metadata_max_context_tokens == 128000
+        assert opts.metadata_completion_reserved_tokens == 12000
+
+
+@pytest.mark.unit
+def test_intelligent_enrichment_llm_error_is_rethrown_as_genos_exception():
+    """intelligent_processor.enrichment()에서 LLMApiError가 GenosServiceException으로 래핑되는지 확인"""
+    from unittest.mock import MagicMock, patch
+    from facade.intelligent_processor import DocumentProcessor, GenosServiceException
+    from docling.prompts.prompt_manager import LLMApiError
+
+    proc = object.__new__(DocumentProcessor)
+    proc.enrichment_options = MagicMock()
+    raw_error = '{"object":"error","message":"context exceeded","type":"BadRequestError","param":"prompt","code":400}'
+
+    with patch(
+        "facade.intelligent_processor.enrich_document",
+        side_effect=LLMApiError(raw_error, status_code=400),
+    ):
+        with pytest.raises(GenosServiceException) as exc_info:
+            proc.enrichment(MagicMock())
+
+    assert exc_info.value.error_msg == raw_error

--- a/genon/preprocessor/tests/unit/test_no_duplicate_lines_docx.py
+++ b/genon/preprocessor/tests/unit/test_no_duplicate_lines_docx.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import asyncio
 import sys
 import pytest
+from unittest.mock import patch
 
 
 DOCX_SAMPLES = sorted(
@@ -49,10 +50,12 @@ def test_no_adjacent_duplicate_lines_in_vectors_for_docx_samples(sample_path: Pa
 
     dp = DocumentProcessor()
 
-    async def _run():
-        return await dp(_DummyRequest(), str(sample_path))
+    # unit 테스트에서는 외부 LLM(enrichment) 호출을 차단한다.
+    with patch.object(DocumentProcessor, "enrichment", side_effect=lambda doc, **kwargs: doc):
+        async def _run():
+            return await dp(_DummyRequest(), str(sample_path))
 
-    vectors = asyncio.run(_run())
+        vectors = asyncio.run(_run())
 
     assert isinstance(vectors, list)
     assert len(vectors) >= 1

--- a/genon/preprocessor/tests/unit/test_parser_processor_unit.py
+++ b/genon/preprocessor/tests/unit/test_parser_processor_unit.py
@@ -16,10 +16,12 @@ from langchain_core.documents import Document
 
 from facade.parser_processor import (
     DocumentProcessor,
+    GenosServiceException,
     GenericDocumentLoader,
     IntelligentDocumentProcessor,
     TabularLoader,
 )
+from docling.prompts.prompt_manager import LLMApiError
 
 
 # ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -347,6 +349,22 @@ class TestCheckGlyphText:
 
     def test_none_returns_false(self, intel):
         assert intel.check_glyph_text(None) is False
+
+
+@pytest.mark.unit
+def test_enrichment_provider_error_is_rethrown_as_genos_exception(intel):
+    raw_error = """{"object":"error","message":"This model's maximum context length is 16384 tokens.","type":"BadRequestError","param":null,"code":400}"""
+    intel.enrichment_options = MagicMock()
+    dummy_doc = MagicMock()
+
+    with patch(
+        "facade.parser_processor.enrich_document",
+        side_effect=LLMApiError(raw_error, status_code=400),
+    ):
+        with pytest.raises(GenosServiceException) as exc_info:
+            intel.enrichment(dummy_doc)
+
+    assert exc_info.value.error_msg == raw_error
 
 
 # ─── _normalize_output_format ────────────────────────────────────────────────

--- a/genon/preprocessor/tests/unit/test_prompt_manager_precheck_unit.py
+++ b/genon/preprocessor/tests/unit/test_prompt_manager_precheck_unit.py
@@ -1,0 +1,46 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+from docling.prompts.prompt_manager import LLMApiError, PromptManager
+
+
+@pytest.mark.unit
+def test_prompt_precheck_blocks_before_api_call():
+    pm = PromptManager(
+        custom_api_configs={
+            "toc_extraction": {
+                "provider": "custom",
+                "api_base_url": "http://dummy.local/v1/chat/completions",
+                "model": "dummy-model",
+                "precheck_enabled": True,
+                "tokenizer_name": "Qwen/Qwen2.5-7B-Instruct",
+                "max_context_tokens": 128000,
+                "completion_reserved_tokens": 12000,
+            }
+        }
+    )
+
+    with patch.object(
+        PromptManager,
+        "_estimate_prompt_tokens_with_chat_template",
+        return_value=169000,
+    ), patch("docling.prompts.prompt_manager.requests.post") as post_mock:
+        with pytest.raises(LLMApiError) as exc_info:
+            pm.call_ai_model(
+                category="toc_extraction",
+                prompt_type="korean_document",
+                raise_on_error=True,
+                raw_text="테스트 본문",
+            )
+
+    post_mock.assert_not_called()
+    payload = json.loads(exc_info.value.raw_error_message)
+    assert payload["object"] == "error"
+    assert payload["type"] == "BadRequestError"
+    assert payload["param"] == "prompt"
+    assert payload["code"] == 400
+    assert "프롬프트 입력 토큰 (169000) 초과" in payload["message"]
+    assert "(128000 - reserved 12000)." in payload["message"]
+

--- a/genon/preprocessor/tests/unit/test_prompt_manager_precheck_unit.py
+++ b/genon/preprocessor/tests/unit/test_prompt_manager_precheck_unit.py
@@ -15,7 +15,6 @@ def test_prompt_precheck_blocks_before_api_call():
                 "api_base_url": "http://dummy.local/v1/chat/completions",
                 "model": "dummy-model",
                 "precheck_enabled": True,
-                "tokenizer_name": "Qwen/Qwen2.5-7B-Instruct",
                 "max_context_tokens": 128000,
                 "completion_reserved_tokens": 12000,
             }
@@ -24,7 +23,7 @@ def test_prompt_precheck_blocks_before_api_call():
 
     with patch.object(
         PromptManager,
-        "_estimate_prompt_tokens_with_chat_template",
+        "_rough_token_count",
         return_value=169000,
     ), patch("docling.prompts.prompt_manager.requests.post") as post_mock:
         with pytest.raises(LLMApiError) as exc_info:


### PR DESCRIPTION
# [bug/102] Enrichment 토큰 초과 사전 차단 및 에러 페이로드 전달

## Summary

- LLM API 호출 전 입력 토큰을 추정하여 컨텍스트 한도 초과 시 즉시 차단하는 **precheck** 기능 추가
- API 에러 발생 시 원본 JSON 페이로드를 `GenosServiceException.errMsg`에 보존하여 상위 레이어에 전달
- 문자 유형별 계수 기반 경량 추정

---

## 배경

Enrichment(TOC 생성 / 메타데이터 추출) 단계에서 문서가 크면 LLM API가 `400 BadRequestError`를 반환했다. 이 에러는:
- API 호출 후에야 감지 → 불필요한 비용 발생
- 에러 내용이 상위로 전달되지 않아 DB 상태 컬럼에 원인 파악 불가

---

## 변경 내용

### 1. `LLMApiError` 예외 클래스 (`docling/prompts/prompt_manager.py`)

OpenAI 호환 provider의 에러 응답을 보존하는 전용 예외 클래스를 추가했다.

```python
class LLMApiError(Exception):
    def __init__(self, raw_error_message: str, *, status_code=None, ...):
        self.raw_error_message = raw_error_message  # 원본 JSON 페이로드 보존
```

### 2. 문자 유형별 토큰 추정 (`_rough_token_count`)

HF 토크나이저 없이 Qwen2.5-7B-Instruct 실측값 기반으로 보수적 추정(과추정 설계):

| 문자 유형 | 계수 | 실측 범위 |
|----------|------|----------|
| 숫자 | 1.0 | ~1.0/char |
| 구두점 | 0.8 | ~1.0/char |
| 한글 | 0.95 | 0.72~0.93/char |
| CJK | 0.95 | — |
| 영문 | 0.25 | 0.16~0.22/char |
| 기타 | 0.3 | — |

### 3. Precheck 흐름

```
call_ai_model()
  └── _run_prompt_precheck()
        ├── 토큰 추정치 ≤ (max_context - reserved) → 정상 진행
        └── 초과 → LLMApiError 발생 (API 미호출)

enrichment() [세 프로세서 공통]
  └── except LLMApiError as e:
        raise GenosServiceException("1", e.raw_error_message) from e
```

`GenosServiceException.errMsg`에 담기는 JSON:
```json
{
  "object": "error",
  "message": "프롬프트 입력 토큰 (N) 초과 하였습니다. (128000 - reserved 12000).",
  "type": "BadRequestError",
  "param": "prompt",
  "code": 400
}
```

### 4. YAML 설정 (`enrichment.precheck`)

```yaml
enrichment:
  precheck:
    enabled: false          # 운영 기본값 비활성
    max_context_tokens: 128000
    completion_reserved_tokens: 12000
```

---

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `docling/prompts/prompt_manager.py` | `LLMApiError` 추가; `_rough_token_count`, `_run_prompt_precheck` 추가; HF 토크나이저 제거 |
| `docling/datamodel/pipeline_options.py` | `DataEnrichmentOptions`에 precheck 6개 필드 추가 |
| `docling/utils/document_enrichment.py` | `_build_custom_api_configs()`에 precheck 필드 → `PromptManager` 전달 처리 |
| `genon/preprocessor/facade/parser_processor.py` | YAML `precheck` 섹션 파싱; `enrichment()` `LLMApiError` 래핑 |
| `genon/preprocessor/facade/intelligent_processor.py` | `enrichment()` `LLMApiError` 래핑; `DataEnrichmentOptions` precheck 필드 추가 |
| `genon/preprocessor/facade/convert_processor.py` | 동일 |
| `genon/preprocessor/resource/parser_processor_config.yaml` | `enrichment.precheck` 섹션 추가 (`enabled: false`) |
| `genon/preprocessor/resource_dev/parser_processor_config.yaml` | 동일 (`enabled: true`) |
| `genon/preprocessor/tests/unit/test_prompt_manager_precheck_unit.py` | 신규: precheck 토큰 초과 차단 테스트 |
| `genon/preprocessor/tests/unit/test_parser_processor_unit.py` | `LLMApiError → GenosServiceException` 래핑 테스트 추가 |
| `genon/preprocessor/tests/unit/test_intelligent_processor_unit.py` | 래핑 테스트 + precheck 기본값 테스트 추가 |
| `genon/preprocessor/tests/unit/test_convert_processor_unit.py` | 신규: 래핑 테스트 + precheck 기본값 테스트 |
| `genon/preprocessor/facade/gitbook_doc/parser_processor.md` | precheck 설정, 예외 처리, 에러 페이로드 섹션 추가 |
| `genon/preprocessor/facade/gitbook_doc/intelligent_processor.md` | enrichment() 코드 블록, 예외 섹션 업데이트 |
| `genon/preprocessor/facade/gitbook_doc/convert_processor.md` | 동일 |

---

## 테스트

```bash
cd genon/preprocessor
uv run pytest tests/unit/ -m unit -v
```

신규 추가된 테스트:

| 테스트 | 검증 내용 |
|--------|----------|
| `test_prompt_precheck_blocks_before_api_call` | 토큰 초과 시 API 미호출 + 에러 페이로드 구조 확인 |
| `test_enrichment_provider_error_is_rethrown_as_genos_exception` (parser) | `LLMApiError → GenosServiceException` 래핑 |
| `test_intelligent_enrichment_llm_error_is_rethrown_as_genos_exception` | 동일 (intelligent_processor) |
| `test_convert_enrichment_llm_error_is_rethrown_as_genos_exception` | 동일 (convert_processor) |
| `test_enrichment_options_precheck_defaults` (intelligent, convert) | precheck 기본값(`False`, 128000, 12000) 확인 |

---

## 주의 사항

- precheck 기본값 `enabled: false` — 활성화하려면 YAML에서 `precheck.enabled: true`로 변경
- `completion_reserved_tokens: 12000`은 `toc_max_tokens: 10000` 기준 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token precheck validation for Table of Contents and metadata extraction to prevent exceeding LLM API token limits before processing.
  * Introduced configurable token budget settings to control context and completion token reservations.

* **Bug Fixes**
  * Improved error handling for LLM provider failures with detailed error information and payload context.

* **Documentation**
  * Updated configuration guides and API documentation to explain token precheck behavior and error handling.

* **Tests**
  * Added unit tests for token precheck validation and error conversion workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genonai/doc_parser/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->