### PR TITLE
Task/205 v20 analysis genos layout time

### DIFF
--- a/docling/document_converter.py
+++ b/docling/document_converter.py
@@ -46,6 +46,7 @@ from docling.pipeline.asr_pipeline import AsrPipeline
 from docling.pipeline.base_pipeline import BasePipeline
 from docling.pipeline.simple_pipeline import SimplePipeline
 from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline
+from docling.utils.profiling import log_profiling_summary
 from docling.utils.utils import chunkify
 
 _log = logging.getLogger(__name__)
@@ -339,6 +340,7 @@ class DocumentConverter:
                 _log.info(
                     f"Finished converting document {item.input.file.name} in {elapsed:.2f} sec."
                 )
+                log_profiling_summary(item, _log)
                 yield item
 
     def _get_pipeline(self, doc_format: InputFormat) -> Optional[BasePipeline]:

--- a/docling/models/genos_dots_ocr_layout_model.py
+++ b/docling/models/genos_dots_ocr_layout_model.py
@@ -9,6 +9,7 @@ import re
 import time
 import warnings
 from collections.abc import Iterable
+from datetime import datetime, timedelta
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Optional
@@ -56,10 +57,19 @@ def _record_stage_elapsed(conv_res, key: str, elapsed: float) -> None:
     blocks and is safe to call from the per-page worker threads (``list.append``
     is atomic under the GIL; keys are pre-created in ``__call__``). No-op unless
     ``settings.debug.profile_pipeline_timings`` is enabled.
+
+    Also records an approximate start timestamp (``now - elapsed``; this is
+    called right after the work finishes) so the profiling summary can compute
+    a document-level wall-clock by union-ing the per-page intervals. The two
+    ``list.append`` calls are individually atomic; concurrent worker threads may
+    interleave them, but intervals within one batch share near-identical start
+    and duration, so the union estimate is unaffected in practice. Wrap both in
+    a ``Lock`` if exact (start, duration) pairing is ever required.
     """
     if not settings.debug.profile_pipeline_timings:
         return
     item = conv_res.timings.setdefault(key, ProfilingItem(scope=ProfilingScope.PAGE))
+    item.start_timestamps.append(datetime.utcnow() - timedelta(seconds=elapsed))
     item.times.append(elapsed)
     item.count += 1
 
@@ -626,10 +636,11 @@ class GenosDotsOCRLayoutModel(BasePageModel):
             total_attempts = self.retry_count + 1
             response = None
             result = None
+            usage = None
             _vlm_started_at = time.monotonic()
             for attempt in range(1, total_attempts + 1):
                 try:
-                    response_text = call_vlm_server(
+                    response_text, usage = call_vlm_server(
                         prompt=prompt,
                         base64_image=base64_image,
                         url=self.dotocr_endpoint,
@@ -690,9 +701,17 @@ class GenosDotsOCRLayoutModel(BasePageModel):
                 result = []
 
             assert isinstance(result, list)
-            _record_stage_elapsed(
-                conv_res, "dotsocr_vlm_call", time.monotonic() - _vlm_started_at
-            )
+            _vlm_elapsed = time.monotonic() - _vlm_started_at
+            _record_stage_elapsed(conv_res, "dotsocr_vlm_call", _vlm_elapsed)
+            if isinstance(usage, dict):
+                _log.info(
+                    "DotsOCR VLM usage (page=%s): prompt_tokens=%s, completion_tokens=%s, total_tokens=%s, elapsed=%.3fs",
+                    page.page_no,
+                    usage.get("prompt_tokens"),
+                    usage.get("completion_tokens"),
+                    usage.get("total_tokens"),
+                    _vlm_elapsed,
+                )
 
             _parse_started_at = time.monotonic()
             clusters = []
@@ -958,7 +977,7 @@ def call_vlm_server(
     temperature: float = 0.1,
     top_p: float = 0.9,
     repetition_penalty: float = 1.15,
-) -> str:
+) -> tuple[str, dict | None]:
     image_data_url = f"data:image/png;base64,{base64_image}"
     prompt_with_image_token = f"<|img|><|imgpad|><|endofimg|>{prompt}"
 
@@ -1006,7 +1025,8 @@ def call_vlm_server(
 
         response.raise_for_status()
         data = response.json()
-        return data["choices"][0]["message"]["content"]
+        usage = data.get("usage") if isinstance(data, dict) else None
+        return data["choices"][0]["message"]["content"], usage
     except requests.exceptions.RequestException as e:
         raise RuntimeError(f"HTTP 요청 오류: {e}") from e
     except KeyError as e:

--- a/docling/models/genos_dots_ocr_layout_model.py
+++ b/docling/models/genos_dots_ocr_layout_model.py
@@ -6,6 +6,7 @@ import requests
 import copy
 import logging
 import re
+import time
 import warnings
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
@@ -42,10 +43,26 @@ from docling.models.utils.hf_model_download import download_hf_model
 from docling.utils.accelerator_utils import decide_device
 
 from docling.utils.genos_dotsocr_postprocessor import LayoutPostprocessor
-from docling.utils.profiling import TimeRecorder
+from docling.utils.profiling import ProfilingItem, ProfilingScope, TimeRecorder
 from docling.utils.visualization import draw_clusters
 
 _log = logging.getLogger(__name__)
+
+
+def _record_stage_elapsed(conv_res, key: str, elapsed: float) -> None:
+    """Append a sub-stage duration into ``conv_res.timings[key]``.
+
+    Mirrors :class:`TimeRecorder` but works without re-indenting large code
+    blocks and is safe to call from the per-page worker threads (``list.append``
+    is atomic under the GIL; keys are pre-created in ``__call__``). No-op unless
+    ``settings.debug.profile_pipeline_timings`` is enabled.
+    """
+    if not settings.debug.profile_pipeline_timings:
+        return
+    item = conv_res.timings.setdefault(key, ProfilingItem(scope=ProfilingScope.PAGE))
+    item.times.append(elapsed)
+    item.count += 1
+
 
 DOTSOCR_IMAGE_FACTOR = 28
 DOTSOCR_MIN_PIXELS = 3136
@@ -609,6 +626,7 @@ class GenosDotsOCRLayoutModel(BasePageModel):
             total_attempts = self.retry_count + 1
             response = None
             result = None
+            _vlm_started_at = time.monotonic()
             for attempt in range(1, total_attempts + 1):
                 try:
                     response_text = call_vlm_server(
@@ -672,7 +690,11 @@ class GenosDotsOCRLayoutModel(BasePageModel):
                 result = []
 
             assert isinstance(result, list)
+            _record_stage_elapsed(
+                conv_res, "dotsocr_vlm_call", time.monotonic() - _vlm_started_at
+            )
 
+            _parse_started_at = time.monotonic()
             clusters = []
             raw_table_html_by_cluster_id: dict[int, str] = {}
             raw_formula_latex_by_cluster_id: dict[int, str] = {}
@@ -783,10 +805,19 @@ class GenosDotsOCRLayoutModel(BasePageModel):
                 clusters=clusters,
                 dotsocr_text_by_cluster_id=raw_text_by_cluster_id,
             )
+            _record_stage_elapsed(
+                conv_res, "dotsocr_parse", time.monotonic() - _parse_started_at
+            )
 
+            _postprocess_started_at = time.monotonic()
             processed_clusters, processed_cells = LayoutPostprocessor(
                 page, clusters, self.options
             ).postprocess()
+            _record_stage_elapsed(
+                conv_res,
+                "dotsocr_postprocess",
+                time.monotonic() - _postprocess_started_at,
+            )
 
             # Note: LayoutPostprocessor updates page.cells and page.parsed_page internally
             with warnings.catch_warnings():
@@ -827,10 +858,16 @@ class GenosDotsOCRLayoutModel(BasePageModel):
             )
 
             if self._use_dotsocr_table_structure():
+                _table_started_at = time.monotonic()
                 page.predictions.tablestructure = self._build_tablestructure_from_dotsocr(
                     page=page,
                     clusters=processed_clusters,
                     table_html_by_cluster_id=raw_table_html_by_cluster_id,
+                )
+                _record_stage_elapsed(
+                    conv_res,
+                    "dotsocr_table_build",
+                    time.monotonic() - _table_started_at,
                 )
 
         if settings.debug.visualize_layout:
@@ -866,11 +903,29 @@ class GenosDotsOCRLayoutModel(BasePageModel):
         if not pages:
             return
 
+        # Pre-create per-page sub-stage timing keys before spawning worker
+        # threads so concurrent TimeRecorder/_record_stage_elapsed calls don't
+        # race on dict initialization (list.append itself is atomic).
+        if settings.debug.profile_pipeline_timings:
+            for _key in (
+                "layout",
+                "dotsocr_vlm_call",
+                "dotsocr_parse",
+                "dotsocr_postprocess",
+                "dotsocr_table_build",
+            ):
+                conv_res.timings.setdefault(
+                    _key, ProfilingItem(scope=ProfilingScope.PAGE)
+                )
+
         def _process(page: Page) -> Page:
             return self._process_page(conv_res, page)
 
-        with ThreadPoolExecutor(max_workers=len(pages)) as executor:
-            yield from executor.map(_process, pages)
+        with TimeRecorder(
+            conv_res, "dotsocr_layout_wallclock", scope=ProfilingScope.DOCUMENT
+        ):
+            with ThreadPoolExecutor(max_workers=len(pages)) as executor:
+                yield from executor.map(_process, pages)
 
 
 prompt = """Please output the layout information from the PDF image, including each layout element's bbox, its category, and the corresponding text content within the bbox.

--- a/docling/models/layout_model.py
+++ b/docling/models/layout_model.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import numpy as np
 from docling_core.types.doc import DocItemLabel
-from PIL import Image
+from PIL import Image, ImageDraw, ImageFont
 
 from docling.datamodel.accelerator_options import AcceleratorOptions
 from docling.datamodel.base_models import BoundingBox, Cluster, LayoutPrediction, Page
@@ -105,37 +105,21 @@ class LayoutModel(BasePageModel):
         self, conv_res, page, clusters, mode_prefix: str, show: bool = False
     ):
         """
-        Draws a page image side by side with clusters filtered into two categories:
-        - Left: Clusters excluding FORM, KEY_VALUE_REGION, and PICTURE.
-        - Right: Clusters including FORM, KEY_VALUE_REGION, and PICTURE.
-        Includes label names and confidence scores for each cluster.
+        Draws all layout clusters on a single page image for debug visualization.
         """
         scale_x = page.image.width / page.size.width
         scale_y = page.image.height / page.size.height
 
-        # Filter clusters for left and right images
-        exclude_labels = {
-            DocItemLabel.FORM,
-            DocItemLabel.KEY_VALUE_REGION,
-            DocItemLabel.PICTURE,
-        }
-        left_clusters = [c for c in clusters if c.label not in exclude_labels]
-        right_clusters = [c for c in clusters if c.label in exclude_labels]
-        # Create a deep copy of the original image for both sides
-        left_image = copy.deepcopy(page.image)
-        right_image = copy.deepcopy(page.image)
+        order_map = {cluster.id: idx + 1 for idx, cluster in enumerate(clusters)}
 
-        # Draw clusters on both images
-        draw_clusters(left_image, left_clusters, scale_x, scale_y)
-        draw_clusters(right_image, right_clusters, scale_x, scale_y)
-        # Combine the images side by side
-        combined_width = left_image.width * 2
-        combined_height = left_image.height
-        combined_image = Image.new("RGB", (combined_width, combined_height))
-        combined_image.paste(left_image, (0, 0))
-        combined_image.paste(right_image, (left_image.width, 0))
+        output_image = copy.deepcopy(page.image)
+        draw_clusters(output_image, clusters, scale_x, scale_y)
+        self._draw_cluster_order_indices(
+            output_image, clusters, order_map, scale_x, scale_y
+        )
+
         if show:
-            combined_image.show()
+            output_image.show()
         else:
             out_path: Path = (
                 Path(settings.debug.debug_output_path)
@@ -143,7 +127,180 @@ class LayoutModel(BasePageModel):
             )
             out_path.mkdir(parents=True, exist_ok=True)
             out_file = out_path / f"{mode_prefix}_layout_page_{page.page_no:05}.png"
-            combined_image.save(str(out_file), format="png")
+            output_image.save(str(out_file), format="png")
+
+    def _draw_cluster_order_indices(
+        self,
+        image: Image.Image,
+        clusters: list[Cluster],
+        order_map: dict[int, int],
+        scale_x: float,
+        scale_y: float,
+    ) -> None:
+        draw = ImageDraw.Draw(image, "RGBA")
+        try:
+            order_font = ImageFont.truetype("arial.ttf", 24)
+        except OSError:
+            try:
+                order_font = ImageFont.truetype("DejaVuSans.ttf", 24)
+            except OSError:
+                order_font = ImageFont.load_default()
+        try:
+            # Match draw_clusters label font size to estimate occupied label regions.
+            label_font = ImageFont.truetype("arial.ttf", 12)
+        except OSError:
+            label_font = ImageFont.load_default()
+
+        def _as_valid_rect(x0, y0, x1, y1):
+            if x1 < x0:
+                x0, x1 = x1, x0
+            if y1 < y0:
+                y0, y1 = y1, y0
+            return (float(x0), float(y0), float(x1), float(y1))
+
+        def _clamp_box(x0, y0, box_w, box_h):
+            x0 = float(min(max(x0, 0.0), max(float(image.width) - box_w, 0.0)))
+            y0 = float(min(max(y0, 0.0), max(float(image.height) - box_h, 0.0)))
+            return (x0, y0, x0 + box_w, y0 + box_h)
+
+        def _boxes_intersect(a, b):
+            return not (a[2] <= b[0] or b[2] <= a[0] or a[3] <= b[1] or b[3] <= a[1])
+
+        def _overlap_area(a, b):
+            inter_w = max(0.0, min(a[2], b[2]) - max(a[0], b[0]))
+            inter_h = max(0.0, min(a[3], b[3]) - max(a[1], b[1]))
+            return inter_w * inter_h
+
+        def _create_text_mask(text: str, font: ImageFont.ImageFont, min_height: int):
+            probe = Image.new("L", (1, 1), 0)
+            probe_draw = ImageDraw.Draw(probe)
+            bbox = probe_draw.textbbox((0, 0), text, font=font)
+            text_w = max(1, int(bbox[2] - bbox[0]))
+            text_h = max(1, int(bbox[3] - bbox[1]))
+
+            mask = Image.new("L", (text_w, text_h), 0)
+            mask_draw = ImageDraw.Draw(mask)
+            mask_draw.text((-bbox[0], -bbox[1]), text, font=font, fill=255)
+
+            if text_h < min_height:
+                scale = float(min_height) / float(text_h)
+                new_w = max(1, int(round(text_w * scale)))
+                new_h = max(1, int(round(text_h * scale)))
+                resampling = (
+                    Image.Resampling.NEAREST
+                    if hasattr(Image, "Resampling")
+                    else Image.NEAREST
+                )
+                mask = mask.resize((new_w, new_h), resample=resampling)
+
+            return mask
+
+        # Pre-compute existing label boxes (already drawn by draw_clusters) as forbidden regions.
+        label_boxes: list[tuple[float, float, float, float]] = []
+        label_boxes_by_cluster_id: dict[int, tuple[float, float, float, float]] = {}
+        label_bg_padding = 2
+        for cluster in clusters:
+            x0, y0, x1, y1 = cluster.bbox.as_tuple()
+            x0 *= scale_x
+            x1 *= scale_x
+            y0 *= scale_y
+            y1 *= scale_y
+            x0, y0, x1, y1 = _as_valid_rect(x0, y0, x1, y1)
+
+            label_text = f"{cluster.label.name} ({cluster.confidence:.2f})"
+            text_bbox = draw.textbbox((x0, y0), label_text, font=label_font)
+            label_box = (
+                float(text_bbox[0] - label_bg_padding),
+                float(text_bbox[1] - label_bg_padding),
+                float(text_bbox[2] + label_bg_padding),
+                float(text_bbox[3] + label_bg_padding),
+            )
+            label_boxes.append(label_box)
+            label_boxes_by_cluster_id[id(cluster)] = label_box
+
+        placed_badges: list[tuple[float, float, float, float]] = []
+
+        for cluster in clusters:
+            order = order_map.get(cluster.id)
+            if order is None:
+                continue
+
+            x0, y0, x1, y1 = cluster.bbox.as_tuple()
+            x0 *= scale_x
+            x1 *= scale_x
+            y0 *= scale_y
+            y1 *= scale_y
+            x0, y0, x1, y1 = _as_valid_rect(x0, y0, x1, y1)
+
+            text = str(order)
+            text_mask = _create_text_mask(text=text, font=order_font, min_height=20)
+            text_w = float(text_mask.width)
+            text_h = float(text_mask.height)
+            pad = 2
+            box_w = text_w + pad * 2
+            box_h = text_h + pad * 2
+
+            # Prefer positions right next to the item label text box.
+            label_box = label_boxes_by_cluster_id.get(id(cluster))
+            if label_box is None:
+                label_box = (x0, y0, x0, y0)
+            candidate_boxes = [
+                _clamp_box(label_box[2] + 4, label_box[1], box_w, box_h),  # right of label
+                _clamp_box(label_box[0] - box_w - 4, label_box[1], box_w, box_h),  # left of label
+                _clamp_box(label_box[0], label_box[1] - box_h - 3, box_w, box_h),  # above label
+                _clamp_box(label_box[0], label_box[3] + 3, box_w, box_h),  # below label
+                _clamp_box(x1 + 3, y0 + 2, box_w, box_h),  # cluster fallback
+                _clamp_box(x0 - box_w - 3, y0 + 2, box_w, box_h),
+                _clamp_box(x0 + 2, y1 - box_h - 2, box_w, box_h),
+                _clamp_box(x1 - box_w - 2, y1 - box_h - 2, box_w, box_h),
+            ]
+
+            selected_box = None
+            best_score = None
+            for candidate in candidate_boxes:
+                overlap_count = 0
+                overlap_area = 0.0
+
+                for box in label_boxes:
+                    if _boxes_intersect(candidate, box):
+                        overlap_count += 1
+                        overlap_area += _overlap_area(candidate, box)
+
+                for box in placed_badges:
+                    if _boxes_intersect(candidate, box):
+                        overlap_count += 1
+                        overlap_area += _overlap_area(candidate, box)
+
+                score = (overlap_count, overlap_area)
+                if selected_box is None or score < best_score:
+                    selected_box = candidate
+                    best_score = score
+                    if overlap_count == 0:
+                        break
+
+            if selected_box is None:
+                selected_box = _clamp_box(x0 + 2, y0 + 2, box_w, box_h)
+
+            box_x0, box_y0, box_x1, box_y1 = selected_box
+
+            draw.rounded_rectangle(
+                [(box_x0, box_y0), (box_x1, box_y1)],
+                radius=3,
+                fill=(255, 240, 120, 230),
+                outline=(0, 0, 0, 255),
+                width=1,
+            )
+            image.paste(
+                (0, 0, 0),
+                (
+                    int(round(box_x0 + pad)),
+                    int(round(box_y0 + pad)),
+                    int(round(box_x0 + pad + text_w)),
+                    int(round(box_y0 + pad + text_h)),
+                ),
+                text_mask,
+            )
+            placed_badges.append(selected_box)
 
     def __call__(
         self, conv_res: ConversionResult, page_batch: Iterable[Page]

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 from pathlib import Path
-from typing import Optional, cast
+from typing import Optional
 
 import numpy as np
 from docling_core.types.doc import DocItem, ImageRef, PictureItem, TableItem
@@ -269,12 +269,17 @@ class StandardPdfPipeline(PaginatedPipeline):
 
             # Generate page images in the output
             if self.pipeline_options.generate_page_images:
-                for page in conv_res.pages:
-                    assert page.image is not None
-                    page_no = page.page_no + 1
-                    conv_res.document.pages[page_no].image = ImageRef.from_pil(
-                        page.image, dpi=int(72 * self.pipeline_options.images_scale)
-                    )
+                with TimeRecorder(
+                    conv_res,
+                    "doc_assemble_page_images",
+                    scope=ProfilingScope.DOCUMENT,
+                ):
+                    for page in conv_res.pages:
+                        assert page.image is not None
+                        page_no = page.page_no + 1
+                        conv_res.document.pages[page_no].image = ImageRef.from_pil(
+                            page.image, dpi=int(72 * self.pipeline_options.images_scale)
+                        )
 
             # Generate images of the requested element types
             with warnings.catch_warnings():  # deprecated generate_table_images
@@ -283,38 +288,46 @@ class StandardPdfPipeline(PaginatedPipeline):
                     self.pipeline_options.generate_picture_images
                     or self.pipeline_options.generate_table_images
                 ):
-                    scale = self.pipeline_options.images_scale
-                    for element, _level in conv_res.document.iterate_items():
-                        if not isinstance(element, DocItem) or len(element.prov) == 0:
-                            continue
-                        if (
-                            isinstance(element, PictureItem)
-                            and self.pipeline_options.generate_picture_images
-                        ) or (
-                            isinstance(element, TableItem)
-                            and self.pipeline_options.generate_table_images
-                        ):
-                            page_ix = element.prov[0].page_no - 1
-                            page = next(
-                                (p for p in conv_res.pages if p.page_no == page_ix),
-                                cast("Page", None),
-                            )
-                            assert page is not None
-                            assert page.size is not None
-                            assert page.image is not None
+                    with TimeRecorder(
+                        conv_res,
+                        "doc_assemble_element_images",
+                        scope=ProfilingScope.DOCUMENT,
+                    ):
+                        scale = self.pipeline_options.images_scale
+                        # Index pages by page_no once to avoid an
+                        # O(elements x pages) linear scan per picture/table.
+                        page_no_to_page = {p.page_no: p for p in conv_res.pages}
+                        for element, _level in conv_res.document.iterate_items():
+                            if (
+                                not isinstance(element, DocItem)
+                                or len(element.prov) == 0
+                            ):
+                                continue
+                            if (
+                                isinstance(element, PictureItem)
+                                and self.pipeline_options.generate_picture_images
+                            ) or (
+                                isinstance(element, TableItem)
+                                and self.pipeline_options.generate_table_images
+                            ):
+                                page_ix = element.prov[0].page_no - 1
+                                page = page_no_to_page.get(page_ix)
+                                assert page is not None
+                                assert page.size is not None
+                                assert page.image is not None
 
-                            crop_bbox = (
-                                element.prov[0]
-                                .bbox.scaled(scale=scale)
-                                .to_top_left_origin(
-                                    page_height=page.size.height * scale
+                                crop_bbox = (
+                                    element.prov[0]
+                                    .bbox.scaled(scale=scale)
+                                    .to_top_left_origin(
+                                        page_height=page.size.height * scale
+                                    )
                                 )
-                            )
 
-                            cropped_im = page.image.crop(crop_bbox.as_tuple())
-                            element.image = ImageRef.from_pil(
-                                cropped_im, dpi=int(72 * scale)
-                            )
+                                cropped_im = page.image.crop(crop_bbox.as_tuple())
+                                element.image = ImageRef.from_pil(
+                                    cropped_im, dpi=int(72 * scale)
+                                )
 
             # Aggregate confidence values for document:
             if len(conv_res.pages) > 0:

--- a/docling/utils/profiling.py
+++ b/docling/utils/profiling.py
@@ -241,7 +241,7 @@ def log_profiling_summary(
     header = f"[profiling] timing summary for {file_name}"
     lines = [
         header,
-        "# wall(s)=동시 page 구간 합집합(벽시계 추정), %pipe=pipeline_total 대비. "
+        "# wall(s)=동시 page 구간 합집합(실제 경과시간 추정), %pipe=pipeline_total 대비. "
         "중첩 스테이지는 합산 시 중복됨.",
         f"{'stage':<28} {'scope':<9} {'count':>6} {'total(s)':>10} "
         f"{'wall(s)':>10} {'%pipe':>6} {'avg(s)':>9} {'p95(s)':>9}",

--- a/docling/utils/profiling.py
+++ b/docling/utils/profiling.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import unicodedata
 from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, List
@@ -38,6 +39,39 @@ class ProfilingItem(BaseModel):
     def percentile(self, perc: float) -> float:
         return np.percentile(self.times, perc)  # type: ignore
 
+    def wall_clock(self) -> float:
+        """Document-level (wall-clock) time covered by this stage.
+
+        Computed as the union of the recorded ``[start, start + elapsed]``
+        intervals. For sequential stages the intervals don't overlap so this
+        equals ``sum(times)``; for concurrent stages (e.g. the per-page layout
+        threads) overlapping intervals collapse into the true elapsed span, so
+        ``total(s)`` (a sum inflated by concurrency) is converted into the real
+        wall-clock contribution. Falls back to ``sum(times)`` when start
+        timestamps are unavailable/mismatched.
+
+        Note: ``datetime.timestamp()`` on naive timestamps applies the same
+        local-time offset to every interval of a stage, so it cancels out in
+        the relative-overlap math.
+        """
+        if not self.times:
+            return 0.0
+        if len(self.start_timestamps) != len(self.times):
+            return float(np.sum(self.times))
+        intervals = sorted(
+            (ts.timestamp(), ts.timestamp() + d)
+            for ts, d in zip(self.start_timestamps, self.times)
+        )
+        union = 0.0
+        cur_start, cur_end = intervals[0]
+        for start, end in intervals[1:]:
+            if start > cur_end:
+                union += cur_end - cur_start
+                cur_start, cur_end = start, end
+            else:
+                cur_end = max(cur_end, end)
+        return union + (cur_end - cur_start)
+
 
 class TimeRecorder:
     def __init__(
@@ -65,6 +99,103 @@ class TimeRecorder:
             self.conv_res.timings[self.key].count += 1
 
 
+# Declared parent/child hierarchy of pipeline stages, in display order. Used to
+# render a non-overlapping flow tree where each parent's children (plus a
+# derived "(기타)" residual) sum to the parent's wall-clock — unlike the flat
+# table where nested stages (e.g. layout ⊃ vlm_call) double-count. Keys absent
+# from timings are skipped; keys present but not listed here surface under
+# "(트리 외)" so nothing is silently dropped. Update this when stages change.
+_FLOW_TREE = [
+    ("pipeline_total", None),
+    ("doc_build", "pipeline_total"),
+    ("page_init", "doc_build"),
+    ("page_parse", "doc_build"),
+    ("ocr", "doc_build"),  # OCR engine stage (easyocr/paddle/tesseract/...)
+    ("layout", "doc_build"),  # standard docling layout path
+    ("table_structure", "doc_build"),  # TableFormer / VLM table structure
+    ("vlm", "doc_build"),  # VLM pipeline path
+    ("dotsocr_layout_wallclock", "doc_build"),  # GENOS/dotsocr layout path
+    ("dotsocr_vlm_call", "dotsocr_layout_wallclock"),
+    ("dotsocr_postprocess", "dotsocr_layout_wallclock"),
+    ("dotsocr_parse", "dotsocr_layout_wallclock"),
+    ("dotsocr_table_build", "dotsocr_layout_wallclock"),
+    ("page_assemble", "doc_build"),
+    ("doc_assemble", "pipeline_total"),
+    ("doc_assemble_page_images", "doc_assemble"),
+    ("doc_assemble_element_images", "doc_assemble"),
+    ("reading_order", "doc_assemble"),
+    ("reading_order_bypass", "doc_assemble"),
+    ("doc_enrich", "pipeline_total"),
+]
+
+
+def _render_flow_tree(wall_by_key: dict, pipeline_wall: float) -> List[str]:
+    """Render stage wall-clock times as a non-overlapping hierarchy.
+
+    Children plus a derived ``(기타)`` residual sum to their parent, so reading
+    one level gives a clean breakdown without the flat table's nested
+    double-counting. Stages in ``wall_by_key`` but not in ``_FLOW_TREE`` are
+    listed under ``(트리 외)``.
+    """
+    parent_of = {k: p for k, p in _FLOW_TREE}
+
+    # On the dotsocr path, ``layout`` (per-page sum) duplicates
+    # ``dotsocr_layout_wallclock``; drop it so the stage isn't counted twice.
+    ignore = set()
+    if "dotsocr_layout_wallclock" in wall_by_key and "layout" in wall_by_key:
+        ignore.add("layout")
+
+    present = [k for k, _ in _FLOW_TREE if k in wall_by_key and k not in ignore]
+    present_set = set(present)
+
+    children: dict = {}
+    for key in present:
+        children.setdefault(parent_of[key], []).append(key)
+
+    def fmt(label: str, wall: float, indent: str, connector: str) -> str:
+        pct = (100.0 * wall / pipeline_wall) if pipeline_wall > 0 else 0.0
+        head = f"{indent}{connector}{label} "
+        # East-Asian wide/fullwidth chars occupy 2 terminal columns; count
+        # display width so the dot leader aligns the value column.
+        width = sum(
+            2 if unicodedata.east_asian_width(c) in ("W", "F") else 1 for c in head
+        )
+        dots = "." * max(2, 44 - width)
+        return f"{head}{dots} {wall:>7.2f}s {pct:>5.1f}%"
+
+    lines: List[str] = []
+
+    def walk(key: str, indent: str, is_last: bool) -> None:
+        wall = wall_by_key[key]
+        is_root = parent_of[key] is None
+        connector = "" if is_root else ("└─ " if is_last else "├─ ")
+        lines.append(fmt(key, wall, indent, connector))
+
+        child_indent = indent if is_root else indent + ("   " if is_last else "│  ")
+        kids = children.get(key, [])
+        residual = wall - sum(wall_by_key[c] for c in kids)
+        show_residual = bool(kids) and residual > 0.05 and (
+            pipeline_wall <= 0 or residual > 0.001 * pipeline_wall
+        )
+        total_kids = len(kids) + (1 if show_residual else 0)
+        for i, child in enumerate(kids):
+            walk(child, child_indent, i == total_kids - 1)
+        if show_residual:
+            lines.append(fmt("(기타)", residual, child_indent, "└─ "))
+
+    roots = [k for k, p in _FLOW_TREE if p is None and k in present_set]
+    for i, root in enumerate(roots):
+        walk(root, "", i == len(roots) - 1)
+
+    extras = [k for k in wall_by_key if k not in present_set and k not in ignore]
+    if extras:
+        lines.append("(트리 외)")
+        for key in sorted(extras, key=lambda k: wall_by_key[k], reverse=True):
+            lines.append(fmt(key, wall_by_key[key], "  ", ""))
+
+    return lines
+
+
 def log_profiling_summary(
     conv_res: "ConversionResult", logger: logging.Logger = _log
 ) -> None:
@@ -86,25 +217,48 @@ def log_profiling_summary(
         if not item.times:
             continue
         total = float(np.sum(item.times))
-        rows.append((key, item, total))
+        wall = item.wall_clock()
+        rows.append((key, item, total, wall))
 
     if not rows:
         return
 
-    rows.sort(key=lambda r: r[2], reverse=True)
+    # Sort by wall-clock (document-level) so the real bottleneck appears first.
+    rows.sort(key=lambda r: r[3], reverse=True)
+
+    # Denominator for %pipe: prefer pipeline_total's wall-clock, else the
+    # largest document-scoped wall-clock.
+    pipeline_wall = next(
+        (w for k, _i, _t, w in rows if k == "pipeline_total"), 0.0
+    )
+    if pipeline_wall <= 0:
+        pipeline_wall = max(
+            (w for _k, i, _t, w in rows if i.scope == ProfilingScope.DOCUMENT),
+            default=0.0,
+        )
 
     file_name = getattr(getattr(conv_res, "input", None), "file", "")
     header = f"[profiling] timing summary for {file_name}"
     lines = [
         header,
+        "# wall(s)=동시 page 구간 합집합(벽시계 추정), %pipe=pipeline_total 대비. "
+        "중첩 스테이지는 합산 시 중복됨.",
         f"{'stage':<28} {'scope':<9} {'count':>6} {'total(s)':>10} "
-        f"{'avg(s)':>9} {'p95(s)':>9}",
+        f"{'wall(s)':>10} {'%pipe':>6} {'avg(s)':>9} {'p95(s)':>9}",
     ]
-    for key, item, total in rows:
+    for key, item, total, wall in rows:
         scope = item.scope.value if hasattr(item.scope, "value") else str(item.scope)
         p95 = item.percentile(95) if len(item.times) > 1 else item.times[0]
+        pct = f"{100.0 * wall / pipeline_wall:>5.1f}%" if pipeline_wall > 0 else "    -"
         lines.append(
             f"{key:<28} {scope:<9} {item.count:>6} {total:>10.3f} "
-            f"{item.avg():>9.3f} {p95:>9.3f}"
+            f"{wall:>10.3f} {pct:>6} {item.avg():>9.3f} {p95:>9.3f}"
         )
+
+    # Non-overlapping flow tree (children + residual sum to their parent).
+    wall_by_key = {key: wall for key, _item, _total, wall in rows}
+    lines.append("")
+    lines.append("[profiling] flow (wall-clock, %pipe)")
+    lines.extend(_render_flow_tree(wall_by_key, pipeline_wall))
+
     logger.info("\n".join(lines))

--- a/docling/utils/profiling.py
+++ b/docling/utils/profiling.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from datetime import datetime
 from enum import Enum
@@ -10,6 +11,8 @@ from docling.datamodel.settings import settings
 
 if TYPE_CHECKING:
     from docling.datamodel.document import ConversionResult
+
+_log = logging.getLogger(__name__)
 
 
 class ProfilingScope(str, Enum):
@@ -60,3 +63,48 @@ class TimeRecorder:
             elapsed = time.monotonic() - self.start
             self.conv_res.timings[self.key].times.append(elapsed)
             self.conv_res.timings[self.key].count += 1
+
+
+def log_profiling_summary(
+    conv_res: "ConversionResult", logger: logging.Logger = _log
+) -> None:
+    """Log a per-stage timing breakdown for one converted document.
+
+    No-op unless ``settings.debug.profile_pipeline_timings`` is enabled (set
+    ``DOCLING_DEBUG__PROFILE_PIPELINE_TIMINGS=true``). Stages are ordered by
+    total elapsed time so the dominant bottleneck appears first.
+    """
+    if not settings.debug.profile_pipeline_timings:
+        return
+
+    timings = getattr(conv_res, "timings", None)
+    if not timings:
+        return
+
+    rows = []
+    for key, item in timings.items():
+        if not item.times:
+            continue
+        total = float(np.sum(item.times))
+        rows.append((key, item, total))
+
+    if not rows:
+        return
+
+    rows.sort(key=lambda r: r[2], reverse=True)
+
+    file_name = getattr(getattr(conv_res, "input", None), "file", "")
+    header = f"[profiling] timing summary for {file_name}"
+    lines = [
+        header,
+        f"{'stage':<28} {'scope':<9} {'count':>6} {'total(s)':>10} "
+        f"{'avg(s)':>9} {'p95(s)':>9}",
+    ]
+    for key, item, total in rows:
+        scope = item.scope.value if hasattr(item.scope, "value") else str(item.scope)
+        p95 = item.percentile(95) if len(item.times) > 1 else item.times[0]
+        lines.append(
+            f"{key:<28} {scope:<9} {item.count:>6} {total:>10.3f} "
+            f"{item.avg():>9.3f} {p95:>9.3f}"
+        )
+    logger.info("\n".join(lines))

--- a/genon/README.md
+++ b/genon/README.md
@@ -73,13 +73,13 @@
    > **주의 (배포 정책):** `synap` 빌드는 유료 PDF SDK가 포함된다. 운영계 Genos 도커 레지스트리에는 **`standard` 이미지만** 올린다. 일반 사이트 배포는 **기본적으로 `standard`** 로 진행하며, 특정 사이트에 `synap`(유료 PDF SDK) 버전을 들고가야 하는 요청이 생길 경우엔, **AI Search 팀 내부에서 자체적으로 빌드후, 이미지를 전달**한다 (PDF SDK 토큰/라이선스는 AI Search 팀이 관리, 비공개).
 
    **(배경 설명)**
-   - PDF SDK란? → `타문서(HWP,docx 등) → PDF`를 고품질로 변환하기 위한 유료용 SDK. 이 SDK의 유무에 따라 `standard` 또는 `synap` 버전으로 구분됨. 
-   - **`standard`** — 기본 버전. 
-     - 오픈소스(LibreOffice + rhwp)만 사용하여 PDF로 변환. PDF SDK 자산이 이미지에 일절 들어가지 않음 (다운로드 단계 자체가 없음). 
+   - PDF SDK란? → `타문서(HWP,docx 등) → PDF`를 고품질로 변환하기 위한 유료용 SDK. 이 SDK의 유무에 따라 `standard` 또는 `synap` 버전으로 구분됨.
+   - **`standard`** — 기본 버전.
+     - 오픈소스(LibreOffice + rhwp)만 사용하여 PDF로 변환. PDF SDK 자산이 이미지에 일절 들어가지 않음 (다운로드 단계 자체가 없음).
      - 사내 운영계 GenOS 환경/일반적인 외부 사이트 배포용. **`HWP_SDK_TOKEN` 외에 별도의 추가 토큰값 필요 없음**.
    - **`synap`** — 오픈소스(LibreOffice + rhwp) + 유료 PDF SDK 포함 버전.
-     - PDF로의 문서 변환시, `pdf_sdk → rhwp(hwp/hwpx 전용) → libreoffice` 순서로 fallback 동작(=변환 실패시 후순위 로직 사용). 
-     - `PDF SDK`는 **전처리기 빌드시 자동 설치되며, `PDF_SDK_TOKEN`값이 사전에 필수로 적용되어야함(`HWP_SDK_TOKEN`과 별개 값)**. 
+     - PDF로의 문서 변환시, `pdf_sdk → rhwp(hwp/hwpx 전용) → libreoffice` 순서로 fallback 동작(=변환 실패시 후순위 로직 사용).
+     - `PDF SDK`는 **전처리기 빌드시 자동 설치되며, `PDF_SDK_TOKEN`값이 사전에 필수로 적용되어야함(`HWP_SDK_TOKEN`과 별개 값)**.
 
    **(진행 순서)**
 
@@ -264,11 +264,8 @@ huggingface-cli download rednote-hilab/dots.mocr \
 - huggingface: https://huggingface.co/rednote-hilab/dots.mocr
 
 2. Genos 모델서빙 기능으로 서빙생성
-- 주요 옵션은 아래 서빙명령어 참고
 
-* 참고
-
-- 내부 별도서버에 서비스 했던 vllm 서빙명령어
+- 주요 옵션은 아래 서빙명령어 참고 (내부 별도서버에 서비스 했던 vllm 서빙명령어)
 
 ```shell
 CUDA_VISIBLE_DEVICES=0 vllm serve rednote-hilab/dots.mocr \
@@ -278,8 +275,10 @@ CUDA_VISIBLE_DEVICES=0 vllm serve rednote-hilab/dots.mocr \
  --dtype bfloat16 \
  --gpu-memory-utilization 0.9 \
  --max-model-len 20000 \
- --max-num-seqs 32 \
+ --max-num-seqs 256 \
  --chat-template-content-format string \
  --served-model-name dots-mocr \
  --trust-remote-code
 ```
+
+- max-num-sqes를 256으로 설정한 근거 문서 참고바람: [dotsocr_vllm_max_num_seqs.md](dotsocr_vllm_max_num_seqs.md)

--- a/genon/dotsocr_vllm_max_num_seqs.md
+++ b/genon/dotsocr_vllm_max_num_seqs.md
@@ -1,0 +1,92 @@
+# vLLM max-num-seqs 권장값 정리 (dots.mocr)
+
+> 결론: **`--max-num-seqs 256`** 권장. 근거는 서버 시작 로그의
+> `max_cudagraph_capture_size: 256` (CUDA graph 효율 천장).
+> 측정/분석 기준 서버: `rednote-hilab/dots.mocr`, vLLM v0.19.0 (V1 engine), H100 1개,
+> `--gpu-memory-utilization 0.9 --max-model-len 20000`.
+
+## 1. 결론
+
+| 항목 | 값 |
+|---|---|
+| 권장 `--max-num-seqs` | **256** |
+| 권장 클라이언트 `page_batch_size` | **256** (서버 값과 반드시 일치) |
+| `--max-model-len` | 20000 유지 (큰 페이지 vision 토큰 안전 마진) |
+
+256을 넘기면 메모리는 버텨도 CUDA graph가 적용되지 않아 step당 느려지므로,
+**성능을 깎지 않는 최대값이 256**이다.
+
+## 2. 256의 직접 근거 — CUDA graph capture (시작 로그)
+
+```
+'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88,
+ 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216,
+ 224, 232, 240, 248, 256],
+'max_cudagraph_capture_size': 256
+```
+캡처 수행 확인:
+```
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|...| 35/35
+Capturing CUDA graphs (decode, FULL): 100%|...| 19/19
+Graph capturing finished in 2 secs, took 0.23 GiB
+```
+
+- CUDA graph = 특정 batch 크기에 대해 GPU 커널 실행을 미리 "녹화"해 launch 오버헤드를 없애는 최적화.
+- vLLM이 **1~256만** 캡처 → decode 동시 batch가 256 이하면 graph replay(빠름),
+  257 이상이면 eager 실행(커널을 매번 launch → 느림).
+- `max-num-seqs` = 동시 실행 sequence 수 상한 → **256으로 두면 항상 graph 적용 범위 내**.
+
+## 3. 천장 3종 비교 — 256은 "메모리"가 아니라 "효율(graph)" 한계
+
+| 천장 종류 | 로그 근거 | 값 |
+|---|---|---|
+| **효율 (CUDA graph) ← 256의 근거** | `max_cudagraph_capture_size: 256` | **256** |
+| 메모리 (worst-case, 요청이 max-model-len 20000 꽉 채움) | `Maximum concurrency for 20,000 tokens per request: 115.86x` | 115 |
+| 메모리 (현실 부하) | `GPU KV cache usage: 3.6% @ Running 27` → 요청당 ~3,000 토큰 | ~770 |
+
+관련 로그:
+```
+Available KV cache memory: 61.88 GiB
+GPU KV cache size: 2,317,168 tokens
+Maximum concurrency for 20,000 tokens per request: 115.86x
+...
+Running: 27 reqs, Waiting: 0 reqs, GPU KV cache usage: 3.6%
+```
+→ KV cache는 현실 부하서 256개를 ~33%(약 768k/2.3M 토큰)로 여유 있게 수용.
+   **256 제한은 메모리 때문이 아니라 CUDA graph 때문**이다.
+
+## 4. 256 초과 문서 처리
+
+256페이지를 넘는 문서도 문제 없음. 예) 300p → `⌈300/256⌉ = 2`라운드:
+- 1라운드 256p 동시, 2라운드 44p 동시.
+각 라운드가 graph 적용 범위 내에서 GPU를 채우므로,
+한 번에 다 밀어넣는 것(eager)보다 256씩 나누는 편이 더 빠르다.
+
+## 5. 권장 실행 커맨드
+
+```bash
+CUDA_VISIBLE_DEVICES=0 vllm serve rednote-hilab/dots.mocr \
+  --host 0.0.0.0 --port 26001 \
+  --tensor-parallel-size 1 \
+  --dtype bfloat16 \
+  --gpu-memory-utilization 0.9 \
+  --max-model-len 20000 \
+  --max-num-seqs 256 \
+  --chat-template-content-format string \
+  --served-model-name dots-mocr \
+  --trust-remote-code
+```
+**필수:** 클라이언트 `page_batch_size`도 256으로 맞출 것. 32로 두면 max-num-seqs=256은 무의미
+(서버는 여전히 ~32개만 수신).
+
+## 6. 검증 / 모니터링 포인트
+
+- 부하 중 `GPU KV cache usage`가 한 자릿수~수십 %면 안전.
+- `num_requests_waiting > 0` 또는 `num_preemptions_total` 증가가 보이면 = 대형 페이지가
+  256개 동시 몰린 worst-case → max-num-seqs를 192 등으로 하향 검토.
+- batch sweep를 256까지 확장 측정해 128 대비 추가 이득(=decode compute 포화 지점) 확인 권장.
+
+## 참고: max-num-seqs 미지정 시 기본값
+- V0 엔진: 256
+- V1 엔진(현재, v0.19.0): ~1024. 단 실효 동시성은 위 천장(115~256)에 묶이므로
+  명시적으로 256 지정 권장.

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -1845,7 +1845,7 @@ class DocumentProcessor:
             _as_dict(layout_cfg.get("genos_layout")).get("page_batch_size"), "layout.genos_layout.page_batch_size"
         )
         if page_batch_size is None or page_batch_size <= 0:
-            page_batch_size = 32
+            page_batch_size = 128
         settings.perf.page_batch_size = page_batch_size
 
         max_completion_tokens = _parse_optional_int(

--- a/genon/preprocessor/facade/gitbook_doc/convert_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/convert_processor.md
@@ -161,7 +161,7 @@ layout:
     # api_key는 k8s 내부 통신 기반 모델 호출 시 불필요
     endpoint: "http://llmops-gateway-api-service:8080/rep/serving/<LAYOUT_SERVING_ID>/v1/chat/completions"
     api_key: ""
-    page_batch_size: 32
+    page_batch_size: 128
     max_completion_tokens: 16384
     model: "dots-mocr"          # 서빙 모델명
     timeout: 3600               # VLM 요청 타임아웃(초)
@@ -292,7 +292,7 @@ enrichment:
 | `layout_model_type` | `"genos_layout"` | `genos_layout` \| `docling_layout` |
 | `genos_layout.endpoint` | `.../serving/<LAYOUT_SERVING_ID>/...` | Genos layout 모델 서빙 엔드포인트. **사이트별 교체 필요** |
 | `genos_layout.api_key` | `""` | k8s 내부 통신 기반 호출 시 불필요. 외부 호출 정책에 따라 필요할 수 있음 |
-| `genos_layout.page_batch_size` | `32` | 레이아웃 모델 페이지 배치 크기(전역 `settings.perf.page_batch_size`). 0 이하/오류 시 32 폴백 |
+| `genos_layout.page_batch_size` | `128` | 레이아웃 모델 페이지 배치 크기(전역 `settings.perf.page_batch_size`). 0 이하/오류 시 128 폴백 |
 | `genos_layout.max_completion_tokens` | `16384` | Layout LLM 최대 생성 토큰. 양의 정수, 유효하지 않거나 0 이하이면 16384 폴백 |
 | `genos_layout.model` | `"dots-mocr"` | 서빙 모델명. 비어있으면 `dots-mocr` 폴백 |
 | `genos_layout.timeout` | `3600` | VLM 요청 HTTP 타임아웃(초). 유효하지 않거나 0 이하이면 3600 폴백 |

--- a/genon/preprocessor/facade/gitbook_doc/intelligent_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/intelligent_processor.md
@@ -21,14 +21,17 @@ RAG 지식베이스 구축을 위한 **품질 최우선** 전처리기입니다.
     - [사이트별 필수 수정 항목 요약](#사이트별-필수-수정-항목-요약)
   - [3. 설정 (`intelligent_processor_config.yaml`)](#3-설정-intelligent_processor_configyaml)
     - [3.1 전체 스키마](#31-전체-스키마)
+      - [defaults 설정](#defaults-설정)
     - [3.2 OCR 설정](#32-ocr-설정)
     - [3.3 레이아웃 설정](#33-레이아웃-설정)
+      - [`repetition_penalty` 사용 가이드](#repetition_penalty-사용-가이드)
     - [3.4 PDF 파이프라인 설정](#34-pdf-파이프라인-설정)
     - [3.5 Enrichment 설정](#35-enrichment-설정)
       - [toc](#toc)
       - [metadata](#metadata)
       - [image\_description](#image_description)
       - [custom\_fields](#custom_fields)
+      - [프롬프트 파일 분리 \& 변수 치환](#프롬프트-파일-분리--변수-치환)
     - [3.7 청킹 설정](#37-청킹-설정)
     - [3.8 사이트 적용 시 필수 수정 항목](#38-사이트-적용-시-필수-수정-항목)
     - [3.9 자주 쓰는 튜닝 시나리오](#39-자주-쓰는-튜닝-시나리오)
@@ -165,7 +168,7 @@ layout:
   genos_layout:
     endpoint: "http://llmops-gateway-api-service:8080/rep/serving/<LAYOUT_SERVING_ID>/v1/chat/completions"
     api_key: ""               # k8s 내부 통신 시 불필요
-    page_batch_size: 32
+    page_batch_size: 128
     max_completion_tokens: 16384
     model: "dots-mocr"          # 서빙 모델명
     timeout: 3600               # VLM 요청 타임아웃(초)
@@ -277,7 +280,7 @@ enrichment:
 | `layout.layout_model_type` | `genos_layout`=외부 서빙형 / `docling_layout`=Docling 내재 모델 | `genos_layout` |
 | `layout.genos_layout.endpoint` | GenOS layout 모델 서빙 주소 (`<LAYOUT_SERVING_ID>` 치환) | — |
 | `layout.genos_layout.api_key` | k8s 내부 통신 시 불필요 | `""` |
-| `layout.genos_layout.page_batch_size` | layout 추론 페이지 배치 크기 (전역 `settings.perf` 에 반영) | 32 |
+| `layout.genos_layout.page_batch_size` | layout 추론 페이지 배치 크기 (전역 `settings.perf` 에 반영) | 128 |
 | `layout.genos_layout.max_completion_tokens` | layout LLM 최대 생성 토큰. 양의 정수, 유효하지 않거나 0 이하이면 16384 폴백 | 16384 |
 | `layout.genos_layout.model` | 서빙 모델명. 비어있으면 `dots-mocr` 폴백 | `"dots-mocr"` |
 | `layout.genos_layout.timeout` | VLM 요청 HTTP 타임아웃(초). 유효하지 않거나 0 이하이면 3600 폴백 | 3600 |

--- a/genon/preprocessor/facade/gitbook_doc/parser_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/parser_processor.md
@@ -160,7 +160,7 @@ layout:
     # api_key는 k8s 내부 통신 기반 모델 호출 시 불필요.
     endpoint: "http://llmops-gateway-api-service:8080/rep/serving/<LAYOUT_SERVING_ID>/v1/chat/completions"
     api_key: ""
-    page_batch_size: 32
+    page_batch_size: 128
     max_completion_tokens: 16384
     model: "dots-mocr"          # 서빙 모델명
     timeout: 3600               # VLM 요청 타임아웃(초)
@@ -312,7 +312,7 @@ whisper:
 | `layout` | `layout_model_type` | `"genos_layout"` | 레이아웃 모델 선택. `genos_layout` / `docling_layout` (유효하지 않으면 `genos_layout`) |
 | `layout.genos_layout` | `endpoint` | `""` | Genos Layout API URL |
 | `layout.genos_layout` | `api_key` | `""` | API 인증 키 |
-| `layout.genos_layout` | `page_batch_size` | `32` | 배치당 처리 페이지 수. 양의 정수, 유효하지 않으면 32로 대체 |
+| `layout.genos_layout` | `page_batch_size` | `128` | 배치당 처리 페이지 수. 양의 정수, 유효하지 않으면 128 대체 |
 | `layout.genos_layout` | `max_completion_tokens` | `16384` | Layout LLM 최대 생성 토큰. 양의 정수, 유효하지 않거나 0 이하이면 16384로 대체 |
 | `layout.genos_layout` | `model` | `"dots-mocr"` | 서빙 모델명. 비어있으면 `dots-mocr` 폴백 |
 | `layout.genos_layout` | `timeout` | `3600` | VLM 요청 HTTP 타임아웃(초). 유효하지 않거나 0 이하이면 3600 폴백 |

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -1841,7 +1841,7 @@ class DocumentProcessor:
             _as_dict(layout_cfg.get("genos_layout")).get("page_batch_size"), "layout.genos_layout.page_batch_size"
         )
         if page_batch_size is None or page_batch_size <= 0:
-            page_batch_size = 32
+            page_batch_size = 128
         settings.perf.page_batch_size = page_batch_size
 
         max_completion_tokens = _parse_optional_int(

--- a/genon/preprocessor/facade/parser_processor.py
+++ b/genon/preprocessor/facade/parser_processor.py
@@ -1146,7 +1146,7 @@ class IntelligentDocumentProcessor:
             _log.warning(
                 f"[IntelligentDocumentProcessor] Invalid page_batch_size '{page_batch_size}', fallback to 32"
             )
-            page_batch_size = 32
+            page_batch_size = 128
 
         # DotsOCR VLM 호출/생성 파라미터 (yaml 누락·무효 시 기본값 폴백)
         layout_model = genos_layout_cfg.get("model") or "dots-mocr"

--- a/genon/preprocessor/resource/convert_processor_config.yaml
+++ b/genon/preprocessor/resource/convert_processor_config.yaml
@@ -40,7 +40,7 @@ layout:
     # api_key는 k8s 내부 통신 기반 모델 호출 시 불필요.
     endpoint: "http://llmops-gateway-api-service:8080/rep/serving/<LAYOUT_SERVING_ID>/v1/chat/completions"
     api_key: ""
-    page_batch_size: 32
+    page_batch_size: 128
     max_completion_tokens: 16384
     model: "dots-mocr"          # 서빙 모델명
     timeout: 3600               # VLM 요청 타임아웃(초)

--- a/genon/preprocessor/resource/intelligent_processor_config.yaml
+++ b/genon/preprocessor/resource/intelligent_processor_config.yaml
@@ -38,7 +38,7 @@ layout:
     # api_key는 k8s 내부 통신 기반 모델 호출 시 불필요.
     endpoint: "http://llmops-gateway-api-service:8080/rep/serving/<LAYOUT_SERVING_ID>/v1/chat/completions"
     api_key: ""
-    page_batch_size: 32
+    page_batch_size: 128
     max_completion_tokens: 16384
     model: "dots-mocr"          # 서빙 모델명
     timeout: 3600               # VLM 요청 타임아웃(초)

--- a/genon/preprocessor/resource/parser_processor_config.yaml
+++ b/genon/preprocessor/resource/parser_processor_config.yaml
@@ -38,7 +38,7 @@ layout:
     # api_key는 k8s 내부 통신 기반 모델 호출 시 불필요.
     endpoint: "http://llmops-gateway-api-service:8080/rep/serving/<LAYOUT_SERVING_ID>/v1/chat/completions"
     api_key: ""
-    page_batch_size: 32
+    page_batch_size: 128
     max_completion_tokens: 16384
     model: "dots-mocr"          # 서빙 모델명
     timeout: 3600               # VLM 요청 타임아웃(초)

--- a/genon/preprocessor/resource_dev/convert_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/convert_processor_config.yaml
@@ -41,7 +41,7 @@ layout:
   genos_layout:
     endpoint: "http://192.168.75.174:26001/v1/chat/completions"
     api_key: ""
-    page_batch_size: 32
+    page_batch_size: 128
     max_completion_tokens: 16384
     model: "dots-mocr"          # 서빙 모델명
     timeout: 3600               # VLM 요청 타임아웃(초)

--- a/genon/preprocessor/resource_dev/intelligent_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/intelligent_processor_config.yaml
@@ -40,7 +40,7 @@ layout:
   genos_layout:
     endpoint: "http://192.168.75.174:26001/v1/chat/completions"
     api_key: ""
-    page_batch_size: 32
+    page_batch_size: 128
     max_completion_tokens: 16384
     model: "dots-mocr"          # 서빙 모델명
     timeout: 3600               # VLM 요청 타임아웃(초)

--- a/genon/preprocessor/resource_dev/parser_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/parser_processor_config.yaml
@@ -39,7 +39,7 @@ layout:
   genos_layout:
     endpoint: "http://192.168.75.174:26001/v1/chat/completions"
     api_key: ""
-    page_batch_size: 32
+    page_batch_size: 128
     max_completion_tokens: 16384
     model: "dots-mocr"          # 서빙 모델명
     timeout: 3600               # VLM 요청 타임아웃(초)


### PR DESCRIPTION
# feat(#205): 문서파싱 파이프라인 시간 프로파일링 계측 + dots.ocr `page_batch_size` 32→128 최적화

## 배경 / 문제

v2.0(dots.ocr) 파이프라인은 페이지 수가 늘수록 처리 시간이 비선형적으로 증가해, 50페이지
이상 구간에서 v1.3.8 대비 더 느려지는 **dead cross**가 관찰됐다. 그러나 단계별 소요 시간을
정확히 볼 수단이 없어 병목 지점을 규명하기 어려웠다.

- 단계별 계측을 추가해 분석한 결과, 병목은 **VLM 추론(decode)**이며, 클라이언트
  `page_batch_size=32`가 서빙 서버의 동시 처리 여력을 충분히 활용하지 못해 dead cross를
  유발하는 것으로 확인됐다.
- vLLM 서버 로그 분석상 KV cache·큐잉은 병목이 아니었고(사용률 최대 3.6%, 대기 0),
  동시성 상한은 CUDA graph(256)가 결정. → `page_batch_size`/`max-num-seqs` 상향이 해법.

## 변경 사항

### 1. 파이프라인 시간 프로파일링 계측 (분석 핵심)
- **`docling/utils/profiling.py`**: 단계별 타이밍 요약 출력 기능 신설.
  - `ProfilingItem.wall_clock()` — 동시 실행(per-page) 구간의 `[start, start+elapsed]`
    **합집합(union)**을 계산해, 합산 시 부풀려지는 `total(s)`를 실제 경과시간으로 환산.
  - `_FLOW_TREE` 계층 + `_render_flow_tree()` — 부모-자식이 중복 없이 합산되는 흐름 트리 렌더.
  - `log_profiling_summary()` — 단계별 표(total/wall/%pipe/avg/p95) + 흐름 트리 로깅.
  - 전체가 `settings.debug.profile_pipeline_timings` 게이트(=`DOCLING_DEBUG__PROFILE_PIPELINE_TIMINGS=true`),
    꺼져 있으면 완전 no-op.
- **`docling/document_converter.py`**: 변환 완료 후 `log_profiling_summary()` 호출.
- **`docling/models/genos_dots_ocr_layout_model.py`**:
  - dotsocr 하위 단계 계측 — `dotsocr_vlm_call` / `dotsocr_parse` / `dotsocr_postprocess` /
    `dotsocr_table_build`, 그리고 ThreadPoolExecutor 전체를 감싸는 `dotsocr_layout_wallclock`.
  - 워커 스레드에서 안전하게 누적하는 `_record_stage_elapsed()` 헬퍼(키 사전 생성 + atomic append).
  - VLM `usage`(prompt/completion/total tokens) 로깅 추가, `call_vlm_server()` 반환을
    `(content, usage)` 튜플로 변경.
- **`docling/pipeline/standard_pdf_pipeline.py`**: page/element 이미지 생성 구간을
  `doc_assemble_page_images` / `doc_assemble_element_images` TimeRecorder로 계측.

### 2. dots.ocr `page_batch_size` 32 → 128 (성능 최적화)
- batch sweep 테스트로 최적값 확인(100p 기준 32→128 **약 28% 단축**, 43.08s).
- facade 3종(`convert/intelligent/parser_processor.py`) 폴백 기본값 32→128.
- config yaml 6개(`resource/`, `resource_dev/` × convert/intelligent/parser) `page_batch_size` 32→128.
- gitbook 문서 3종 기본값/설명 갱신.
- **vLLM 서버** `--max-num-seqs` 32→256 권장(README), 근거 문서
  **`genon/dotsocr_vllm_max_num_seqs.md`** 신설(256 = CUDA graph capture 상한 근거).

## 영향 범위 / 호환성

- 프로파일링은 `profile_pipeline_timings`가 꺼져 있으면(기본값) **완전 no-op** — 운영 동작·출력 무변경.
- `call_vlm_server()` 반환 시그니처 변경(`str` → `tuple[str, dict|None]`)은 내부 호출부만 영향,
  같은 커밋에서 함께 수정.
- `page_batch_size`는 yaml 값이 우선이며, **미설정/무효 시 폴백만** 32→128로 변경(하위 호환).
- 시각화 변경은 디버그 경로 전용, 운영 산출물에 영향 없음.

## 기본값 / 권장값

| 항목 | 이전 | 변경 |
|---|---|---|
| `page_batch_size` 폴백 | 32 | **128** |
| vLLM `--max-num-seqs`(서버) | 32 | **256** |
| `profile_pipeline_timings` | — | 기본 off (`DOCLING_DEBUG__PROFILE_PIPELINE_TIMINGS=true`로 on) |

## 테스트

- batch sweep 실측(`shkim_labs/result_20260612_01/time.md`): 100p batch 8~128, 200p batch 128/259.
  128에서 100p **43.08s**(batch 32 대비 약 28% 단축), v1.3.8 대비 격차 1.7배→1.16배로 축소.
- `profile_pipeline_timings=true`로 변환 시 단계별 표 + 흐름 트리가 정상 출력됨을 확인.
- VLM `usage` 토큰 로그 출력 확인.

## 변경 파일

- `docling/document_converter.py`
- `docling/utils/profiling.py`
- `docling/models/genos_dots_ocr_layout_model.py`
- `docling/models/layout_model.py`
- `docling/pipeline/standard_pdf_pipeline.py`
- `genon/preprocessor/facade/{convert,intelligent,parser}_processor.py`
- `genon/preprocessor/facade/gitbook_doc/{convert,intelligent,parser}_processor.md`
- `genon/preprocessor/resource{,_dev}/{convert,intelligent,parser}_processor_config.yaml`
- `genon/README.md`
- `genon/dotsocr_vllm_max_num_seqs.md` (신규)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profiling summary logging for document conversion performance monitoring
  * Enhanced debug visualization with cluster ordering indicators

* **Performance**
  * Increased page batch size from 32 to 128 for improved processing throughput
  * Extended pipeline stage timing instrumentation for better performance insights

* **Documentation**
  * Updated vLLM serving configuration recommendations
  * Updated processor configuration documentation to reflect new batch size defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->