### PR TITLE
dots ocr, 한개 테이블 아이템에 여러 table 태그가 출력될 때 첫 table 만 출력하는 버그 수정. 모든 테이블…

### DIFF
--- a/docling/models/genos_dots_ocr_layout_model.py
+++ b/docling/models/genos_dots_ocr_layout_model.py
@@ -677,6 +677,10 @@ class GenosDotsOCRLayoutModel(BasePageModel):
             raw_table_html_by_cluster_id: dict[int, str] = {}
             raw_formula_latex_by_cluster_id: dict[int, str] = {}
             raw_text_by_cluster_id: dict[int, str] = {}
+            # Cluster ids default to the item index. Items that split into
+            # multiple table clusters need extra ids that cannot collide with
+            # any item index, so allocate them starting past the last index.
+            next_extra_cluster_id = len(result)
             for idx, pred_item in enumerate(result):
                 if not isinstance(pred_item, dict):
                     _log.warning(
@@ -708,11 +712,6 @@ class GenosDotsOCRLayoutModel(BasePageModel):
                     continue
 
                 pred_item_text = _extract_layout_item_text(pred_item)
-                if label in self.TABLE_LABELS:
-                    if pred_item_text:
-                        table_html = _extract_table_html(pred_item_text)
-                        if table_html:
-                            raw_table_html_by_cluster_id[idx] = table_html
 
                 bbox_values = _rescale_dotsocr_bbox_to_page(
                     bbox=pred_item["bbox"],
@@ -728,6 +727,46 @@ class GenosDotsOCRLayoutModel(BasePageModel):
                         pred_item.get("bbox"),
                     )
                     continue
+
+                confidence = _coerce_confidence(pred_item.get("confidence"))
+
+                # A single DotsOCR Table item may pack multiple stacked tables
+                # into its text. Split them into separate clusters (one table
+                # each) so none are dropped; otherwise only the first survives.
+                if label in self.TABLE_LABELS:
+                    table_htmls = (
+                        _extract_all_table_html(pred_item_text)
+                        if pred_item_text
+                        else []
+                    )
+                    if len(table_htmls) > 1:
+                        sub_bboxes = _split_bbox_vertically(
+                            bbox_values, len(table_htmls)
+                        )
+                        for band_idx, (sub_bbox, table_html) in enumerate(
+                            zip(sub_bboxes, table_htmls)
+                        ):
+                            if band_idx == 0:
+                                cluster_id = idx
+                            else:
+                                cluster_id = next_extra_cluster_id
+                                next_extra_cluster_id += 1
+                            clusters.append(
+                                Cluster(
+                                    id=cluster_id,
+                                    label=label,
+                                    confidence=confidence,
+                                    bbox=BoundingBox.model_validate(sub_bbox),
+                                    cells=[],
+                                )
+                            )
+                            raw_table_html_by_cluster_id[cluster_id] = table_html
+                        continue
+
+                    # Single (or no) table: fall through to single-cluster path.
+                    if table_htmls:
+                        raw_table_html_by_cluster_id[idx] = table_htmls[0]
+
                 bbox = {
                     "l": bbox_values[0],
                     "t": bbox_values[1],
@@ -737,7 +776,7 @@ class GenosDotsOCRLayoutModel(BasePageModel):
                 cluster = Cluster(
                     id=idx,
                     label=label,
-                    confidence=_coerce_confidence(pred_item.get("confidence")),
+                    confidence=confidence,
                     # bbox=BoundingBox.model_validate(pred_item),
                     bbox=BoundingBox.model_validate(bbox),
                     cells=[],
@@ -1220,22 +1259,15 @@ def _extract_layout_item_text(layout_item: dict) -> Optional[str]:
     return None
 
 
-def _extract_table_html(raw_text: str) -> Optional[str]:
-    if not isinstance(raw_text, str):
-        return None
+def _extract_balanced_table_blocks(text: str) -> list[str]:
+    """Collect every balanced ``<table>...</table>`` block from raw text.
 
-    text = raw_text.strip()
-    if not text:
-        return None
-
-    soup = BeautifulSoup(text, "html.parser")
-    first_table = soup.find("table")
-    if isinstance(first_table, Tag):
-        return str(first_table)
-
-    # Fallback for malformed/non-HTML-like payloads:
-    # find the first balanced <table>...</table> block without truncating nested tables.
+    Used as a fallback for malformed/non-HTML-like payloads where the HTML
+    parser fails to expose tables. Nested tables are kept intact (the block
+    closes only when its own opening tag is balanced).
+    """
     tag_pattern = re.compile(r"</?table\b[^>]*>", re.IGNORECASE)
+    blocks: list[str] = []
     start_idx = None
     depth = 0
 
@@ -1255,9 +1287,65 @@ def _extract_table_html(raw_text: str) -> Optional[str]:
 
         depth -= 1
         if depth == 0:
-            return text[start_idx:match.end()]
+            blocks.append(text[start_idx : match.end()])
+            start_idx = None
 
-    return None
+    return blocks
+
+
+def _extract_all_table_html(raw_text: str) -> list[str]:
+    """Extract all top-level ``<table>`` blocks from a DotsOCR item's text.
+
+    A single DotsOCR layout item may pack multiple stacked tables into its
+    text (e.g. ``<table>...</table><table>...</table>``). Returns each
+    top-level table's HTML as a separate string, in document order. Nested
+    tables are not returned separately (they belong to their outer table).
+    """
+    if not isinstance(raw_text, str):
+        return []
+
+    text = raw_text.strip()
+    if not text:
+        return []
+
+    soup = BeautifulSoup(text, "html.parser")
+    top_level_tables = [
+        tag for tag in soup.find_all("table") if tag.find_parent("table") is None
+    ]
+    if top_level_tables:
+        return [str(tag) for tag in top_level_tables]
+
+    # Fallback for malformed/non-HTML-like payloads.
+    return _extract_balanced_table_blocks(text)
+
+
+def _extract_table_html(raw_text: str) -> Optional[str]:
+    """Extract the first top-level ``<table>`` block, or ``None``."""
+    tables = _extract_all_table_html(raw_text)
+    return tables[0] if tables else None
+
+
+def _split_bbox_vertically(
+    bbox_values: tuple[float, float, float, float], count: int
+) -> list[dict]:
+    """Split a (l, t, r, b) bbox into ``count`` non-overlapping vertical bands.
+
+    DotsOCR can group several stacked tables under one bbox. Splitting the
+    bbox into disjoint top-to-bottom bands lets each table become its own
+    cluster without triggering overlap-based dedup in the postprocessor
+    (adjacent bands share only an edge, so their intersection area is zero).
+    """
+    left, top, right, bottom = bbox_values
+    if count <= 1:
+        return [{"l": left, "t": top, "r": right, "b": bottom}]
+
+    span = (bottom - top) / count
+    bands: list[dict] = []
+    for i in range(count):
+        band_top = top + span * i
+        band_bottom = bottom if i == count - 1 else top + span * (i + 1)
+        bands.append({"l": left, "t": band_top, "r": right, "b": band_bottom})
+    return bands
 
 
 def _parse_html_to_table_data(html: str) -> Optional[TableData]:

--- a/genon/preprocessor/tests/unit/test_table_structure_unit.py
+++ b/genon/preprocessor/tests/unit/test_table_structure_unit.py
@@ -146,3 +146,147 @@ def test_all_gt_tables_parse_with_consistent_grid(table_gt):
 
     # 데이터셋에 병합셀 표가 다수 존재(33/51) — 파싱 결과에도 반영되어야 함.
     assert merged_seen >= 20, f"병합셀이 인식된 표가 너무 적음: {merged_seen}"
+
+
+# ─── (c) DotsOCR 한 아이템에 여러 <table> → 개별 분리 ────────────────────────
+
+
+def _extract_all(text):
+    """한 DotsOCR 아이템 text 에서 최상위 <table> 들을 모두 추출(실제 함수)."""
+    from docling.models.genos_dots_ocr_layout_model import _extract_all_table_html
+
+    return _extract_all_table_html(text)
+
+
+def _split_bbox(bbox_values, count):
+    from docling.models.genos_dots_ocr_layout_model import _split_bbox_vertically
+
+    return _split_bbox_vertically(bbox_values, count)
+
+
+# 사용자 제보 샘플: 한 아이템 text 에 <table> 2개가 연속으로 들어있는 경우
+# (앞은 목차 표, 뒤는 회의록 표). 기존엔 첫 표만 가져오고 둘째 표가 통째로 유실됨.
+_TWO_TABLE_HTML = (
+    "<table>"
+    "<tr><td>5. 2026년도 경상남도 제1회 추가경정예산안(계속)</td><td></td></tr>"
+    "<tr><td>다. 관광개발국 소관</td><td>44면</td></tr>"
+    "<tr><td>라. 보건의료국 소관</td><td>52면</td></tr>"
+    "<tr><td>부록</td><td>59면</td></tr>"
+    "</table>"
+    "<table>"
+    "<tr><td>(15시 51분 개의)</td><td>존경하는 박주언 위원장님!</td></tr>"
+    "<tr><td>전기풍 의원입니다.</td><td>감사합니다.</td></tr>"
+    "</table>"
+)
+
+
+@pytest.mark.unit
+def test_extract_all_tables_returns_each_top_level_table():
+    """여러 <table> 가 각각 분리되어 반환되는지(둘째 표 유실 없음)."""
+    tables = _extract_all(_TWO_TABLE_HTML)
+    assert len(tables) == 2
+    # 각 추출 결과는 정확히 하나의 최상위 table.
+    for html in tables:
+        assert html.count("<table") == 1
+    # 첫째는 목차, 둘째는 회의록 — 내용이 서로 섞이지 않음.
+    assert "44면" in tables[0] and "44면" not in tables[1]
+    assert "존경하는" in tables[1] and "존경하는" not in tables[0]
+
+
+@pytest.mark.unit
+def test_extract_all_tables_single_table_returns_one():
+    """단일 table 입력은 1개만 반환(회귀 방지)."""
+    single = "<table><tr><td>a</td><td>b</td></tr></table>"
+    tables = _extract_all(single)
+    assert len(tables) == 1
+    assert "a" in tables[0] and "b" in tables[0]
+
+
+@pytest.mark.unit
+def test_extract_all_tables_ignores_nested_tables():
+    """중첩 table 은 별도 항목이 아니라 외곽 table 안에 보존되어야 함."""
+    nested = (
+        "<table><tr><td>outer"
+        "<table><tr><td>inner</td></tr></table>"
+        "</td></tr></table>"
+    )
+    tables = _extract_all(nested)
+    assert len(tables) == 1
+    assert "inner" in tables[0]
+
+
+@pytest.mark.unit
+def test_extract_all_tables_empty_or_non_table():
+    """table 이 없으면 빈 리스트."""
+    assert _extract_all("") == []
+    assert _extract_all("그냥 텍스트") == []
+    assert _extract_all(None) == []
+
+
+@pytest.mark.unit
+def test_extract_table_html_first_only_backward_compat():
+    """_extract_table_html 은 기존처럼 첫 table 만 반환."""
+    from docling.models.genos_dots_ocr_layout_model import _extract_table_html
+
+    html = _extract_table_html(_TWO_TABLE_HTML)
+    assert html is not None
+    assert "44면" in html and "존경하는" not in html
+
+
+@pytest.mark.unit
+def test_extracted_tables_parse_to_consistent_grids():
+    """분리 추출한 각 표가 격자 정합(겹침/구멍 0)으로 파싱되는지."""
+    for html in _extract_all(_TWO_TABLE_HTML):
+        td = _parse(html)
+        assert td is not None
+        overlaps, holes = _grid_issues(td)
+        assert overlaps == [], f"격자 셀 겹침: {overlaps[:5]}"
+        assert holes == [], f"격자 빈 칸: {holes[:5]}"
+
+
+@pytest.mark.unit
+def test_different_column_counts_stay_consistent_when_split():
+    """컬럼 수가 다른 두 표 — 분리하면 각자 정합 격자 유지(병합 시 구멍 발생 방지)."""
+    mixed = (
+        "<table><tr><td>a</td><td>b</td></tr></table>"
+        "<table><tr><td>x</td><td>y</td><td>z</td></tr></table>"
+    )
+    tables = _extract_all(mixed)
+    assert len(tables) == 2
+
+    td0, td1 = _parse(tables[0]), _parse(tables[1])
+    assert (td0.num_rows, td0.num_cols) == (1, 2)
+    assert (td1.num_rows, td1.num_cols) == (1, 3)
+    for td in (td0, td1):
+        overlaps, holes = _grid_issues(td)
+        assert overlaps == [] and holes == []
+
+
+@pytest.mark.unit
+def test_split_bbox_vertically_disjoint_and_ordered():
+    """원본 bbox 를 세로 N등분 — 겹치지 않고 위→아래 순서, 원본 범위 내부."""
+    bbox_values = (10.0, 100.0, 200.0, 400.0)  # l, t, r, b
+    bands = _split_bbox(bbox_values, 3)
+    assert len(bands) == 3
+
+    for band in bands:
+        # 좌우 폭은 원본과 동일.
+        assert band["l"] == 10.0 and band["r"] == 200.0
+        # 세로는 원본 범위 내부.
+        assert 100.0 <= band["t"] <= band["b"] <= 400.0
+
+    # 첫 밴드 상단 = 원본 상단, 마지막 밴드 하단 = 원본 하단.
+    assert bands[0]["t"] == 100.0
+    assert bands[-1]["b"] == 400.0
+    # 인접 밴드는 경계만 공유(면적 겹침 0) → 후처리 overlap-dedup 비대상.
+    for i in range(len(bands) - 1):
+        assert bands[i]["b"] == bands[i + 1]["t"]
+        assert bands[i]["t"] < bands[i]["b"]
+
+
+@pytest.mark.unit
+def test_split_bbox_vertically_single_band():
+    """count<=1 이면 원본 bbox 그대로."""
+    assert _split_bbox((0.0, 0.0, 10.0, 10.0), 1) == [
+        {"l": 0.0, "t": 0.0, "r": 10.0, "b": 10.0}
+    ]


### PR DESCRIPTION
# fix(#265): DotsOCR — 한 아이템에 여러 `<table>`이 올 때 모든 표를 개별 표로 출력

## 배경 / 문제

DotsOCR(dots.ocr VLM) 결과의 한 레이아웃 아이템(`category: "Table"`)이 `text` 필드에
`<table>...</table><table>...</table>` 처럼 **여러 `<table>` 태그**를 담는 경우가 있다
(예: 목차 표 + 회의록 표가 하나의 bbox로 묶임).

기존 `_extract_table_html()`는 `soup.find("table")`로 **첫 번째 표만** 추출했고, 정규식 폴백도
첫 번째 균형 블록에서 멈췄다. 그 결과 **두 번째 이후 표의 내용이 통째로 유실**되었다.

## 설계 결정 — "병합"이 아니라 "개별 표로 분리"

- **병합 기각**: 여러 표를 하나의 `<table>`로 합치면 `parse_table_data`가
  `num_cols = max(행별 열 수)`로 격자를 만들어, **컬럼 수가 다른 표끼리** 합쳐질 때 적은 열의
  행에 빈 칸(구멍)이 생기고 의미적으로 별개인 표가 한 격자로 뭉개진다.
- **동일 bbox로 N개 클러스터 생성도 기각**: TABLE/DOCUMENT_INDEX는 `WRAPPER_TYPES`라
  후처리에서 `_remove_overlapping_clusters(wrapper_clusters, "wrapper")`를 거치는데, 같은
  bbox는 IoU=1.0 > 0.8 임계값이라 Union-Find로 묶여 **하나만 살아남고 나머지는 버려진다**
  (버그가 추출 단계에서 후처리 단계로 옮겨갈 뿐).
- **채택**: 원본 아이템 bbox를 표 개수만큼 **겹치지 않는 세로 밴드**로 N등분하여 N개의 별도
  클러스터로 만들고, 각 클러스터에 해당 표 HTML을 매핑한다. 표마다 독립 격자로 파싱되므로
  컬럼 수가 달라도 구조가 깨지지 않는다.

### 분리가 안전한 근거 (코드 확인)

- **빈 클러스터 제거 비대상**: table은 special/wrapper 경로(`_process_special_clusters`)로
  처리되어, 빈 클러스터 필터(`_process_regular_clusters`)의 대상이 아니다 →
  밴드별 synthetic cell 주입 **불필요**.
- **비연속 클러스터 id 안전**: 파이프라인은 id를 dict 키로만 사용(`table_map[cluster.id]`).
  신규 id는 항목 인덱스와 충돌하지 않도록 `len(result)`부터 채번.
- **reading order**: bbox 기하(상단 좌표) 기준 정렬이라 세로 밴드는 위→아래로 올바르게
  정렬되고, 모든 밴드가 원본 bbox 내부에 있어 다른 페이지 요소와의 전체 순서도 보존된다.

## 변경 사항

### 1. 다중 표 추출 (`genos_dots_ocr_layout_model.py`)
- **`_extract_all_table_html()` 신규**: 최상위 `<table>`을 모두 추출해 `list[str]` 반환
  (`find_all` + `find_parent` 필터로 중첩 표는 외곽 표 안에 보존).
- **`_extract_balanced_table_blocks()` 신규**: 정규식 폴백을 "첫 블록"에서 "모든 균형 블록"
  수집으로 확장(malformed/non-HTML 응답 대비).
- **`_extract_table_html()`**: 첫 표만 반환하는 얇은 래퍼로 유지(하위 호환).

### 2. 단일 아이템 → N 클러스터 분리 (파싱 루프)
- **`_split_bbox_vertically()` 신규**: (l,t,r,b) bbox를 겹치지 않는 세로 밴드 N개로 분할
  (인접 밴드는 경계만 공유 → 면적 겹침 0).
- 라벨이 `TABLE_LABELS`이고 추출된 표가 **2개 이상**이면: 밴드별 `Cluster` 생성(첫 클러스터는
  기존 `id=idx` 유지, 나머지는 `len(result)`부터 채번), 각 클러스터 id에 해당 표 HTML 매핑.
- 표가 1개(또는 0개)면 기존 단일 클러스터 경로 그대로(회귀 없음).

> `_build_tablestructure_from_dotsocr` / `_parse_html_to_table_data`는 클러스터별 단일 표
> HTML을 받으므로 수정 불필요.

## 영향 범위 / 호환성

- 표가 1개인 기존 케이스는 동작 불변(단일 클러스터, 단일 매핑).
- 신규 클러스터 id는 항목 인덱스 범위 밖에서 채번하고, 후처리 orphan id(`max(id)+1`)도
  이를 반영하므로 id 충돌 없음.
- 세로 등분은 표의 실제 픽셀 경계를 모를 때의 **근사 휴리스틱**이다(표 간 상하 순서는 보존,
  정확한 경계는 근사).

## 테스트

`genon/preprocessor/tests/unit/test_table_structure_unit.py` 에 단위 테스트 9종 추가
(네트워크 불필요 → CI 상시 실행):

- 다중 표가 각각 분리 추출되는지(둘째 표 유실 없음), 내용이 서로 섞이지 않는지
- 단일 표 입력 1개 반환(회귀 방지), 중첩 표는 외곽 표 안에 보존, 빈/비-table 입력 `[]`
- `_extract_table_html` 첫 표 반환(하위 호환)
- 분리한 각 표가 격자 정합(겹침/구멍 0)으로 파싱되는지
- **컬럼 수가 다른 두 표** — 분리 시 각자 `(1,2)`/`(1,3)` 정합 격자 유지
- `_split_bbox_vertically` — disjoint·위→아래 순서·원본 범위 내부·단일 밴드

```
pytest genon/preprocessor/tests/unit/test_table_structure_unit.py -m unit -q
# 14 passed
```

- (서버 연동) 다중 `<table>`을 포함하는 페이지로 두 표가 모두 출력되는지 육안/지표 확인 권장
  (`tests/smoke/test_parser_processor_dotsocr_table_smoke.py`).

## 변경 파일

- `docling/models/genos_dots_ocr_layout_model.py`
- `genon/preprocessor/tests/unit/test_table_structure_unit.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of documents containing multiple tables within a single element, ensuring accurate table detection and structure parsing without data loss.

* **Tests**
  * Added comprehensive test coverage for table extraction and layout processing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->