### PR TITLE
Feature/96 enrichment image description

### DIFF
--- a/genon/preprocessor/facade/gitbook_doc/parser_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/parser_processor.md
@@ -170,6 +170,27 @@ enrichment:
     seed: 33
     max_tokens: 10000
 
+  # facade 후처리 기반 이미지 설명 생성 (문맥 포함)
+  image_description:
+    enabled: false
+    # 필요 시만 지정 (미지정 시 enrichment.api_url 상속)
+    api_url: ""
+    # 필요 시만 지정 (미지정 시 enrichment.api_key 상속)
+    api_key: ""
+    # 필요 시만 지정 (미지정 시 enrichment.model 상속)
+    model: "model"
+    before_items: 3
+    after_items: 2
+    max_context_chars: 1500
+    prompt_template: |
+      문서의 일부 이미지를 설명해줘. 아래 문맥을 참고해서 핵심 정보를 2~4문장으로 간결하게 작성해줘.
+      [앞 문맥]
+      {before_context}
+      [캡션]
+      {caption}
+      [뒤 문맥]
+      {after_context}
+
 # ───────────────────────────────────────────────
 # 출력 형식
 # ───────────────────────────────────────────────
@@ -211,6 +232,14 @@ output:
 | `enrichment.toc` | `top_p` | `0.00001` | TOC 생성 top-p |
 | `enrichment.toc` | `seed` | `33` | TOC 생성 seed |
 | `enrichment.toc` | `max_tokens` | `10000` | TOC 생성 최대 토큰 수 |
+| `enrichment.image_description` | `enabled` | `false` | facade 이미지 설명 enrichment 활성화 여부 |
+| `enrichment.image_description` | `api_url` | `""` | 이미지 설명 VLM API URL. 비어 있으면 `enrichment.api_url` 상속 |
+| `enrichment.image_description` | `api_key` | `""` | 이미지 설명 VLM API 키. 비어 있으면 `enrichment.api_key` 상속 |
+| `enrichment.image_description` | `model` | `"model"` | 이미지 설명에 사용할 모델명. 비어 있으면 `enrichment.model` 상속 |
+| `enrichment.image_description` | `before_items` | `3` | 이미지 앞 문맥으로 넣을 텍스트 item 수 |
+| `enrichment.image_description` | `after_items` | `2` | 이미지 뒤 문맥으로 넣을 텍스트 item 수 |
+| `enrichment.image_description` | `max_context_chars` | `1500` | 프롬프트 전체 최대 문자 수 (초과 시 절단) |
+| `enrichment.image_description` | `prompt_template` | 내장 기본 프롬프트 | 이미지 설명 요청 프롬프트 템플릿 (`{before_context}`, `{caption}`, `{after_context}` 치환) |
 | `output` | `format` | `"json"` | 응답 포맷. `json` / `html` / `markdown`. 유효하지 않으면 `json`으로 대체 |
 | `output` | `table_format` | `"html"` | 표 변환 포맷. `html` / `markdown`. 유효하지 않으면 `html`로 대체 |
 
@@ -223,6 +252,7 @@ output:
   - endpoint: `<LAYOUT_SERVING_ID>` 는 Genos에 등록한 layout 모델서빙 ID 로 변경해야 합니다.
 - enrichment
   - api_url: `<ENRICHMENT_SERVING_ID>`는 Genos에 등록한 enrichment 모델서빙 ID로 변경해야 합니다.
+  - image_description.api_url: 별도 VLM endpoint 사용 시 변경해야 합니다. 비워두면 `enrichment.api_url` 상속
 
 ---
 
@@ -248,6 +278,7 @@ output:
 - **Layout 모델 서버:** `parser_processor_config.yaml`의 `layout.genos_layout.endpoint` 로 접근 가능한 vLLM 호환 서버가 실행 중이어야 함
 - **OCR 서버:** `ocr_mode`가 `disable`이 아닌 경우 `ocr.ocr_endpoint`에 PaddleOCR 서버가 실행 중이어야 함 (단, `ocr_mode=auto`이면 OCR 품질 감지 후 필요할 때만 접근)
 - **Enrichment LLM:** `enrichment.do_toc=true` 또는 `do_metadata=true`인 경우 `enrichment.api_url`에 LLM API가 실행 중이어야 함
+- **Image Description VLM(선택):** `enrichment.image_description.enabled=true`인 경우 `image_description.api_url`(또는 상속된 `enrichment.api_url`)에 이미지+텍스트 입력 가능한 VLM API가 실행 중이어야 함
 - **Python 패키지:** `docling`, `docling-core`, `pymupdf`
 
 ---
@@ -339,6 +370,8 @@ GenosHwpDocumentBackend  →  HwpDocumentBackend/HwpxDocumentBackend  →  Libre
 | `use_hwp_sdk` | `bool` | `true` | `true`: GenosHwpDocumentBackend 사용. `false`: 내장 백엔드(HwpDocumentBackend/HwpxDocumentBackend) 강제 사용 |
 | `dump_sdk_output` | `bool` | `false` | HWP SDK 내부 출력 덤프 여부 (`use_hwp_sdk=true`일 때만 유효) |
 
+> 이미지 설명 문맥 추출(`enrichment.image_description.*`)은 현재 `parser_processor_config.yaml` 설정값으로 제어합니다.
+
 ---
 
 ## 출력 데이터 구조
@@ -372,8 +405,8 @@ GenosHwpDocumentBackend  →  HwpDocumentBackend/HwpxDocumentBackend  →  Libre
 {
   "id": 0,
   "page": 1,
-  "category": "paragraph",
-  "content": "텍스트 내용 또는 HTML 테이블",
+  "category": "picture",
+  "content": "문맥 기반 이미지 설명",
   "coordinates": [
     {"x": 0.1, "y": 0.1},
     {"x": 0.9, "y": 0.1},
@@ -400,7 +433,7 @@ GenosHwpDocumentBackend  →  HwpDocumentBackend/HwpxDocumentBackend  →  Libre
 | `paragraph` | 본문 텍스트 문자열 | `"이 문서는 ..."` |
 | `list_item` | 목록 항목 텍스트 문자열 | `"• 항목 내용"` |
 | `table` | HTML 또는 Markdown 형식의 표 (`output.table_format` 설정에 따라 결정) | `"<table>...</table>"` |
-| `picture` | 빈 문자열 `""` (이미지 자체는 별도 파일로 저장) | `""` |
+| `picture` | 기본은 빈 문자열 `""` (이미지 자체는 별도 파일로 저장). 이미지 설명 활성화 시 `content`에 설명 텍스트가 포함됨 | `"이미지 설명 텍스트"` |
 | `caption` | 그림/표 캡션 텍스트 | `"그림 1. 시스템 구조도"` |
 | `footnote` | 각주 텍스트 | `"1) 출처: ..."` |
 | `page_header` | 페이지 상단 반복 텍스트 | `"2025 연간 보고서"` |
@@ -434,7 +467,7 @@ Docling 파이프라인(PDF/HTML/HWP/HWPX/DOCX) 출력 기준:
 | `paragraph` | 일반 단락 | |
 | `list_item` | 목록 항목 | |
 | `table` | 표 | `output.table_format`에 따라 HTML 또는 Markdown |
-| `picture` | 이미지 | `content`는 빈 문자열 |
+| `picture` | 이미지 | 기본 `content`는 빈 문자열, 옵션 활성화 시 `content`에 설명 텍스트가 포함됨 |
 | `caption` | 그림/표 캡션 | |
 | `footnote` | 각주 | |
 | `page_header` | 페이지 헤더 | |

--- a/genon/preprocessor/facade/gitbook_doc/parser_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/parser_processor.md
@@ -179,6 +179,8 @@ enrichment:
     api_key: ""
     # 필요 시만 지정 (미지정 시 enrichment.model 상속)
     model: "model"
+    # 이미지 설명 요청 병렬 수 (기본 4)
+    concurrency: 4
     before_items: 3
     after_items: 2
     max_context_chars: 1500
@@ -236,6 +238,7 @@ output:
 | `enrichment.image_description` | `api_url` | `""` | 이미지 설명 VLM API URL. 비어 있으면 `enrichment.api_url` 상속 |
 | `enrichment.image_description` | `api_key` | `""` | 이미지 설명 VLM API 키. 비어 있으면 `enrichment.api_key` 상속 |
 | `enrichment.image_description` | `model` | `"model"` | 이미지 설명에 사용할 모델명. 비어 있으면 `enrichment.model` 상속 |
+| `enrichment.image_description` | `concurrency` | `16` | 이미지 설명 VLM 요청 병렬 처리 수 (`ThreadPoolExecutor`의 `max_workers`) |
 | `enrichment.image_description` | `before_items` | `3` | 이미지 앞 문맥으로 넣을 텍스트 item 수 |
 | `enrichment.image_description` | `after_items` | `2` | 이미지 뒤 문맥으로 넣을 텍스트 item 수 |
 | `enrichment.image_description` | `max_context_chars` | `1500` | 프롬프트 전체 최대 문자 수 (초과 시 절단) |

--- a/genon/preprocessor/facade/parser_processor.py
+++ b/genon/preprocessor/facade/parser_processor.py
@@ -30,6 +30,8 @@ import unicodedata
 import uuid
 import warnings
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
 from datetime import datetime
 from glob import glob
 from pathlib import Path
@@ -85,10 +87,12 @@ from docling.document_converter import (
 )
 from docling.pipeline.simple_pipeline import SimplePipeline
 from docling.prompts.prompt_manager import LLMApiError
+from docling.utils.api_image_request import api_image_request
 from docling.utils.document_enrichment import check_document, enrich_document
 from docling_core.types import DoclingDocument
 from docling_core.types.doc import (
     BoundingBox,
+    DescriptionAnnotation,
     DocItem,
     DocItemLabel,
     DoclingDocument,
@@ -530,6 +534,459 @@ TITLE:<document title>
 
 
 # ============================================================
+# Facade Image Description
+# ============================================================
+
+_DEFAULT_IMAGE_DESCRIPTION_PROMPT_TEMPLATE = (
+    "문서의 일부 이미지를 설명해줘. "
+    "아래 문맥을 참고해서 핵심 정보를 2~4문장으로 간결하게 작성해줘.\n\n"
+    "[앞 문맥]\n{before_context}\n\n"
+    "[캡션]\n{caption}\n\n"
+    "[뒤 문맥]\n{after_context}\n\n"
+    "요구사항:\n"
+    "1) 추측은 최소화하고 이미지에서 확인 가능한 사실 중심으로 작성\n"
+    "2) 문서 문맥과의 연결점을 포함\n"
+    "3) 한국어로 작성"
+)
+
+
+@dataclass(frozen=True)
+class ImageDescriptionOptions:
+    enabled: bool = False
+    api_url: str = ""
+    api_key: str = ""
+    model: str = "model"
+    timeout: float = 20.0
+    concurrency: int = 1
+    before_items: int = 3
+    after_items: int = 2
+    max_context_chars: int = 1500
+    include_caption: bool = True
+    include_section_header: bool = True
+    same_page_first: bool = True
+    provenance: str = "facade_image_description"
+    prompt_template: str = _DEFAULT_IMAGE_DESCRIPTION_PROMPT_TEMPLATE
+    headers: dict[str, str] = field(default_factory=dict)
+    params: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_config(
+        cls,
+        *,
+        image_desc_cfg: dict,
+        fallback_api_url: str,
+        fallback_api_key: str,
+        fallback_model: str,
+    ) -> "ImageDescriptionOptions":
+        image_desc_cfg = _as_dict(image_desc_cfg)
+
+        def _parse_optional_bool(value: Any, key: str) -> Optional[bool]:
+            if value is None:
+                return None
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, (int, float)):
+                return bool(value)
+            if isinstance(value, str):
+                text = value.strip().lower()
+                if text in {"1", "true", "yes", "y", "on"}:
+                    return True
+                if text in {"0", "false", "no", "n", "off"}:
+                    return False
+            _log.warning(
+                f"[ImageDescriptionOptions] Invalid bool value for '{key}': {value!r}. Fallback to default."
+            )
+            return None
+
+        def _parse_optional_int(value: Any, key: str) -> Optional[int]:
+            if value is None or value == "":
+                return None
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                _log.warning(
+                    f"[ImageDescriptionOptions] Invalid int value for '{key}': {value!r}. Fallback to default."
+                )
+                return None
+
+        def _parse_optional_float(value: Any, key: str) -> Optional[float]:
+            if value is None or value == "":
+                return None
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                _log.warning(
+                    f"[ImageDescriptionOptions] Invalid float value for '{key}': {value!r}. Fallback to default."
+                )
+                return None
+
+        enabled = _parse_optional_bool(image_desc_cfg.get("enabled"), "enabled")
+        timeout = _parse_optional_float(image_desc_cfg.get("timeout"), "timeout")
+        concurrency = _parse_optional_int(image_desc_cfg.get("concurrency"), "concurrency")
+        before_items = _parse_optional_int(image_desc_cfg.get("before_items"), "before_items")
+        after_items = _parse_optional_int(image_desc_cfg.get("after_items"), "after_items")
+        max_context_chars = _parse_optional_int(
+            image_desc_cfg.get("max_context_chars"), "max_context_chars"
+        )
+        include_caption = _parse_optional_bool(image_desc_cfg.get("include_caption"), "include_caption")
+        include_section_header = _parse_optional_bool(
+            image_desc_cfg.get("include_section_header"), "include_section_header"
+        )
+        same_page_first = _parse_optional_bool(image_desc_cfg.get("same_page_first"), "same_page_first")
+
+        timeout = 20.0 if timeout is None or timeout <= 0 else timeout
+        if concurrency is None or concurrency <= 0:
+            concurrency = 1
+        if before_items is None or before_items < 0:
+            before_items = 3
+        if after_items is None or after_items < 0:
+            after_items = 2
+        if max_context_chars is None or max_context_chars <= 0:
+            max_context_chars = 1500
+
+        return cls(
+            enabled=False if enabled is None else enabled,
+            api_url=str(image_desc_cfg.get("api_url") or fallback_api_url or "").strip(),
+            api_key=str(image_desc_cfg.get("api_key") or fallback_api_key or "").strip(),
+            model=str(image_desc_cfg.get("model") or fallback_model or "model").strip(),
+            timeout=timeout,
+            concurrency=concurrency,
+            before_items=before_items,
+            after_items=after_items,
+            max_context_chars=max_context_chars,
+            include_caption=True if include_caption is None else include_caption,
+            include_section_header=True if include_section_header is None else include_section_header,
+            same_page_first=True if same_page_first is None else same_page_first,
+            provenance=str(
+                image_desc_cfg.get("provenance", "facade_image_description")
+            ).strip()
+            or "facade_image_description",
+            prompt_template=str(
+                image_desc_cfg.get("prompt_template", _DEFAULT_IMAGE_DESCRIPTION_PROMPT_TEMPLATE)
+            ),
+            headers=_as_dict(image_desc_cfg.get("headers")),
+            params=_as_dict(image_desc_cfg.get("params")),
+        )
+
+    @classmethod
+    def from_legacy_processor(cls, processor: Any) -> "ImageDescriptionOptions":
+        def _safe_int(value: Any, default: int, min_value: int) -> int:
+            try:
+                parsed = int(value)
+            except (TypeError, ValueError):
+                return default
+            return parsed if parsed >= min_value else default
+
+        def _safe_float(value: Any, default: float, min_value: float) -> float:
+            try:
+                parsed = float(value)
+            except (TypeError, ValueError):
+                return default
+            return parsed if parsed >= min_value else default
+
+        return cls(
+            enabled=bool(getattr(processor, "image_description_enabled", False)),
+            api_url=str(getattr(processor, "image_description_api_url", "") or "").strip(),
+            api_key=str(getattr(processor, "image_description_api_key", "") or "").strip(),
+            model=str(getattr(processor, "image_description_model", "model") or "model").strip(),
+            timeout=_safe_float(getattr(processor, "image_description_timeout", 20.0), 20.0, 0.00001),
+            concurrency=_safe_int(getattr(processor, "image_description_concurrency", 1), 1, 1),
+            before_items=_safe_int(getattr(processor, "image_description_before_items", 3), 3, 0),
+            after_items=_safe_int(getattr(processor, "image_description_after_items", 2), 2, 0),
+            max_context_chars=_safe_int(
+                getattr(processor, "image_description_max_context_chars", 1500), 1500, 1
+            ),
+            include_caption=bool(getattr(processor, "image_description_include_caption", True)),
+            include_section_header=bool(
+                getattr(processor, "image_description_include_section_header", True)
+            ),
+            same_page_first=bool(getattr(processor, "image_description_same_page_first", True)),
+            provenance=str(
+                getattr(processor, "image_description_provenance", "facade_image_description")
+                or "facade_image_description"
+            ).strip(),
+            prompt_template=str(
+                getattr(
+                    processor,
+                    "image_description_prompt_template",
+                    _DEFAULT_IMAGE_DESCRIPTION_PROMPT_TEMPLATE,
+                )
+            ),
+            headers=dict(getattr(processor, "image_description_headers", {}) or {}),
+            params=dict(getattr(processor, "image_description_params", {}) or {}),
+        )
+
+
+class PictureDescriptionExtractor:
+    @staticmethod
+    def extract(item: PictureItem) -> str:
+        for annotation in getattr(item, "annotations", []) or []:
+            if not isinstance(annotation, DescriptionAnnotation):
+                continue
+            text = str(getattr(annotation, "text", "") or "").strip()
+            if text:
+                return text
+        return ""
+
+
+class FacadeImageDescriptionEnricher:
+    def __init__(self, options: ImageDescriptionOptions):
+        self.options = options
+
+    @staticmethod
+    def _get_item_page_no(item: DocItem, default_page_no: int = 1) -> int:
+        prov_list = getattr(item, "prov", None) or []
+        if not prov_list:
+            return default_page_no
+        page_no = getattr(prov_list[0], "page_no", None)
+        if isinstance(page_no, int) and page_no > 0:
+            return page_no
+        return default_page_no
+
+    @staticmethod
+    def _to_single_line(text: str) -> str:
+        return re.sub(r"\s+", " ", text).strip()
+
+    def _is_context_candidate(self, item: DocItem) -> bool:
+        if isinstance(item, PictureItem):
+            return False
+
+        text = self._to_single_line(str(getattr(item, "text", "") or ""))
+        if not text:
+            return False
+
+        label = getattr(item, "label", None)
+        label_value = label.value if hasattr(label, "value") else str(label or "")
+        if label_value in {"page_header", "page_footer"}:
+            return False
+        return True
+
+    def _collect_neighbor_context(
+        self,
+        items: list[DocItem],
+        picture_index: int,
+        picture_page_no: int,
+        max_items: int,
+        direction: str,
+    ) -> list[str]:
+        if max_items <= 0:
+            return []
+
+        if direction == "before":
+            scan_range = range(picture_index - 1, -1, -1)
+        else:
+            scan_range = range(picture_index + 1, len(items))
+
+        sequential: list[str] = []
+        same_page: list[str] = []
+        cross_page: list[str] = []
+
+        for idx in scan_range:
+            candidate = items[idx]
+            if not self._is_context_candidate(candidate):
+                continue
+            text = self._to_single_line(str(getattr(candidate, "text", "") or ""))
+            if not text:
+                continue
+
+            if not self.options.same_page_first:
+                sequential.append(text)
+                if len(sequential) >= max_items:
+                    break
+                continue
+
+            candidate_page_no = self._get_item_page_no(
+                candidate, default_page_no=picture_page_no
+            )
+            if candidate_page_no == picture_page_no:
+                same_page.append(text)
+            else:
+                cross_page.append(text)
+
+            if len(same_page) + len(cross_page) >= max_items:
+                break
+
+        if self.options.same_page_first:
+            if direction == "before":
+                # 그룹 우선순위(same page -> cross page)는 유지하면서 문서 순서로 정렬
+                same_page = list(reversed(same_page))
+                cross_page = list(reversed(cross_page))
+            selected = (same_page + cross_page)[:max_items]
+        else:
+            selected = sequential[:max_items]
+            if direction == "before":
+                # 앞 문맥은 문서 순서(먼저 나온 텍스트 → 최근 텍스트)로 정렬한다.
+                selected.reverse()
+        return selected
+
+    def _collect_section_header_context(
+        self,
+        items: list[DocItem],
+        picture_index: int,
+    ) -> str:
+        for idx in range(picture_index - 1, -1, -1):
+            candidate = items[idx]
+            label = getattr(candidate, "label", None)
+            label_value = label.value if hasattr(label, "value") else str(label or "")
+            if label_value in {"section_header", "title"}:
+                text = self._to_single_line(str(getattr(candidate, "text", "") or ""))
+                if text:
+                    return text
+        return ""
+
+    def _truncate_context(self, text: str) -> str:
+        if len(text) <= self.options.max_context_chars:
+            return text
+        return text[: self.options.max_context_chars].rstrip() + " ..."
+
+    def _build_prompt(self, before_context: str, after_context: str, caption: str) -> str:
+        safe_before = before_context or "-"
+        safe_after = after_context or "-"
+        safe_caption = caption or "-"
+        try:
+            prompt = self.options.prompt_template.format(
+                before_context=safe_before,
+                after_context=safe_after,
+                caption=safe_caption,
+            )
+        except Exception as exc:
+            _log.warning(
+                f"[FacadeImageDescriptionEnricher] Invalid prompt_template, fallback to default: {exc}"
+            )
+            prompt = (
+                "문맥을 참고해서 이미지를 설명해줘.\n\n"
+                f"[앞 문맥]\n{safe_before}\n\n"
+                f"[캡션]\n{safe_caption}\n\n"
+                f"[뒤 문맥]\n{safe_after}"
+            )
+        return self._truncate_context(prompt)
+
+    def _annotate_single_picture(
+        self,
+        document: DoclingDocument,
+        picture_item: PictureItem,
+        prompt: str,
+    ) -> Optional[DescriptionAnnotation]:
+        image = picture_item.get_image(document, prov_index=0)
+        if image is None:
+            return None
+
+        headers = dict(self.options.headers)
+        if self.options.api_key and "Authorization" not in headers:
+            headers["Authorization"] = f"Bearer {self.options.api_key}"
+
+        params = dict(self.options.params)
+        if self.options.model and "model" not in params:
+            params["model"] = self.options.model
+
+        output = api_image_request(
+            image=image,
+            prompt=prompt,
+            url=self.options.api_url,
+            timeout=self.options.timeout,
+            headers=headers,
+            **params,
+        )
+        output_text = str(output or "").strip()
+        if not output_text:
+            return None
+        return DescriptionAnnotation(
+            text=output_text,
+            provenance=self.options.provenance,
+        )
+
+    def enrich(self, document: DoclingDocument, **kwargs: dict) -> DoclingDocument:
+        if not self.options.enabled:
+            return document
+
+        if not self.options.api_url:
+            _log.warning(
+                "[FacadeImageDescriptionEnricher] enabled=true but api_url is empty; skip"
+            )
+            return document
+
+        items: list[DocItem] = [
+            item
+            for item, _ in document.iterate_items(
+                included_content_layers={ContentLayer.BODY, ContentLayer.FURNITURE}
+            )
+        ]
+        if not items:
+            return document
+
+        targets: list[tuple[PictureItem, str]] = []
+        for idx, item in enumerate(items):
+            if not isinstance(item, PictureItem):
+                continue
+
+            page_no = self._get_item_page_no(item, default_page_no=1)
+            before_context_items = self._collect_neighbor_context(
+                items=items,
+                picture_index=idx,
+                picture_page_no=page_no,
+                max_items=self.options.before_items,
+                direction="before",
+            )
+            after_context_items = self._collect_neighbor_context(
+                items=items,
+                picture_index=idx,
+                picture_page_no=page_no,
+                max_items=self.options.after_items,
+                direction="after",
+            )
+
+            if self.options.include_section_header:
+                section_header = self._collect_section_header_context(
+                    items=items, picture_index=idx
+                )
+                if section_header:
+                    before_context_items = [section_header] + before_context_items
+
+            caption = ""
+            if self.options.include_caption:
+                try:
+                    caption = self._to_single_line(item.caption_text(document))
+                except Exception:
+                    caption = ""
+
+            before_context = "\n".join(before_context_items)
+            after_context = "\n".join(after_context_items)
+            prompt = self._build_prompt(
+                before_context=before_context,
+                after_context=after_context,
+                caption=caption,
+            )
+            targets.append((item, prompt))
+
+        if not targets:
+            return document
+
+        def _annotate_target(target: tuple[PictureItem, str]) -> None:
+            pic, prompt = target
+            try:
+                annotation = self._annotate_single_picture(document, pic, prompt)
+            except Exception as exc:
+                _log.warning(f"[FacadeImageDescriptionEnricher] image description failed: {exc}")
+                return
+            if annotation is None:
+                return
+            pic.annotations = [
+                ann
+                for ann in pic.annotations
+                if not (
+                    isinstance(ann, DescriptionAnnotation)
+                    and getattr(ann, "provenance", "") == self.options.provenance
+                )
+            ]
+            pic.annotations.append(annotation)
+
+        with ThreadPoolExecutor(max_workers=self.options.concurrency) as executor:
+            list(executor.map(_annotate_target, targets))
+
+        return document
+
+
+# ============================================================
 # IntelligentDocumentProcessor — PDF 전용 (from intelligent_processor.py)
 # 파싱에 필요한 메서드만 포함 (청킹/벡터 메서드 제외)
 # ============================================================
@@ -581,6 +1038,7 @@ class IntelligentDocumentProcessor:
         enrichment_model = enrichment_cfg.get("model", cfg.get("enrichment_model", "model"))
         do_toc = bool(enrichment_cfg.get("do_toc", cfg.get("do_toc", True)))
         do_metadata = bool(enrichment_cfg.get("do_metadata", cfg.get("do_metadata", True)))
+        image_desc_cfg = _as_dict(enrichment_cfg.get("image_description"))
 
         toc_cfg = _as_dict(enrichment_cfg.get("toc"))
         toc_temperature = toc_cfg.get("temperature", cfg.get("toc_temperature", 0.0))
@@ -708,6 +1166,15 @@ class IntelligentDocumentProcessor:
         self.ocr_pipe_line_options.ocr_options.force_full_page_ocr = True
 
         self._create_converters()
+        self.image_description_options = ImageDescriptionOptions.from_config(
+            image_desc_cfg=image_desc_cfg,
+            fallback_api_url=enrichment_url,
+            fallback_api_key=enrichment_key,
+            fallback_model=enrichment_model,
+        )
+        self.image_description_enricher = FacadeImageDescriptionEnricher(
+            self.image_description_options
+        )
 
         self.enrichment_options = DataEnrichmentOptions(
             do_toc_enrichment=do_toc,
@@ -874,6 +1341,19 @@ class IntelligentDocumentProcessor:
         except LLMApiError as e:
             # Preserve provider error payload as-is for load status error message.
             raise GenosServiceException("1", e.raw_error_message) from e
+
+    def _get_or_create_image_description_enricher(self) -> FacadeImageDescriptionEnricher:
+        enricher = getattr(self, "image_description_enricher", None)
+        if enricher is None:
+            # 테스트 등에서 __init__ 우회 시 legacy attribute 기반으로 재구성
+            legacy_options = ImageDescriptionOptions.from_legacy_processor(self)
+            enricher = FacadeImageDescriptionEnricher(legacy_options)
+            self.image_description_enricher = enricher
+        return enricher
+
+    def enrich_image_descriptions(self, document: DoclingDocument, **kwargs: dict) -> DoclingDocument:
+        enricher = self._get_or_create_image_description_enricher()
+        return enricher.enrich(document, **kwargs)
 
     def check_glyph_text(self, text: str, threshold: int = 1) -> bool:
         if not text:
@@ -1262,6 +1742,7 @@ class DocumentProcessor:
         #     image_dir=artifacts_dir, page_no=None, reference_path=reference_path
         # )
         document = self._intel.enrichment(document, **kwargs)
+
         return document
 
     def _parse_hwp_hwpx(self, file_path: str, **kwargs) -> DoclingDocument:
@@ -1314,6 +1795,14 @@ class DocumentProcessor:
 
     def _parse_other(self, file_path: str, **kwargs) -> list:
         return self._generic.load_documents(file_path, **kwargs)
+
+    def _apply_docling_post_enrichment(self, document: DoclingDocument, **kwargs) -> DoclingDocument:
+        """Facade 후처리 enrichment 훅."""
+        try:
+            return self._intel.enrich_image_descriptions(document, **kwargs)
+        except Exception as exc:
+            _log.warning(f"[DocumentProcessor] facade image enrichment skipped: {exc}")
+            return document
 
     # ------------------------------------------------------------------
     # 직렬화 헬퍼
@@ -1440,14 +1929,22 @@ class DocumentProcessor:
             else:
                 text = getattr(item, "text", "") or ""
 
-            elements.append({
+            element = {
                 "category": label_value,
                 # "content": {"html": html, "markdown": "", "text": text},
                 "content": text,
                 "coordinates": coordinates,
                 "id": element_id,
                 "page": page_no,
-            })
+            }
+            if isinstance(item, PictureItem):
+                image_description = PictureDescriptionExtractor.extract(item)
+                if image_description:
+                    # 최종 소비계층에서 별도 필드 매핑 없이 바로 활용할 수 있도록
+                    # picture 의 content 를 이미지 설명 텍스트로 채운다.
+                    element["content"] = image_description
+
+            elements.append(element)
             element_id += 1
 
         # full_html = "\n".join(e["content"]["html"] for e in elements)
@@ -1671,14 +2168,17 @@ class DocumentProcessor:
 
         if ext in (".hwp", ".hwpx"):
             doc = self._parse_hwp_hwpx(file_path, **kwargs)
+            doc = self._apply_docling_post_enrichment(doc, **kwargs)
             return self._normalize_response(self._build_docling_response(doc))
 
         if ext == ".docx":
             doc = self._parse_docx(file_path, **kwargs)
+            doc = self._apply_docling_post_enrichment(doc, **kwargs)
             return self._normalize_response(self._build_docling_response(doc, clear_coordinates=True))
 
         if ext in (".pdf", ".html", ".htm"):
             doc = self._parse_docling(file_path, **kwargs)
+            doc = self._apply_docling_post_enrichment(doc, **kwargs)
             # result["docling_document"] = self._serialize_docling_document(doc)
             return self._normalize_response(self._build_docling_response(doc))
 

--- a/genon/preprocessor/facade/parser_processor.py
+++ b/genon/preprocessor/facade/parser_processor.py
@@ -26,6 +26,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import time
 import unicodedata
 import uuid
 import warnings
@@ -556,8 +557,8 @@ class ImageDescriptionOptions:
     api_url: str = ""
     api_key: str = ""
     model: str = "model"
-    timeout: float = 20.0
-    concurrency: int = 1
+    timeout: float = 360.0
+    concurrency: int = 16
     before_items: int = 3
     after_items: int = 2
     max_context_chars: int = 1500
@@ -634,9 +635,9 @@ class ImageDescriptionOptions:
         )
         same_page_first = _parse_optional_bool(image_desc_cfg.get("same_page_first"), "same_page_first")
 
-        timeout = 20.0 if timeout is None or timeout <= 0 else timeout
+        timeout = 360.0 if timeout is None or timeout <= 0 else timeout
         if concurrency is None or concurrency <= 0:
-            concurrency = 1
+            concurrency = 4
         if before_items is None or before_items < 0:
             before_items = 3
         if after_items is None or after_items < 0:
@@ -690,7 +691,7 @@ class ImageDescriptionOptions:
             api_key=str(getattr(processor, "image_description_api_key", "") or "").strip(),
             model=str(getattr(processor, "image_description_model", "model") or "model").strip(),
             timeout=_safe_float(getattr(processor, "image_description_timeout", 20.0), 20.0, 0.00001),
-            concurrency=_safe_int(getattr(processor, "image_description_concurrency", 1), 1, 1),
+            concurrency=_safe_int(getattr(processor, "image_description_concurrency", 4), 4, 1),
             before_items=_safe_int(getattr(processor, "image_description_before_items", 3), 3, 0),
             after_items=_safe_int(getattr(processor, "image_description_after_items", 2), 2, 0),
             max_context_chars=_safe_int(
@@ -899,6 +900,8 @@ class FacadeImageDescriptionEnricher:
         if not self.options.enabled:
             return document
 
+        stage_started_at = time.perf_counter()
+
         if not self.options.api_url:
             _log.warning(
                 "[FacadeImageDescriptionEnricher] enabled=true but api_url is empty; skip"
@@ -914,7 +917,7 @@ class FacadeImageDescriptionEnricher:
         if not items:
             return document
 
-        targets: list[tuple[PictureItem, str]] = []
+        targets: list[tuple[int, PictureItem, str]] = []
         for idx, item in enumerate(items):
             if not isinstance(item, PictureItem):
                 continue
@@ -956,19 +959,52 @@ class FacadeImageDescriptionEnricher:
                 after_context=after_context,
                 caption=caption,
             )
-            targets.append((item, prompt))
+            picture_seq = len(targets) + 1
+            targets.append((picture_seq, item, prompt))
 
         if not targets:
+            elapsed = time.perf_counter() - stage_started_at
+            _log.info(
+                f"[FacadeImageDescriptionEnricher] no picture target for image description; "
+                f"elapsed={elapsed:.3f}s"
+            )
             return document
 
-        def _annotate_target(target: tuple[PictureItem, str]) -> None:
-            pic, prompt = target
+        total_targets = len(targets)
+        _log.info(
+            f"[FacadeImageDescriptionEnricher] image description start: "
+            f"targets={total_targets}, concurrency={self.options.concurrency}"
+        )
+
+        stats_lock = threading.Lock()
+        success_count = 0
+        failed_count = 0
+        skipped_count = 0
+
+        def _annotate_target(target: tuple[int, PictureItem, str]) -> None:
+            nonlocal success_count, failed_count, skipped_count
+            seq, pic, prompt = target
+            picture_started_at = time.perf_counter()
+            page_no = self._get_item_page_no(pic, default_page_no=1)
             try:
                 annotation = self._annotate_single_picture(document, pic, prompt)
             except Exception as exc:
-                _log.warning(f"[FacadeImageDescriptionEnricher] image description failed: {exc}")
+                elapsed = time.perf_counter() - picture_started_at
+                with stats_lock:
+                    failed_count += 1
+                _log.warning(
+                    f"[FacadeImageDescriptionEnricher] image description failed: "
+                    f"seq={seq}, page={page_no}, elapsed={elapsed:.3f}s, error={exc}"
+                )
                 return
             if annotation is None:
+                elapsed = time.perf_counter() - picture_started_at
+                with stats_lock:
+                    skipped_count += 1
+                _log.debug(
+                    f"[FacadeImageDescriptionEnricher] image description empty: "
+                    f"seq={seq}, page={page_no}, elapsed={elapsed:.3f}s"
+                )
                 return
             pic.annotations = [
                 ann
@@ -979,9 +1015,23 @@ class FacadeImageDescriptionEnricher:
                 )
             ]
             pic.annotations.append(annotation)
+            elapsed = time.perf_counter() - picture_started_at
+            with stats_lock:
+                success_count += 1
+            _log.debug(
+                f"[FacadeImageDescriptionEnricher] image description done: "
+                f"seq={seq}, page={page_no}, elapsed={elapsed:.3f}s"
+            )
 
         with ThreadPoolExecutor(max_workers=self.options.concurrency) as executor:
             list(executor.map(_annotate_target, targets))
+
+        total_elapsed = time.perf_counter() - stage_started_at
+        _log.info(
+            f"[FacadeImageDescriptionEnricher] image description done: "
+            f"targets={total_targets}, success={success_count}, skipped={skipped_count}, "
+            f"failed={failed_count}, elapsed={total_elapsed:.3f}s"
+        )
 
         return document
 

--- a/genon/preprocessor/resource/parser_processor_config.yaml
+++ b/genon/preprocessor/resource/parser_processor_config.yaml
@@ -50,13 +50,14 @@ enrichment:
 
   # facade 후처리 기반 이미지 설명 생성 (문맥 포함)
   image_description:
-    enabled: false
-    # 필요 시만 지정 (미지정 시 enrichment.api_url 상속)
-    api_url: ""
-    # 필요 시만 지정 (미지정 시 enrichment.api_key 상속)
+    enabled: true
+    # <IMAGE_DESCRIPTION_SERVING_ID>: Genos에 등록한 이미지 설명 모델서빙 ID로 변경 필요
+    # api_key는 k8s 내부 통신 기반 모델 호출 시 불필요.
+    api_url: "http://llmops-gateway-api-service:8080/rep/serving/<IMAGE_DESCRIPTION_SERVING_ID>/v1/chat/completions"
     api_key: ""
-    # 필요 시만 지정 (미지정 시 enrichment.model 상속)
     model: "model"
+    # 이미지 설명 요청 병렬 수 (기본 16)
+    concurrency: 16
     before_items: 3
     after_items: 2
     max_context_chars: 1500

--- a/genon/preprocessor/resource/parser_processor_config.yaml
+++ b/genon/preprocessor/resource/parser_processor_config.yaml
@@ -48,6 +48,35 @@ enrichment:
     seed: 33
     max_tokens: 10000
 
+  # facade 후처리 기반 이미지 설명 생성 (문맥 포함)
+  image_description:
+    enabled: false
+    # 필요 시만 지정 (미지정 시 enrichment.api_url 상속)
+    api_url: ""
+    # 필요 시만 지정 (미지정 시 enrichment.api_key 상속)
+    api_key: ""
+    # 필요 시만 지정 (미지정 시 enrichment.model 상속)
+    model: "model"
+    before_items: 3
+    after_items: 2
+    max_context_chars: 1500
+    prompt_template: |
+      문서의 일부 이미지를 설명해줘. 아래 문맥을 참고해서 핵심 정보를 2~4문장으로 간결하게 작성해줘.
+
+      [앞 문맥]
+      {before_context}
+
+      [캡션]
+      {caption}
+
+      [뒤 문맥]
+      {after_context}
+
+      요구사항:
+      1) 추측은 최소화하고 이미지에서 확인 가능한 사실 중심으로 작성
+      2) 문서 문맥과의 연결점을 포함
+      3) 한국어로 작성
+
 output:
   format: "json" # "json" (default), "html", "markdown"
   table_format: "html" # "html" (default), "markdown"

--- a/genon/preprocessor/resource_dev/parser_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/parser_processor_config.yaml
@@ -42,6 +42,35 @@ enrichment:
     seed: 33
     max_tokens: 10000
 
+  # facade 후처리 기반 이미지 설명 생성 (문맥 포함)
+  image_description:
+    enabled: false
+    # 필요 시만 지정 (미지정 시 enrichment.api_url 상속)
+    api_url: ""
+    # 필요 시만 지정 (미지정 시 enrichment.api_key 상속)
+    api_key: ""
+    # 필요 시만 지정 (미지정 시 enrichment.model 상속)
+    model: "model"
+    before_items: 3
+    after_items: 2
+    max_context_chars: 1500
+    prompt_template: |
+      문서의 일부 이미지를 설명해줘. 아래 문맥을 참고해서 핵심 정보를 2~4문장으로 간결하게 작성해줘.
+
+      [앞 문맥]
+      {before_context}
+
+      [캡션]
+      {caption}
+
+      [뒤 문맥]
+      {after_context}
+
+      요구사항:
+      1) 추측은 최소화하고 이미지에서 확인 가능한 사실 중심으로 작성
+      2) 문서 문맥과의 연결점을 포함
+      3) 한국어로 작성
+
 output:
   format: "json" # "json" (default), "html", "markdown"
   table_format: "html" # "html" (default), "markdown"

--- a/genon/preprocessor/resource_dev/parser_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/parser_processor_config.yaml
@@ -44,13 +44,12 @@ enrichment:
 
   # facade 후처리 기반 이미지 설명 생성 (문맥 포함)
   image_description:
-    enabled: false
-    # 필요 시만 지정 (미지정 시 enrichment.api_url 상속)
-    api_url: ""
-    # 필요 시만 지정 (미지정 시 enrichment.api_key 상속)
-    api_key: ""
-    # 필요 시만 지정 (미지정 시 enrichment.model 상속)
+    enabled: true
+    api_url: "https://genos.genon.ai/api/gateway/rep/serving/750/v1/chat/completions"
+    api_key: "26e6a516de0847f59a3b9db8e418976e"
     model: "model"
+    # 이미지 설명 요청 병렬 수 (기본 16, 문서 내 이미지가 많을 때 처리속도에 영향)
+    concurrency: 16
     before_items: 3
     after_items: 2
     max_context_chars: 1500

--- a/genon/preprocessor/tests/conftest.py
+++ b/genon/preprocessor/tests/conftest.py
@@ -64,3 +64,23 @@ def attachment_processor():
 def parser_processor():
     mod = pytest.importorskip("facade.parser_processor")
     return mod.DocumentProcessor
+
+
+@pytest.fixture(autouse=True)
+def _stub_vlm_for_unit_tests(request, monkeypatch):
+    """unit 테스트에서는 외부 VLM 호출을 기본 차단한다."""
+    if request.node.get_closest_marker("unit") is None:
+        return
+
+    try:
+        import facade.parser_processor as parser_mod
+    except Exception:
+        # parser_processor를 사용하지 않는 unit 테스트도 있으므로 조용히 패스
+        return
+
+    monkeypatch.setattr(
+        parser_mod,
+        "api_image_request",
+        lambda *args, **kwargs: "",
+        raising=False,
+    )

--- a/genon/preprocessor/tests/unit/test_parser_processor_unit.py
+++ b/genon/preprocessor/tests/unit/test_parser_processor_unit.py
@@ -9,8 +9,15 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
+from PIL import Image
 
-from docling_core.types.doc import BoundingBox
+from docling_core.types.doc import (
+    BoundingBox,
+    DescriptionAnnotation,
+    DocItemLabel,
+    PictureItem,
+    ProvenanceItem,
+)
 from docling_core.types.doc.base import CoordOrigin
 from langchain_core.documents import Document
 
@@ -63,6 +70,23 @@ def _make_text_item(text="hello", label="paragraph", page_no=1, has_prov=True, l
     item.text = text
     item.level = level  # needed when label == "section_header"
     return item
+
+
+def _make_picture_item(page_no=1, annotations=None):
+    return PictureItem(
+        self_ref="#/pictures/0",
+        parent=None,
+        children=[],
+        label=DocItemLabel.PICTURE,
+        prov=[
+            ProvenanceItem(
+                page_no=page_no,
+                bbox=BoundingBox(l=10, t=20, r=90, b=80, coord_origin=CoordOrigin.TOPLEFT),
+                charspan=(0, 0),
+            )
+        ],
+        annotations=annotations or [],
+    )
 
 
 def _make_mock_doc(items, num_pages=1):
@@ -267,6 +291,20 @@ class TestDoclingToParseFormat:
         result = DocumentProcessor._docling_to_parse_format(doc)
         assert result["elements"][0]["category"] == "section_header"
 
+    def test_picture_annotation_is_mapped_to_content(self):
+        picture = _make_picture_item(
+            annotations=[
+                DescriptionAnnotation(
+                    text="문맥 기반 이미지 설명",
+                    provenance="facade_image_description",
+                )
+            ]
+        )
+        doc = _make_mock_doc([picture])
+        element = DocumentProcessor._docling_to_parse_format(doc)["elements"][0]
+        assert element["category"] == "picture"
+        assert element["content"] == "문맥 기반 이미지 설명"
+
 
 # ─── DocumentProcessor.__call__ routing ──────────────────────────────────────
 
@@ -349,6 +387,98 @@ class TestCheckGlyphText:
 
     def test_none_returns_false(self, intel):
         assert intel.check_glyph_text(None) is False
+
+
+@pytest.mark.unit
+class TestEnrichImageDescriptions:
+    def _make_intel(self, enabled=True):
+        intel = object.__new__(IntelligentDocumentProcessor)
+        intel.image_description_enabled = enabled
+        intel.image_description_api_url = "http://example.com/v1/chat/completions"
+        intel.image_description_api_key = "secret"
+        intel.image_description_model = "mock-model"
+        intel.image_description_timeout = 10.0
+        intel.image_description_concurrency = 1
+        intel.image_description_before_items = 2
+        intel.image_description_after_items = 2
+        intel.image_description_max_context_chars = 1500
+        intel.image_description_include_caption = False
+        intel.image_description_include_section_header = False
+        intel.image_description_same_page_first = True
+        intel.image_description_headers = {}
+        intel.image_description_params = {}
+        intel.image_description_provenance = "facade_image_description"
+        intel.image_description_prompt_template = (
+            "[앞 문맥]\\n{before_context}\\n[캡션]\\n{caption}\\n[뒤 문맥]\\n{after_context}"
+        )
+        return intel
+
+    def test_disabled_option_skips_image_description_api_call(self):
+        intel = self._make_intel(enabled=False)
+        doc = MagicMock()
+        doc.iterate_items.return_value = []
+
+        with patch("facade.parser_processor.api_image_request") as mock_api:
+            result = intel.enrich_image_descriptions(doc)
+
+        assert result is doc
+        mock_api.assert_not_called()
+
+    def test_enrichment_adds_description_annotation_with_context(self):
+        intel = self._make_intel(enabled=True)
+        before_item = _make_text_item(text="앞 문단 텍스트", page_no=1)
+        picture_item = _make_picture_item(page_no=1)
+        after_item = _make_text_item(text="뒤 문단 텍스트", page_no=1)
+        doc = _make_mock_doc([before_item, picture_item, after_item])
+
+        with patch.object(
+            PictureItem,
+            "get_image",
+            return_value=Image.new("RGB", (8, 8), color="white"),
+        ), patch(
+            "facade.parser_processor.api_image_request",
+            return_value="문맥 기반 설명 결과",
+        ) as mock_api:
+            result = intel.enrich_image_descriptions(doc)
+
+        assert result is doc
+        descriptions = [
+            ann
+            for ann in picture_item.annotations
+            if isinstance(ann, DescriptionAnnotation)
+        ]
+        assert descriptions
+        assert descriptions[0].text == "문맥 기반 설명 결과"
+        assert descriptions[0].provenance == "facade_image_description"
+
+        prompt = mock_api.call_args.kwargs["prompt"]
+        assert "앞 문단 텍스트" in prompt
+        assert "뒤 문단 텍스트" in prompt
+
+    def test_enrichment_vlm_unreachable_is_ignored(self):
+        intel = self._make_intel(enabled=True)
+        before_item = _make_text_item(text="앞 문단 텍스트", page_no=1)
+        picture_item = _make_picture_item(page_no=1)
+        after_item = _make_text_item(text="뒤 문단 텍스트", page_no=1)
+        doc = _make_mock_doc([before_item, picture_item, after_item])
+
+        with patch.object(
+            PictureItem,
+            "get_image",
+            return_value=Image.new("RGB", (8, 8), color="white"),
+        ), patch(
+            "facade.parser_processor.api_image_request",
+            side_effect=RuntimeError("VLM endpoint is unreachable"),
+        ):
+            result = intel.enrich_image_descriptions(doc)
+
+        assert result is doc
+        descriptions = [
+            ann
+            for ann in picture_item.annotations
+            if isinstance(ann, DescriptionAnnotation)
+        ]
+        assert descriptions == []
 
 
 @pytest.mark.unit


### PR DESCRIPTION
# [feature/96] image description 추가

## Summary

문서 내 이미지에 대한 자동 설명 생성 기능(Image Description)를 추가합니다.

---

## Changes

### 1. 이미지 설명 생성 기능 (Image Description) `#96`

VLM(Vision Language Model)을 사용하여 문서 내 이미지에 대한 자연어 설명을 자동으로 생성합니다.

**주요 구현 사항:**
- `ImageDescriptionOptions` dataclass 추가 (`parser_processor.py`)
  - `enabled`, `api_url`, `api_key`, `model`, `timeout`, `concurrency` 등 전체 옵션 지원
  - `before_items` / `after_items`: 이미지 앞뒤 문맥 항목 수 설정
  - `max_context_chars`: 문맥 최대 글자 수 제한
  - `include_caption`, `include_section_header`, `same_page_first` 옵션
  - `prompt_template`: 커스텀 프롬프트 템플릿 지원
- `ThreadPoolExecutor` 기반 병렬 처리 (`concurrency` 설정값 사용)
- `convert_processor.py`, `intelligent_processor.py`에서 이미지 설명 기능 통합
- `parser_processor_config.yaml`에 `image_description` 섹션 추가
- `from_config()` 클래스 메서드를 통해 YAML 설정 파일에서 옵션 로드

**기본 프롬프트 동작:**
- 이미지 앞뒤 문맥 + 캡션을 포함하여 VLM에 전달
- 한국어로 2~4문장의 간결한 설명 생성

## Test Plan

- [ ] `image_description.enabled: true` 설정 후 이미지 포함 PDF 파싱 → `DescriptionAnnotation` 생성 확인
- [ ] `concurrency` 설정 변경 후 병렬 처리 동작 확인

---

## Files Changed

| 파일 | 변경 내용 |
|------|-----------|
| `genon/preprocessor/facade/parser_processor.py` | `ImageDescriptionOptions`, 이미지 설명 생성 로직 추가 |
| `genon/preprocessor/resource/parser_processor_config.yaml` | `image_description` 설정 섹션 추가 |
| `genon/preprocessor/tests/unit/` | 관련 단위 테스트 추가/수정 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic image description enrichment: Generates contextual descriptions for images in documents using an external vision-language model API
  * New configurable parameters for image descriptions including context window sizing, concurrency limits, and prompt customization

* **Documentation**
  * Updated parser processor documentation with new image description configuration schema and API prerequisites

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genonai/doc_parser/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->