### PR TITLE
fix(#251): 전처리기 이미지에 facade COPY 추가

### DIFF
--- a/genon/preprocessor/docker/Dockerfile.standard
+++ b/genon/preprocessor/docker/Dockerfile.standard
@@ -362,6 +362,17 @@ COPY ./genon/preprocessor/src /app/src
 # (facade 의 `from genon.preprocessor.converters.hwp_to_pdf import ...` 가 풀림).
 COPY ./genon/preprocessor/converters /app/genon/preprocessor/converters
 
+# facade 처리기 본체. 웹 UI 에서 src/preprocessor.py 를 대체하는 엔트리
+# (attachment/intelligent/convert/parser_processor) 와 enrichment 서브패키지가
+# PYTHONPATH=/app 기준 genon.preprocessor.facade.* 로 import 됨.
+# 이게 없으면 워커 부팅 시 ModuleNotFoundError: genon.preprocessor.facade 로 죽음.
+COPY ./genon/preprocessor/facade /app/genon/preprocessor/facade
+# 런타임 미사용 자산 제거: 평가 픽스처/문서 이미지 (이미지 경량화 + 외부 배포본에
+# 내부 테스트 문서 미포함). 코드 디렉토리(legacy/legal_parser/enrichment)는 유지.
+RUN rm -rf /app/genon/preprocessor/facade/evaluation \
+           /app/genon/preprocessor/facade/gitbook_doc \
+    && find /app/genon/preprocessor/facade -type d -name __pycache__ -prune -exec rm -rf {} +
+
 # 🔴 HWP sdk (무료 자산이라 오픈소스 빌드에도 포함)
 COPY --from=sdk_artifacts /app/hwp_sdk /app/hwp_sdk
 

--- a/genon/preprocessor/docker/Dockerfile.synap
+++ b/genon/preprocessor/docker/Dockerfile.synap
@@ -384,6 +384,17 @@ COPY ./genon/preprocessor/src /app/src
 # (facade 의 `from genon.preprocessor.converters.hwp_to_pdf import ...` 가 풀림).
 COPY ./genon/preprocessor/converters /app/genon/preprocessor/converters
 
+# facade 처리기 본체. 웹 UI 에서 src/preprocessor.py 를 대체하는 엔트리
+# (attachment/intelligent/convert/parser_processor) 와 enrichment 서브패키지가
+# PYTHONPATH=/app 기준 genon.preprocessor.facade.* 로 import 됨.
+# 이게 없으면 워커 부팅 시 ModuleNotFoundError: genon.preprocessor.facade 로 죽음.
+COPY ./genon/preprocessor/facade /app/genon/preprocessor/facade
+# 런타임 미사용 자산 제거: 평가 픽스처/문서 이미지 (이미지 경량화).
+# 코드 디렉토리(legacy/legal_parser/enrichment)는 유지.
+RUN rm -rf /app/genon/preprocessor/facade/evaluation \
+           /app/genon/preprocessor/facade/gitbook_doc \
+    && find /app/genon/preprocessor/facade -type d -name __pycache__ -prune -exec rm -rf {} +
+
 # 🔴 HWP sdk
 COPY --from=sdk_artifacts /app/hwp_sdk /app/hwp_sdk
 

--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -1197,7 +1197,10 @@ class DocxProcessor:
         current_page = None
         chunk_index_on_page = 0
         vectors = []
-        upload_tasks = []
+        # 같은 이미지가 여러 청크에 걸쳐 참조되면 청크마다 업로드돼 동일 파일이
+        # 중복 업로드/삭제되며 'No such file' / 'Session is closed' 가 발생함.
+        # 경로 기준으로 dedupe 해 루프 밖에서 1회만 업로드한다.
+        media_files_to_upload: dict[str, dict] = {}
         for chunk_idx, chunk in enumerate(chunks):
             if chunker_type == "recursive":
                 chunk_page = chunk["page_no"]
@@ -1224,13 +1227,11 @@ class DocxProcessor:
 
             chunk_index_on_page += 1
             if upload_files:
-                file_list = self.get_media_files(doc_items)
-                upload_tasks.append(asyncio.create_task(
-                    upload_files(file_list, request=request)
-                ))
+                for media in self.get_media_files(doc_items):
+                    media_files_to_upload.setdefault(media['path'], media)
 
-        if upload_tasks:
-            await asyncio.gather(*upload_tasks)
+        if upload_files and media_files_to_upload:
+            await upload_files(list(media_files_to_upload.values()), request=request)
         return vectors
 
     async def __call__(self, request: Request, file_path: str, **kwargs: dict):

--- a/genon/preprocessor/src/genos_utils.py
+++ b/genon/preprocessor/src/genos_utils.py
@@ -107,7 +107,12 @@ async def upload_files(file_list: list[dict], request: Request, concurrency: int
                 except Exception as e:
                     print(f"Error on Upload file from {org_path}: {e}")
                 finally:
-                    await asyncio.to_thread(os.remove, org_path)
+                    # 이미 지워진 경우(중복 task 등) FileNotFoundError 가 finally 밖으로
+                    # 전파되면 gather→ClientSession 이 닫혀 'Session is closed' 연쇄가 남.
+                    try:
+                        await asyncio.to_thread(os.remove, org_path)
+                    except FileNotFoundError:
+                        pass
 
         tasks = [_upload_single(item['path'], item['name']) for item in file_list]
         results = await asyncio.gather(*tasks)


### PR DESCRIPTION
## 배경
Closes #251

배포 전처리기 워커가 부팅 시 전부 죽고 master 가 `Worker failed to boot` 로 종료됨.

```
File "/app/src/preprocessor.py", line 151, in <module>
    from genon.preprocessor.facade.enrichment.enrichment_config import EnrichmentConfig
ModuleNotFoundError: No module named 'genon.preprocessor.facade'
```

## [1] facade COPY 누락 (이슈 본건)
`Dockerfile.standard`·`Dockerfile.synap` 이 런타임 트리로 `converters` 만 COPY 하고 `facade` 를 빠뜨림. K9s 확인 시 `/app/genon/preprocessor/` 에 `converters` 만 존재. 웹 UI 에서 `src/preprocessor.py` 를 대체하는 4개 엔트리(attachment/intelligent/convert/parser_processor)와 `enrichment` 서브패키지가 모두 `facade` 안에 있어 import 실패.

**변경**
- 두 Dockerfile 에 `COPY ./genon/preprocessor/facade /app/genon/preprocessor/facade` 추가.
- 런타임 미사용 자산(`evaluation/` 테스트 PDF 7.5M, `gitbook_doc/` 2M, `__pycache__`)은 동일 RUN 레이어에서 제거. `legacy/legal_parser/enrichment` 코드 디렉토리는 유지.

**경로 해석 근거**: 절대 import 라 파일 위치 무관, `sys.path` 기준. `gunicorn_conf.py` 의 `chdir="/app"` 가 gunicorn `app/base.py:89` 에서 `sys.path.insert` → `/app` 이 path 에 올라와 기존 `converters` 와 동일하게 `genon.preprocessor.facade.*` 해석됨. `src/` 로 옮길 필요 없음.

## [2] 첨부 이미지 중복 업로드 → `Session is closed` / `No such file` 수정 (동반)
`DocxProcessor.compose_vectors` 가 **청크마다** `upload_files` 를 task 로 띄워, 한 이미지가 여러 청크에 참조되면 동일 파일이 중복 업로드/삭제됨. `genos_utils.upload_files` 의 `finally` 가 가드 없이 `os.remove` 해서, 이미 지워진 파일에서 `FileNotFoundError` 가 `gather` 밖으로 전파 → `ClientSession` 이 닫히며 잔여 task 가 `Session is closed` 로 줄줄이 실패.

**변경**
- `DocxProcessor`: media 파일을 경로 기준 dedupe 후 루프 밖에서 1회만 업로드.
- `upload_files`: `finally` 의 `os.remove` 를 `FileNotFoundError` 무시로 가드.

> 참고: `HwpProcessor.compose_vectors` 는 `upload_tasks` 를 만들기만 하고 append 하지 않아 HWP 이미지가 업로드되지 않는 별개 사안이 있음(이번 PR 범위 외).

## 검증 방법
빌드 후 컨테이너에서:
```
python -c "import sys; sys.path.insert(0,'/app'); import genon.preprocessor.facade.enrichment.enrichment_config; print('OK')"
```
+ 워커 부팅 / smoke test 통과 + docx 첨부 이미지 업로드 에러 미발생 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)