### PR TITLE
fix(#249): HWP/HWPX → PDF 변환 rhwp 우선으로 순서 변경

### DIFF
--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -1,4 +1,4 @@
-# 첨부용 전처리기 v.2.1.5 (2026-05-21 Release)
+# 첨부용 전처리기 v.2.2.0 (2026-06-02 Release)
 from __future__ import annotations
 
 from collections import defaultdict

--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -174,24 +174,23 @@ def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
     PDF 변환을 시도한다. 실패해도 예외를 던지지 않고 None을 반환한다.
 
     chain (HWP/HWPX 입력):
-      use_pdf_sdk=True  → pdf_sdk → libreoffice → rhwp
-      use_pdf_sdk=False → libreoffice → rhwp
+      use_pdf_sdk=True  → pdf_sdk → rhwp → libreoffice
+      use_pdf_sdk=False → rhwp → libreoffice
     chain (그 외 입력, 예: docx/pptx):
       use_pdf_sdk=True  → pdf_sdk → libreoffice
       use_pdf_sdk=False → libreoffice
 
-    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않는다. 또한 도입
-    초기 단계라 안정성 검증 전까지는 최후순위 fallback 으로만 두며, 검증 후
-    우선순위 상향을 검토한다.
+    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않는다. HWP/HWPX
+    변환은 rhwp 를 libreoffice 보다 우선한다 (pdf_sdk 가 있으면 그 다음 순위).
     내부 구현은 `genon.preprocessor.converters.hwp_to_pdf` 모듈에 통합되어 있다.
     """
     from genon.preprocessor.converters.hwp_to_pdf import convert_hwp_to_pdf
     ext = os.path.splitext(file_path)[1].lower()
     is_hwp = ext in (".hwp", ".hwpx")
     if use_pdf_sdk:
-        order = ["pdf_sdk", "libreoffice", "rhwp"] if is_hwp else ["pdf_sdk", "libreoffice"]
+        order = ["pdf_sdk", "rhwp", "libreoffice"] if is_hwp else ["pdf_sdk", "libreoffice"]
     else:
-        order = ["libreoffice", "rhwp"] if is_hwp else ["libreoffice"]
+        order = ["rhwp", "libreoffice"] if is_hwp else ["libreoffice"]
     return convert_hwp_to_pdf(file_path, order=order)
 
 

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -234,24 +234,23 @@ def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
     PDF 변환을 시도한다. 실패해도 예외를 던지지 않고 None을 반환한다.
 
     chain (HWP/HWPX 입력):
-      use_pdf_sdk=True  → pdf_sdk → libreoffice → rhwp
-      use_pdf_sdk=False → libreoffice → rhwp
+      use_pdf_sdk=True  → pdf_sdk → rhwp → libreoffice
+      use_pdf_sdk=False → rhwp → libreoffice
     chain (그 외 입력, 예: docx/pptx):
       use_pdf_sdk=True  → pdf_sdk → libreoffice
       use_pdf_sdk=False → libreoffice
 
-    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않는다. 또한 도입
-    초기 단계라 안정성 검증 전까지는 최후순위 fallback 으로만 두며, 검증 후
-    우선순위 상향을 검토한다.
+    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않는다. HWP/HWPX
+    변환은 rhwp 를 libreoffice 보다 우선한다 (pdf_sdk 가 있으면 그 다음 순위).
     내부 구현은 `genon.preprocessor.converters.hwp_to_pdf` 모듈에 통합되어 있다.
     """
     from genon.preprocessor.converters.hwp_to_pdf import convert_hwp_to_pdf
     ext = os.path.splitext(file_path)[1].lower()
     is_hwp = ext in (".hwp", ".hwpx")
     if use_pdf_sdk:
-        order = ["pdf_sdk", "libreoffice", "rhwp"] if is_hwp else ["pdf_sdk", "libreoffice"]
+        order = ["pdf_sdk", "rhwp", "libreoffice"] if is_hwp else ["pdf_sdk", "libreoffice"]
     else:
-        order = ["libreoffice", "rhwp"] if is_hwp else ["libreoffice"]
+        order = ["rhwp", "libreoffice"] if is_hwp else ["libreoffice"]
     return convert_hwp_to_pdf(file_path, order=order)
 
 def _get_pdf_path(file_path: str) -> str:

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -1,4 +1,4 @@
-# 변환용 전처리기 v.2.1.5 (2026-05-21 Release)
+# 변환용 전처리기 v.2.2.0 (2026-06-02 Release)
 from __future__ import annotations
 
 import json

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -30,24 +30,23 @@ def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
     PDF 변환을 시도한다. 실패해도 예외를 던지지 않고 None을 반환한다.
 
     chain (HWP/HWPX 입력):
-      use_pdf_sdk=True  → pdf_sdk → libreoffice → rhwp
-      use_pdf_sdk=False → libreoffice → rhwp
+      use_pdf_sdk=True  → pdf_sdk → rhwp → libreoffice
+      use_pdf_sdk=False → rhwp → libreoffice
     chain (그 외 입력, 예: docx/pptx):
       use_pdf_sdk=True  → pdf_sdk → libreoffice
       use_pdf_sdk=False → libreoffice
 
-    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않는다. 또한 도입
-    초기 단계라 안정성 검증 전까지는 최후순위 fallback 으로만 두며, 검증 후
-    우선순위 상향을 검토한다.
+    rhwp 는 HWP/HWPX 전용이라 비-HWP 입력에는 chain 에 들어가지 않는다. HWP/HWPX
+    변환은 rhwp 를 libreoffice 보다 우선한다 (pdf_sdk 가 있으면 그 다음 순위).
     내부 구현은 `genon.preprocessor.converters.hwp_to_pdf` 모듈에 통합되어 있다.
     """
     from genon.preprocessor.converters.hwp_to_pdf import convert_hwp_to_pdf
     ext = os.path.splitext(file_path)[1].lower()
     is_hwp = ext in (".hwp", ".hwpx")
     if use_pdf_sdk:
-        order = ["pdf_sdk", "libreoffice", "rhwp"] if is_hwp else ["pdf_sdk", "libreoffice"]
+        order = ["pdf_sdk", "rhwp", "libreoffice"] if is_hwp else ["pdf_sdk", "libreoffice"]
     else:
-        order = ["libreoffice", "rhwp"] if is_hwp else ["libreoffice"]
+        order = ["rhwp", "libreoffice"] if is_hwp else ["libreoffice"]
     return convert_hwp_to_pdf(file_path, order=order)
 
 def _is_pdf(file_path: str) -> bool:

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -1,4 +1,4 @@
-# 적재용(지능형) 전처리기 v.2.1.5 (2026-05-21 Release)
+# 적재용(지능형) 전처리기 v.2.2.0 (2026-06-02 Release)
 from __future__ import annotations
 
 import json

--- a/genon/preprocessor/facade/parser_processor.py
+++ b/genon/preprocessor/facade/parser_processor.py
@@ -1,3 +1,4 @@
+# 파싱용 전처리기 v.2.2.0 (2026-06-02 Release)
 from __future__ import annotations
 
 import base64


### PR DESCRIPTION
Closes #249

## Summary
- HWP/HWPX → PDF 변환 backend 우선순위를 정책·문서·모듈 기본값(`_auto_default_order`)과 일치하도록 `libreoffice 우선` → `rhwp 우선`으로 변경.
- 대상: `attachment_processor.py`, `convert_processor.py`, `intelligent_processor.py` 의 `convert_to_pdf`.
  - `use_pdf_sdk=True`  → `pdf_sdk → rhwp → libreoffice`
  - `use_pdf_sdk=False` → `rhwp → libreoffice`
  - 비-HWP 입력(docx/pptx 등)은 기존대로 (rhwp 미포함).
- docstring 도 새 순서로 갱신 (기존 "rhwp 도입 초기라 최후순위" 문구 제거).
- (부수) facade 4개 파일 버전 주석을 `v.2.2.0 (2026-06-02 Release)` 로 갱신.