### PR TITLE
Feature/133 config model path

### DIFF
--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -10,6 +10,7 @@ import math
 import os
 import pandas as pd
 import pydub
+import re
 import requests
 import shutil
 import subprocess
@@ -106,6 +107,35 @@ _DEFAULT_TOKENIZER_ID = "sentence-transformers/all-MiniLM-L6-v2"
 _DEFAULT_HYBRID_MAX_TOKENS = int(1e30)
 
 
+def _warn_unresolved_placeholders(cfg: dict, config_path: str) -> None:
+    """config 에 남아있는 미치환 플레이스홀더(<UPPER_SNAKE>)를 탐지해 경고한다.
+
+    Site 배포 시 Whisper endpoint 등의 치환 누락을 조기에 드러내기 위함.
+    fail-fast 하지 않고(기동 보존) WARNING 로그만 남긴다.
+    """
+    pattern = re.compile(r"<[A-Z0-9_]+>")
+    found = []
+
+    def _scan(node, path):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                _scan(v, f"{path}.{k}" if path else str(k))
+        elif isinstance(node, list):
+            for i, v in enumerate(node):
+                _scan(v, f"{path}[{i}]")
+        elif isinstance(node, str):
+            for ph in pattern.findall(node):
+                found.append((path, ph))
+
+    _scan(cfg, "")
+    if found:
+        lines = "\n".join(f"  - {path}: {ph}" for path, ph in found)
+        _log.warning(
+            "[DocumentProcessor] 미치환 설정 플레이스홀더가 발견되었습니다 "
+            f"(config='{config_path}'). Site 배포 시 실제 값으로 변경하세요:\n{lines}"
+        )
+
+
 def _load_config(config_path: str) -> dict:
     try:
         with open(config_path, "r", encoding="utf-8") as f:
@@ -123,6 +153,7 @@ def _load_config(config_path: str) -> dict:
             f"(expected mapping, got {type(cfg).__name__}). Using defaults."
         )
         return {}
+    _warn_unresolved_placeholders(cfg, config_path)
     return cfg
 
 

--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -169,6 +169,17 @@ def _resolve_default_attachment_config_path() -> str:
     return str(default_config)
 
 
+def _resolve_tokenizer(models_cfg: dict):
+    """models config 로부터 토크나이저를 결정한다.
+
+    tokenizer_path 가 실제 존재하면 그 로컬 경로를, 없으면 tokenizer_id(HF) 로 폴백한다
+    (외부 네트워크 차단 환경 대비). config 미지정 시 기본값은 현행 하드코딩 값과 동일.
+    """
+    local = models_cfg.get("tokenizer_path") or _DEFAULT_TOKENIZER_LOCAL_PATH
+    hf_id = models_cfg.get("tokenizer_id") or _DEFAULT_TOKENIZER_ID
+    return Path(local) if Path(local).exists() else hf_id
+
+
 def convert_to_pdf(file_path: str, use_pdf_sdk: bool = True) -> str | None:
     """
     PDF 변환을 시도한다. 실패해도 예외를 던지지 않고 None을 반환한다.
@@ -1096,7 +1107,9 @@ def _split_with_recursive_chunker(
 
 
 class DocxProcessor:
-    def __init__(self):
+    def __init__(self, tokenizer=None):
+        # 청킹용 토크나이저 (config 기반; 미지정 시 현행 기본값)
+        self._tokenizer = tokenizer if tokenizer is not None else _resolve_tokenizer({})
         self.page_chunk_counts = defaultdict(int)
         self.pipeline_options = PipelineOptions()
         self.converter = DocumentConverter(
@@ -1173,6 +1186,7 @@ class DocxProcessor:
         chunker_kwargs = {
             "max_tokens": hybrid_max_tokens,
             "merge_peers": hybrid_merge_peers,
+            "tokenizer": self._tokenizer,
         }
         hybrid_tokenizer = kwargs.get("hybrid_tokenizer_id")
         if hybrid_tokenizer:
@@ -1246,8 +1260,9 @@ class DocxProcessor:
 
 
 class HwpProcessor:
-    def __init__(self):
-        pass
+    def __init__(self, tokenizer=None):
+        # 청킹용 토크나이저 (config 기반; 미지정 시 현행 기본값)
+        self._tokenizer = tokenizer if tokenizer is not None else _resolve_tokenizer({})
 
     def get_paths(self, file_path: str):
         """이미지 등 리소스가 저장될 경로 계산 (기존 로직 유지)"""
@@ -1339,6 +1354,7 @@ class HwpProcessor:
         chunker_kwargs = {
             "max_tokens": hybrid_max_tokens,
             "merge_peers": hybrid_merge_peers,
+            "tokenizer": self._tokenizer,
         }
         hybrid_tokenizer = kwargs.get("hybrid_tokenizer_id")
         if hybrid_tokenizer:
@@ -1465,6 +1481,10 @@ class DocumentProcessor:
         image_loader_cfg = _as_dict(loaders_cfg.get("image"))
         tabular_loader_cfg = _as_dict(loaders_cfg.get("tabular"))
         whisper_cfg = _as_dict(cfg.get("whisper"))
+        models_cfg = _as_dict(cfg.get("models"))
+
+        # 청킹용 토크나이저 (config 기반; 미지정 시 현행 기본값)
+        self._tokenizer = _resolve_tokenizer(models_cfg)
 
         chunker_type = str(defaults_cfg.get("chunker_type", "recursive")).strip().lower()
         if chunker_type not in {"recursive", "hybrid"}:
@@ -1589,8 +1609,8 @@ class DocumentProcessor:
         }
 
         self.page_chunk_counts = defaultdict(int)
-        self.hwp_processor = HwpProcessor()
-        self.docx_processor = DocxProcessor()
+        self.hwp_processor = HwpProcessor(tokenizer=self._tokenizer)
+        self.docx_processor = DocxProcessor(tokenizer=self._tokenizer)
 
     def _merge_runtime_kwargs(self, kwargs: dict) -> dict:
         merged = dict(self._default_kwargs)

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -731,6 +731,22 @@ def _resolve_default_convert_config_path() -> str:
     return str(default_config)
 
 
+# 청킹용 토크나이저 기본 경로 (config 미지정 시 현행 동작 유지)
+_DEFAULT_TOKENIZER_LOCAL_PATH = "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
+_DEFAULT_TOKENIZER_ID = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def _resolve_tokenizer(models_cfg: dict):
+    """models config 로부터 토크나이저를 결정한다.
+
+    tokenizer_path 가 실제 존재하면 그 로컬 경로를, 없으면 tokenizer_id(HF) 로 폴백한다
+    (외부 네트워크 차단 환경 대비). config 미지정 시 기본값은 현행 하드코딩 값과 동일.
+    """
+    local = models_cfg.get("tokenizer_path") or _DEFAULT_TOKENIZER_LOCAL_PATH
+    hf_id = models_cfg.get("tokenizer_id") or _DEFAULT_TOKENIZER_ID
+    return Path(local) if Path(local).exists() else hf_id
+
+
 # ============================================
 #
 # Copyright IBM Corp. 2024 - 2024
@@ -785,9 +801,9 @@ class GenosSmartChunker(BaseChunker):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     tokenizer: Union[PreTrainedTokenizerBase, str, Path] = (
-            Path("/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2")
-            if Path("/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2").exists()
-            else "sentence-transformers/all-MiniLM-L6-v2"
+            Path(_DEFAULT_TOKENIZER_LOCAL_PATH)
+            if Path(_DEFAULT_TOKENIZER_LOCAL_PATH).exists()
+            else _DEFAULT_TOKENIZER_ID
         )
     max_tokens: int = 1024
     merge_peers: bool = True
@@ -1693,7 +1709,11 @@ class DocumentProcessor:
         ocr_cfg = _as_dict(cfg.get("ocr"))
         layout_cfg = _as_dict(cfg.get("layout"))
         pdf_cfg = _as_dict(cfg.get("pdf_pipeline"))
+        models_cfg = _as_dict(cfg.get("models"))
         ec = EnrichmentConfig.from_raw(cfg.get("enrichment"), self._config_dir, parent_cfg=cfg)
+
+        # 청킹용 토크나이저 (config 기반; 미지정 시 현행 기본값)
+        self._tokenizer = _resolve_tokenizer(models_cfg)
 
         # OCR 엔드포인트는 ocr.paddle.ocr_endpoint 가 정식 위치.
         # 구버전 호환: ocr.ocr_endpoint(상위) / 최상위 ocr_endpoint 도 폴백으로 인식.
@@ -1846,6 +1866,13 @@ class DocumentProcessor:
         self.pipe_line_options.table_structure_options.do_cell_matching = True
         self.pipe_line_options.table_structure_options.mode = table_structure_mode
         self.pipe_line_options.accelerator_options = accelerator_options
+
+        # docling 모델(TableFormer 등) 로컬 경로. config 에 값이 있을 때만 설정하고,
+        # 비어있으면 설정하지 않아 docling 기본 캐시 동작을 그대로 유지(backward compat).
+        # (아래 ocr_pipe_line_options 는 pipe_line_options 의 deep copy 라 자동 전파됨)
+        artifacts_path = models_cfg.get("artifacts_path")
+        if artifacts_path:
+            self.pipe_line_options.artifacts_path = Path(artifacts_path)
 
         # Simple 파이프라인 옵션을 인스턴스 변수로 저장
         self.simple_pipeline_options = PipelineOptions()
@@ -2109,7 +2136,8 @@ class DocumentProcessor:
     def split_documents(self, documents: DoclingDocument, **kwargs: dict) -> List[DocChunk]:
         chunker: GenosSmartChunker = GenosSmartChunker(
             max_tokens = kwargs.get('max_chunk_size', 0),
-            merge_peers = True
+            merge_peers = True,
+            tokenizer = self._tokenizer,
         )
 
         chunks: List[DocChunk] = list(chunker.chunk(dl_doc=documents, **kwargs))

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -158,11 +158,41 @@ from genon.preprocessor.facade.enrichment.prompt_template import PromptTemplate
 # 설정 로딩 헬퍼 (from parser_processor.py)
 # ============================================================
 
+def _warn_unresolved_placeholders(cfg: dict, config_path: str) -> None:
+    """config 에 남아있는 미치환 플레이스홀더(<UPPER_SNAKE>)를 탐지해 경고한다.
+
+    Site 배포 시 OCR/Layout/Enrichment endpoint·serving ID 등의 치환 누락을 조기에
+    드러내기 위함. fail-fast 하지 않고(기동 보존) WARNING 로그만 남긴다.
+    """
+    pattern = re.compile(r"<[A-Z0-9_]+>")
+    found = []
+
+    def _scan(node, path):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                _scan(v, f"{path}.{k}" if path else str(k))
+        elif isinstance(node, list):
+            for i, v in enumerate(node):
+                _scan(v, f"{path}[{i}]")
+        elif isinstance(node, str):
+            for ph in pattern.findall(node):
+                found.append((path, ph))
+
+    _scan(cfg, "")
+    if found:
+        lines = "\n".join(f"  - {path}: {ph}" for path, ph in found)
+        _log.warning(
+            "[DocumentProcessor] 미치환 설정 플레이스홀더가 발견되었습니다 "
+            f"(config='{config_path}'). Site 배포 시 실제 값으로 변경하세요:\n{lines}"
+        )
+
+
 def _load_config(config_path: str) -> dict:
     with open(config_path, "r", encoding="utf-8") as f:
         cfg = yaml.safe_load(f) or {}
     if not isinstance(cfg, dict):
         raise ValueError(f"Invalid config format: expected mapping, got {type(cfg).__name__}")
+    _warn_unresolved_placeholders(cfg, config_path)
     return cfg
 
 

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -175,11 +175,41 @@ except ImportError:
 # 설정 로딩 헬퍼 (from parser_processor.py)
 # ============================================================
 
+def _warn_unresolved_placeholders(cfg: dict, config_path: str) -> None:
+    """config 에 남아있는 미치환 플레이스홀더(<UPPER_SNAKE>)를 탐지해 경고한다.
+
+    Site 배포 시 OCR/Layout/Enrichment endpoint·serving ID 등의 치환 누락을 조기에
+    드러내기 위함. fail-fast 하지 않고(기동 보존) WARNING 로그만 남긴다.
+    """
+    pattern = re.compile(r"<[A-Z0-9_]+>")
+    found = []
+
+    def _scan(node, path):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                _scan(v, f"{path}.{k}" if path else str(k))
+        elif isinstance(node, list):
+            for i, v in enumerate(node):
+                _scan(v, f"{path}[{i}]")
+        elif isinstance(node, str):
+            for ph in pattern.findall(node):
+                found.append((path, ph))
+
+    _scan(cfg, "")
+    if found:
+        lines = "\n".join(f"  - {path}: {ph}" for path, ph in found)
+        _log.warning(
+            "[DocumentProcessor] 미치환 설정 플레이스홀더가 발견되었습니다 "
+            f"(config='{config_path}'). Site 배포 시 실제 값으로 변경하세요:\n{lines}"
+        )
+
+
 def _load_config(config_path: str) -> dict:
     with open(config_path, "r", encoding="utf-8") as f:
         cfg = yaml.safe_load(f) or {}
     if not isinstance(cfg, dict):
         raise ValueError(f"Invalid config format: expected mapping, got {type(cfg).__name__}")
+    _warn_unresolved_placeholders(cfg, config_path)
     return cfg
 
 

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -748,6 +748,22 @@ def _resolve_default_intelligent_config_path() -> str:
     return str(default_config)
 
 
+# 청킹용 토크나이저 기본 경로 (config 미지정 시 현행 동작 유지)
+_DEFAULT_TOKENIZER_LOCAL_PATH = "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
+_DEFAULT_TOKENIZER_ID = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def _resolve_tokenizer(models_cfg: dict):
+    """models config 로부터 토크나이저를 결정한다.
+
+    tokenizer_path 가 실제 존재하면 그 로컬 경로를, 없으면 tokenizer_id(HF) 로 폴백한다
+    (외부 네트워크 차단 환경 대비). config 미지정 시 기본값은 현행 하드코딩 값과 동일.
+    """
+    local = models_cfg.get("tokenizer_path") or _DEFAULT_TOKENIZER_LOCAL_PATH
+    hf_id = models_cfg.get("tokenizer_id") or _DEFAULT_TOKENIZER_ID
+    return Path(local) if Path(local).exists() else hf_id
+
+
 # ============================================
 #
 # Copyright IBM Corp. 2024 - 2024
@@ -762,9 +778,9 @@ class GenosSmartChunker(BaseChunker):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     tokenizer: Union[PreTrainedTokenizerBase, str, Path] = (
-            Path("/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2")
-            if Path("/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2").exists()
-            else "sentence-transformers/all-MiniLM-L6-v2"
+            Path(_DEFAULT_TOKENIZER_LOCAL_PATH)
+            if Path(_DEFAULT_TOKENIZER_LOCAL_PATH).exists()
+            else _DEFAULT_TOKENIZER_ID
         )
     max_tokens: int = 1024
     merge_peers: bool = True
@@ -1690,7 +1706,11 @@ class DocumentProcessor:
         ocr_cfg = _as_dict(cfg.get("ocr"))
         layout_cfg = _as_dict(cfg.get("layout"))
         pdf_cfg = _as_dict(cfg.get("pdf_pipeline"))
+        models_cfg = _as_dict(cfg.get("models"))
         ec = EnrichmentConfig.from_raw(cfg.get("enrichment"), self._config_dir, parent_cfg=cfg)
+
+        # 청킹용 토크나이저 (config 기반; 미지정 시 현행 기본값)
+        self._tokenizer = _resolve_tokenizer(models_cfg)
 
         # OCR 엔드포인트는 ocr.paddle.ocr_endpoint 가 정식 위치.
         # 구버전 호환: ocr.ocr_endpoint(상위) / 최상위 ocr_endpoint 도 폴백으로 인식.
@@ -1842,6 +1862,13 @@ class DocumentProcessor:
         self.pipe_line_options.table_structure_options.do_cell_matching = True
         self.pipe_line_options.table_structure_options.mode = table_structure_mode
         self.pipe_line_options.accelerator_options = accelerator_options
+
+        # docling 모델(TableFormer 등) 로컬 경로. config 에 값이 있을 때만 설정하고,
+        # 비어있으면 설정하지 않아 docling 기본 캐시 동작을 그대로 유지(backward compat).
+        # (아래 ocr_pipe_line_options 는 pipe_line_options 의 deep copy 라 자동 전파됨)
+        artifacts_path = models_cfg.get("artifacts_path")
+        if artifacts_path:
+            self.pipe_line_options.artifacts_path = Path(artifacts_path)
 
         # Simple 파이프라인 옵션을 인스턴스 변수로 저장
         self.simple_pipeline_options = PipelineOptions()
@@ -2074,7 +2101,8 @@ class DocumentProcessor:
     def split_documents(self, documents: DoclingDocument, **kwargs: dict) -> List[DocChunk]:
         chunker: GenosSmartChunker = GenosSmartChunker(
             max_tokens = kwargs.get('max_chunk_size', 0),
-            merge_peers = True
+            merge_peers = True,
+            tokenizer = self._tokenizer,
         )
 
         chunks: List[DocChunk] = list(chunker.chunk(dl_doc=documents, **kwargs))

--- a/genon/preprocessor/facade/parser_processor.py
+++ b/genon/preprocessor/facade/parser_processor.py
@@ -140,11 +140,41 @@ CONVERTIBLE_EXTENSIONS = ['.hwp', '.txt', '.json', '.md', '.ppt', '.pptx', '.doc
 # 설정 로딩
 # ============================================================
 
+def _warn_unresolved_placeholders(cfg: dict, config_path: str) -> None:
+    """config 에 남아있는 미치환 플레이스홀더(<UPPER_SNAKE>)를 탐지해 경고한다.
+
+    Site 배포 시 OCR/Layout/Enrichment endpoint·serving ID 등의 치환 누락을 조기에
+    드러내기 위함. fail-fast 하지 않고(기동 보존) WARNING 로그만 남긴다.
+    """
+    pattern = re.compile(r"<[A-Z0-9_]+>")
+    found = []
+
+    def _scan(node, path):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                _scan(v, f"{path}.{k}" if path else str(k))
+        elif isinstance(node, list):
+            for i, v in enumerate(node):
+                _scan(v, f"{path}[{i}]")
+        elif isinstance(node, str):
+            for ph in pattern.findall(node):
+                found.append((path, ph))
+
+    _scan(cfg, "")
+    if found:
+        lines = "\n".join(f"  - {path}: {ph}" for path, ph in found)
+        _log.warning(
+            "[DocumentProcessor] 미치환 설정 플레이스홀더가 발견되었습니다 "
+            f"(config='{config_path}'). Site 배포 시 실제 값으로 변경하세요:\n{lines}"
+        )
+
+
 def _load_config(config_path: str) -> dict:
     with open(config_path, "r", encoding="utf-8") as f:
         cfg = yaml.safe_load(f) or {}
     if not isinstance(cfg, dict):
         raise ValueError(f"Invalid config format: expected mapping, got {type(cfg).__name__}")
+    _warn_unresolved_placeholders(cfg, config_path)
     return cfg
 
 

--- a/genon/preprocessor/resource/attachment_processor_config.yaml
+++ b/genon/preprocessor/resource/attachment_processor_config.yaml
@@ -50,8 +50,8 @@ loaders:
     # CSV 인코딩 감지 시 샘플링 바이트 수
     encoding_detect_sample_bytes: 10000
 
-# 음성 파일(.wav/.mp3/.m4a) 처리 기본값
-# <WHISPER_ENDPOINT>: 음성인식 모델 서버 주소로 변경 필요
+# 음성 파일(.wav/.mp3/.m4a) 처리 기본값. 음성 처리 시에만 필요(선택).
+# <WHISPER_ENDPOINT>: 음성인식 모델 서버 주소로 변경 필요 (음성 미사용 시 무시)
 whisper:
   url: "http://<WHISPER_ENDPOINT>/v1/audio/transcriptions"
   model: "model"

--- a/genon/preprocessor/resource/attachment_processor_config.yaml
+++ b/genon/preprocessor/resource/attachment_processor_config.yaml
@@ -64,3 +64,10 @@ whisper:
   chunk_overlap_ms: 300
   # 끝에 / 를 주면 디렉터리로 간주해 내부에 파일명 기준 하위 폴더 생성
   tmp_dir_prefix: "./tmp_audios_"
+
+# 모델 경로 (다운로드된 기본값 사용; 미지정 시 현행 동작 유지)
+models:
+  # 청킹용 토크나이저. tokenizer_path 가 실제 존재하면 그 경로,
+  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
+  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
+  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"

--- a/genon/preprocessor/resource/convert_processor_config.yaml
+++ b/genon/preprocessor/resource/convert_processor_config.yaml
@@ -113,3 +113,12 @@ enrichment:
       after_items: 2
       max_context_chars: 1500
       prompt_template_file: prompt_image_description_default.md
+
+# 모델 경로 (다운로드된 기본값 사용; 미지정 시 현행 동작 유지)
+models:
+  # 청킹용 토크나이저. tokenizer_path 가 실제 존재하면 그 경로,
+  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
+  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
+  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
+  # docling 모델(TableFormer 등) 로컬 경로. 비우면 docling 기본 캐시 사용(현행).
+  artifacts_path: ""

--- a/genon/preprocessor/resource/intelligent_processor_config.yaml
+++ b/genon/preprocessor/resource/intelligent_processor_config.yaml
@@ -108,3 +108,12 @@ enrichment:
       after_items: 2
       max_context_chars: 1500
       prompt_template_file: prompt_image_description_default.md
+
+# 모델 경로 (다운로드된 기본값 사용; 미지정 시 현행 동작 유지)
+models:
+  # 청킹용 토크나이저. tokenizer_path 가 실제 존재하면 그 경로,
+  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
+  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
+  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
+  # docling 모델(TableFormer 등) 로컬 경로. 비우면 docling 기본 캐시 사용(현행).
+  artifacts_path: ""

--- a/genon/preprocessor/resource/parser_processor_config.yaml
+++ b/genon/preprocessor/resource/parser_processor_config.yaml
@@ -113,9 +113,10 @@ output:
   format: "json" # "json" (default), "html", "markdown"
   table_format: "html" # "html" (default), "markdown"
 
-# whisper 설정, 음성인식 모델이 필요한 경우 설정.
+# whisper 설정. 음성(.wav/.mp3/.m4a) 처리 시에만 필요(선택).
+# <WHISPER_ENDPOINT>: 음성인식 모델 서버 주소로 변경 필요 (음성 미사용 시 무시)
 whisper:
-  url: ""
+  url: "http://<WHISPER_ENDPOINT>/v1/audio/transcriptions"
   model: "model"
   language: "ko"
   response_format: "json"

--- a/genon/preprocessor/resource_dev/attachment_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/attachment_processor_config.yaml
@@ -63,3 +63,10 @@ whisper:
   chunk_overlap_ms: 300
   # 끝에 / 를 주면 디렉터리로 간주해 내부에 파일명 기준 하위 폴더 생성
   tmp_dir_prefix: "./tmp_audios_"
+
+# 모델 경로 (다운로드된 기본값 사용; 미지정 시 현행 동작 유지)
+models:
+  # 청킹용 토크나이저. tokenizer_path 가 실제 존재하면 그 경로,
+  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
+  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
+  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"

--- a/genon/preprocessor/resource_dev/convert_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/convert_processor_config.yaml
@@ -141,3 +141,12 @@ enrichment:
   - custom_fields:
       enable: false
       config_file: custom_field_authors.yaml   # resource_path 자동 = 이 yaml 파일 디렉토리
+
+# 모델 경로 (다운로드된 기본값 사용; 미지정 시 현행 동작 유지)
+models:
+  # 청킹용 토크나이저. tokenizer_path 가 실제 존재하면 그 경로,
+  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
+  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
+  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
+  # docling 모델(TableFormer 등) 로컬 경로. 비우면 docling 기본 캐시 사용(현행).
+  artifacts_path: ""

--- a/genon/preprocessor/resource_dev/intelligent_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/intelligent_processor_config.yaml
@@ -154,3 +154,12 @@ enrichment:
   - custom_fields:
       enable: false
       config_file: custom_field_authors.yaml   # resource_path 자동 = 이 yaml 파일 디렉토리
+
+# 모델 경로 (다운로드된 기본값 사용; 미지정 시 현행 동작 유지)
+models:
+  # 청킹용 토크나이저. tokenizer_path 가 실제 존재하면 그 경로,
+  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
+  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
+  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
+  # docling 모델(TableFormer 등) 로컬 경로. 비우면 docling 기본 캐시 사용(현행).
+  artifacts_path: ""


### PR DESCRIPTION
# feat(#133): 모델 경로(토크나이저·artifacts) yaml 설정화 + 미치환 플레이스홀더 경고

## 배경 / 문제

- **모델 경로 하드코딩**: 청킹용 토크나이저 경로(`/models/doc_parser_models/...`)와
  HF fallback id, docling 모델(TableFormer 등) artifacts 경로가 코드에 하드코딩되어
  있어, site별로 경로가 다르거나 외부 네트워크가 차단된 환경에서 **재배포 없이 변경할 수
  없었다.**
- **플레이스홀더 치환 누락**: site 배포 시 config yaml의 `<WHISPER_ENDPOINT>` 등
  플레이스홀더를 실제 값으로 치환해야 하는데, 치환을 빠뜨려도 기동 시점에 드러나지 않고
  해당 기능을 실제로 호출할 때서야 오류가 발생했다.

## 변경 사항

### 1. 모델 경로 yaml 설정화 (`models:` 섹션 신설)
config yaml에 `models:` 섹션을 추가하여 토크나이저/artifacts 경로를 코드 수정 없이 조정
가능하도록 노출. **미지정 시 현행 하드코딩 기본값과 동일하게 동작(하위 호환).**

```yaml
models:
  # 청킹용 토크나이저. tokenizer_path 가 실제 존재하면 그 경로,
  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
  # docling 모델(TableFormer 등) 로컬 경로. 비우면 docling 기본 캐시 사용(현행).
  artifacts_path: ""
```

- **`_resolve_tokenizer(models_cfg)` 헬퍼**: `tokenizer_path` 가 실제 존재하면 로컬
  경로(`Path`)를, 없으면 `tokenizer_id`(HF) 로 폴백. `GenosSmartChunker.tokenizer`
  기본값도 동일 로직의 모듈 상수(`_DEFAULT_TOKENIZER_LOCAL_PATH` /
  `_DEFAULT_TOKENIZER_ID`)로 정리.
- **`artifacts_path`**: config에 값이 있을 때만 `pipe_line_options.artifacts_path`
  를 설정하고, 비어 있으면 설정하지 않아 **docling 기본 캐시 동작을 그대로 유지**
  (`ocr_pipe_line_options` 는 deep copy라 자동 전파). convert/intelligent에 적용.
- `DocumentProcessor` 에서 `cfg.get("models")` 를 읽어 `self._tokenizer` 를 결정하고,
  `split_documents()` 의 청킹 시 해당 토크나이저를 전달.

### 2. 미치환 플레이스홀더 경고
- **`_warn_unresolved_placeholders(cfg, config_path)`**: `_load_config()` 에서 config
  전체를 재귀 스캔해 `<[A-Z0-9_]+>` 패턴(미치환 UPPER_SNAKE 플레이스홀더)을 탐지.
  발견 시 **경로와 함께 WARNING 로그**를 남긴다.
- **fail-fast 아님**: 기동을 막지 않고 경고만 남겨, 해당 플레이스홀더가 사용되지 않는
  경우(예: 음성 미사용 site의 `<WHISPER_ENDPOINT>`)에도 정상 기동.

### 3. whisper 설정 주석 정리
- whisper 설정이 음성(.wav/.mp3/.m4a) 처리 시에만 필요한 **선택 항목**임을 주석으로
  명확화하고, `<WHISPER_ENDPOINT>` 가 미사용 시 무시됨을 명시.

## 영향 범위 / 호환성

- `models:` 섹션 / 신규 키를 생략하면 **기존과 동일하게 코드 기본값으로 동작**(하위 호환).
- `artifacts_path` 가 비어 있으면 docling 기본 캐시 경로를 그대로 사용.
- 플레이스홀더 경고는 **기동을 차단하지 않음**(WARNING 로그만).

## 변경 파일

**facade 4종**
- `genon/preprocessor/facade/parser_processor.py`
- `genon/preprocessor/facade/convert_processor.py`
- `genon/preprocessor/facade/intelligent_processor.py`
- `genon/preprocessor/facade/attachment_processor.py`

**config yaml 7종** (`models:` 섹션 추가 / whisper 주석 정리)
- `resource/{parser,convert,intelligent,attachment}_processor_config.yaml`
- `resource_dev/{convert,intelligent,attachment}_processor_config.yaml`

## 테스트

- 각 processor를 기본 config로 기동 → 신규 키 없이도 현행과 동일 동작 확인.
- `tokenizer_path` 가 존재하지 않는 환경에서 `tokenizer_id`(HF) 폴백 확인.
- `artifacts_path` 지정 시 docling 모델이 해당 로컬 경로에서 로딩되는지 확인.
- `<WHISPER_ENDPOINT>` 등 플레이스홀더가 남은 config 로드 시 경로와 함께 WARNING
  로그가 출력되는지 확인.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configurable tokenizer selection: specify local model paths or use HuggingFace-hosted alternatives for document chunking operations
  * Configurable artifacts directory for managing local model storage and resources
  * Configuration validation with startup warnings for unresolved placeholders, allowing startup to proceed with advisory alerts

* **Documentation**
  * Improved configuration documentation clarifying audio transcription and endpoint configuration guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->