### PR TITLE
Feature/174 char base tokenizer

### DIFF
--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -200,14 +200,14 @@ def _resolve_default_attachment_config_path() -> str:
     return str(default_config)
 
 
-def _resolve_tokenizer(models_cfg: dict):
-    """models config 로부터 토크나이저를 결정한다.
+def _resolve_tokenizer(chunking_cfg: dict):
+    """chunking config 로부터 토크나이저를 결정한다.
 
     tokenizer_path 가 실제 존재하면 그 로컬 경로를, 없으면 tokenizer_id(HF) 로 폴백한다
     (외부 네트워크 차단 환경 대비). config 미지정 시 기본값은 현행 하드코딩 값과 동일.
     """
-    local = models_cfg.get("tokenizer_path") or _DEFAULT_TOKENIZER_LOCAL_PATH
-    hf_id = models_cfg.get("tokenizer_id") or _DEFAULT_TOKENIZER_ID
+    local = chunking_cfg.get("tokenizer_path") or _DEFAULT_TOKENIZER_LOCAL_PATH
+    hf_id = chunking_cfg.get("tokenizer_id") or _DEFAULT_TOKENIZER_ID
     return Path(local) if Path(local).exists() else hf_id
 
 
@@ -847,19 +847,32 @@ class HybridChunker(BaseChunker):
         )
     max_tokens: int = _DEFAULT_HYBRID_MAX_TOKENS  # type: ignore[assignment]
     merge_peers: bool = True
+    # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
+    tokenizer_type: str = "char"
     _inner_chunker: HierarchicalChunker = HierarchicalChunker()
 
     @model_validator(mode="after")
     def _patch_tokenizer_and_max_tokens(self) -> Self:
-        self._tokenizer = (
-            self.tokenizer
-            if isinstance(self.tokenizer, PreTrainedTokenizerBase)
-            else AutoTokenizer.from_pretrained(self.tokenizer)
-        )
-        if self.max_tokens is None:
-            self.max_tokens = TypeAdapter(PositiveInt).validate_python(
-                self._tokenizer.model_max_length
+        mode = (self.tokenizer_type or "char").strip().lower()
+        if mode not in {"char", "huggingface"}:
+            _log.warning(f"[HybridChunker] Unknown tokenizer_type '{mode}', fallback to 'char'.")
+            mode = "char"
+        self.tokenizer_type = mode
+        if mode == "char":
+            # 문자 수 기반: HF 토크나이저 로드 불필요 (외부 모델 의존 제거)
+            self._tokenizer = None
+            if self.max_tokens is None:
+                self.max_tokens = _DEFAULT_HYBRID_MAX_TOKENS
+        else:
+            self._tokenizer = (
+                self.tokenizer
+                if isinstance(self.tokenizer, PreTrainedTokenizerBase)
+                else AutoTokenizer.from_pretrained(self.tokenizer)
             )
+            if self.max_tokens is None:
+                self.max_tokens = TypeAdapter(PositiveInt).validate_python(
+                    self._tokenizer.model_max_length
+                )
         return self
 
     def _count_text_tokens(self, text: Optional[Union[str, list[str]]]):
@@ -870,6 +883,8 @@ class HybridChunker(BaseChunker):
             for t in text:
                 total += self._count_text_tokens(t)
             return total
+        if self._tokenizer is None:   # 문자 수 기반
+            return len(text)
         return len(self._tokenizer.tokenize(text))
 
     class _ChunkLengthInfo(BaseModel):
@@ -879,6 +894,8 @@ class HybridChunker(BaseChunker):
 
     def _count_chunk_tokens(self, doc_chunk: DocChunk):
         ser_txt = self.serialize(chunk=doc_chunk)
+        if self._tokenizer is None:   # 문자 수 기반
+            return len(ser_txt)
         return len(self._tokenizer.tokenize(text=ser_txt))
 
     def _doc_chunk_length(self, doc_chunk: DocChunk):
@@ -955,8 +972,10 @@ class HybridChunker(BaseChunker):
         else:
             # 헤더/캡션을 제외하고 본문 텍스트에 할당 가능한 토큰 수 계산
             available_length = self.max_tokens - lengths.other_len
+            # char 모드는 문자 수 카운터 len 사용
+            counter = len if self._tokenizer is None else self._tokenizer
             sem_chunker = semchunk.chunkerify(
-                self._tokenizer, chunk_size=available_length
+                counter, chunk_size=available_length
             )
             if available_length <= 0:
                 warnings.warn(
@@ -1208,16 +1227,17 @@ class DocxProcessor:
             return chunks
 
         # hybrid
-        hybrid_max_tokens = _parse_optional_int(kwargs.get("hybrid_max_tokens"), "hybrid_max_tokens")
-        if hybrid_max_tokens is None or hybrid_max_tokens <= 0:
-            hybrid_max_tokens = _DEFAULT_HYBRID_MAX_TOKENS
+        hybrid_chunk_size = _parse_optional_int(kwargs.get("hybrid_chunk_size"), "hybrid_chunk_size")
+        if hybrid_chunk_size is None or hybrid_chunk_size <= 0:
+            hybrid_chunk_size = _DEFAULT_HYBRID_MAX_TOKENS
         hybrid_merge_peers = _parse_optional_bool(kwargs.get("hybrid_merge_peers"), "hybrid_merge_peers")
         if hybrid_merge_peers is None:
             hybrid_merge_peers = True
         chunker_kwargs = {
-            "max_tokens": hybrid_max_tokens,
+            "max_tokens": hybrid_chunk_size,
             "merge_peers": hybrid_merge_peers,
             "tokenizer": self._tokenizer,
+            "tokenizer_type": kwargs.get("hybrid_tokenizer_type", "char"),
         }
         hybrid_tokenizer = kwargs.get("hybrid_tokenizer_id")
         if hybrid_tokenizer:
@@ -1376,16 +1396,17 @@ class HwpProcessor:
             return chunks, page_chunk_counts
 
         # hybrid
-        hybrid_max_tokens = _parse_optional_int(kwargs.get("hybrid_max_tokens"), "hybrid_max_tokens")
-        if hybrid_max_tokens is None or hybrid_max_tokens <= 0:
-            hybrid_max_tokens = _DEFAULT_HYBRID_MAX_TOKENS
+        hybrid_chunk_size = _parse_optional_int(kwargs.get("hybrid_chunk_size"), "hybrid_chunk_size")
+        if hybrid_chunk_size is None or hybrid_chunk_size <= 0:
+            hybrid_chunk_size = _DEFAULT_HYBRID_MAX_TOKENS
         hybrid_merge_peers = _parse_optional_bool(kwargs.get("hybrid_merge_peers"), "hybrid_merge_peers")
         if hybrid_merge_peers is None:
             hybrid_merge_peers = True
         chunker_kwargs = {
-            "max_tokens": hybrid_max_tokens,
+            "max_tokens": hybrid_chunk_size,
             "merge_peers": hybrid_merge_peers,
             "tokenizer": self._tokenizer,
+            "tokenizer_type": kwargs.get("hybrid_tokenizer_type", "char"),
         }
         hybrid_tokenizer = kwargs.get("hybrid_tokenizer_id")
         if hybrid_tokenizer:
@@ -1512,10 +1533,9 @@ class DocumentProcessor:
         image_loader_cfg = _as_dict(loaders_cfg.get("image"))
         tabular_loader_cfg = _as_dict(loaders_cfg.get("tabular"))
         whisper_cfg = _as_dict(cfg.get("whisper"))
-        models_cfg = _as_dict(cfg.get("models"))
 
-        # 청킹용 토크나이저 (config 기반; 미지정 시 현행 기본값)
-        self._tokenizer = _resolve_tokenizer(models_cfg)
+        # 청킹용 토크나이저 (chunking config 기반; 미지정 시 현행 기본값)
+        self._tokenizer = _resolve_tokenizer(chunking_cfg)
 
         chunker_type = str(defaults_cfg.get("chunker_type", "recursive")).strip().lower()
         if chunker_type not in {"recursive", "hybrid"}:
@@ -1564,17 +1584,23 @@ class DocumentProcessor:
             recursive_token_cap = _RECURSIVE_CHUNK_SIZE_CAP
         recursive_tokenizer_id = str(recursive_chunk_cfg.get("tokenizer_id") or "").strip() or None
 
-        hybrid_max_tokens = _parse_optional_int(
-            hybrid_chunk_cfg.get("max_tokens"), "chunking.hybrid.max_tokens"
+        hybrid_chunk_size = _parse_optional_int(
+            hybrid_chunk_cfg.get("chunk_size"), "chunking.hybrid.chunk_size"
         )
-        if hybrid_max_tokens is None or hybrid_max_tokens <= 0:
-            hybrid_max_tokens = _DEFAULT_HYBRID_MAX_TOKENS
+        if hybrid_chunk_size is None or hybrid_chunk_size <= 0:
+            hybrid_chunk_size = _DEFAULT_HYBRID_MAX_TOKENS
         hybrid_merge_peers = _parse_optional_bool(
             hybrid_chunk_cfg.get("merge_peers"), "chunking.hybrid.merge_peers"
         )
         if hybrid_merge_peers is None:
             hybrid_merge_peers = True
         hybrid_tokenizer_id = str(hybrid_chunk_cfg.get("tokenizer_id") or "").strip() or None
+        hybrid_tokenizer_type = str(hybrid_chunk_cfg.get("tokenizer_type", "char")).strip().lower()
+        if hybrid_tokenizer_type not in {"char", "huggingface"}:
+            _log.warning(
+                f"[DocumentProcessor] Unknown chunking.hybrid.tokenizer_type '{hybrid_tokenizer_type}', fallback to 'char'."
+            )
+            hybrid_tokenizer_type = "char"
 
         image_ocr_languages = image_loader_cfg.get("ocr_languages", ["kor", "eng"])
         if isinstance(image_ocr_languages, (list, tuple, set)):
@@ -1616,9 +1642,10 @@ class DocumentProcessor:
             "recursive_chunk_overlap": recursive_chunk_overlap,
             "recursive_token_chunk_size_cap": recursive_token_cap,
             "recursive_tokenizer_id": recursive_tokenizer_id,
-            "hybrid_max_tokens": hybrid_max_tokens,
+            "hybrid_chunk_size": hybrid_chunk_size,
             "hybrid_merge_peers": hybrid_merge_peers,
             "hybrid_tokenizer_id": hybrid_tokenizer_id,
+            "hybrid_tokenizer_type": hybrid_tokenizer_type,
             "image_ocr_languages": image_ocr_languages,
             "tabular_encoding_detect_sample_bytes": tabular_sample_bytes,
             "whisper_url": str(

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -766,14 +766,14 @@ _DEFAULT_TOKENIZER_LOCAL_PATH = "/models/doc_parser_models/sentence-transformers
 _DEFAULT_TOKENIZER_ID = "sentence-transformers/all-MiniLM-L6-v2"
 
 
-def _resolve_tokenizer(models_cfg: dict):
-    """models config 로부터 토크나이저를 결정한다.
+def _resolve_tokenizer(chunking_cfg: dict):
+    """chunking config 로부터 토크나이저를 결정한다.
 
     tokenizer_path 가 실제 존재하면 그 로컬 경로를, 없으면 tokenizer_id(HF) 로 폴백한다
     (외부 네트워크 차단 환경 대비). config 미지정 시 기본값은 현행 하드코딩 값과 동일.
     """
-    local = models_cfg.get("tokenizer_path") or _DEFAULT_TOKENIZER_LOCAL_PATH
-    hf_id = models_cfg.get("tokenizer_id") or _DEFAULT_TOKENIZER_ID
+    local = chunking_cfg.get("tokenizer_path") or _DEFAULT_TOKENIZER_LOCAL_PATH
+    hf_id = chunking_cfg.get("tokenizer_id") or _DEFAULT_TOKENIZER_ID
     return Path(local) if Path(local).exists() else hf_id
 
 
@@ -837,6 +837,8 @@ class GenosSmartChunker(BaseChunker):
         )
     max_tokens: int = 1024
     merge_peers: bool = True
+    # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
+    tokenizer_type: str = "char"
 
     # _inner_chunker: BaseChunker = None
     _tokenizer: PreTrainedTokenizerBase = None
@@ -845,11 +847,20 @@ class GenosSmartChunker(BaseChunker):
     @model_validator(mode="after")
     def _initialize_components(self) -> Self:
         # 토크나이저 초기화
-        self._tokenizer = (
-            self.tokenizer
-            if isinstance(self.tokenizer, PreTrainedTokenizerBase)
-            else AutoTokenizer.from_pretrained(self.tokenizer)
-        )
+        mode = (self.tokenizer_type or "char").strip().lower()
+        if mode not in {"char", "huggingface"}:
+            _log.warning(f"[GenosSmartChunker] Unknown tokenizer_type '{mode}', fallback to 'char'.")
+            mode = "char"
+        self.tokenizer_type = mode
+        if mode == "char":
+            # 문자 수 기반: HF 토크나이저 로드 불필요 (외부 모델 의존 제거)
+            self._tokenizer = None
+        else:
+            self._tokenizer = (
+                self.tokenizer
+                if isinstance(self.tokenizer, PreTrainedTokenizerBase)
+                else AutoTokenizer.from_pretrained(self.tokenizer)
+            )
         return self
 
     def preprocess(self, dl_doc: DLDocument, **kwargs: Any) -> Iterator[BaseChunk]:
@@ -981,6 +992,9 @@ class GenosSmartChunker(BaseChunker):
         """텍스트의 토큰 수 계산 (안전한 분할 처리)"""
         if not text:
             return 0
+
+        if self._tokenizer is None:   # 문자 수 기반
+            return len(text)
 
         # 텍스트를 더 작은 단위로 분할하여 계산
         max_chunk_length = 300  # 더 안전한 길이로 설정
@@ -1149,8 +1163,9 @@ class GenosSmartChunker(BaseChunker):
             return [table_text]
 
         # 단순히 토큰 수 기준으로 텍스트 분할
-        # semchunk 사용하여 토큰 제한에 맞게 분할
-        chunker = semchunk.chunkerify(self._tokenizer, chunk_size=max_tokens)
+        # semchunk 사용하여 토큰 제한에 맞게 분할 (char 모드는 문자 수 카운터 len 사용)
+        counter = len if self._tokenizer is None else self._tokenizer
+        chunker = semchunk.chunkerify(counter, chunk_size=max_tokens)
         chunks = chunker(table_text)
         return chunks if chunks else [table_text]
 
@@ -1740,10 +1755,22 @@ class DocumentProcessor:
         layout_cfg = _as_dict(cfg.get("layout"))
         pdf_cfg = _as_dict(cfg.get("pdf_pipeline"))
         models_cfg = _as_dict(cfg.get("models"))
+        chunking_cfg = _as_dict(cfg.get("chunking"))
         ec = EnrichmentConfig.from_raw(cfg.get("enrichment"), self._config_dir, parent_cfg=cfg)
 
-        # 청킹용 토크나이저 (config 기반; 미지정 시 현행 기본값)
-        self._tokenizer = _resolve_tokenizer(models_cfg)
+        # 청킹용 토크나이저 (chunking config 기반; 미지정 시 현행 기본값)
+        self._tokenizer = _resolve_tokenizer(chunking_cfg)
+
+        # 토큰 수 계산 방식 (chunking 섹션). "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
+        self._tokenizer_type = str(chunking_cfg.get("tokenizer_type", "char")).strip().lower()
+        if self._tokenizer_type not in {"char", "huggingface"}:
+            _log.warning(
+                f"[DocumentProcessor] Unknown chunking.tokenizer_type '{self._tokenizer_type}', fallback to 'char'."
+            )
+            self._tokenizer_type = "char"
+
+        # 청크 최대 크기(GenosSmartChunker.max_tokens) 기본값. kwargs 의 chunk_size 가 우선.
+        self._chunk_size = _parse_optional_int(chunking_cfg.get("chunk_size"), "chunking.chunk_size")
 
         # OCR 엔드포인트는 ocr.paddle.ocr_endpoint 가 정식 위치.
         # 구버전 호환: ocr.ocr_endpoint(상위) / 최상위 ocr_endpoint 도 폴백으로 인식.
@@ -2181,10 +2208,15 @@ class DocumentProcessor:
         return chunks
 
     def split_documents(self, documents: DoclingDocument, **kwargs: dict) -> List[DocChunk]:
+        # chunk_size 우선순위: kwargs > yaml(chunking.chunk_size) > 0
+        chunk_size = _parse_optional_int(kwargs.get('chunk_size'), 'chunk_size')
+        if chunk_size is None:
+            chunk_size = self._chunk_size
         chunker: GenosSmartChunker = GenosSmartChunker(
-            max_tokens = kwargs.get('max_chunk_size', 0),
+            max_tokens = chunk_size if chunk_size is not None else 0,
             merge_peers = True,
             tokenizer = self._tokenizer,
+            tokenizer_type = self._tokenizer_type,
         )
 
         chunks: List[DocChunk] = list(chunker.chunk(dl_doc=documents, **kwargs))

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -1593,7 +1593,8 @@ class GenosSmartChunker(BaseChunker):
                 text = "\n".join(g["texts"])
                 headings = self._extract_used_headers(g["h_short"]) or []
                 header_line = ("HEADER: " + ", ".join(headings) + "\n") if headings else ""
-                return len(header_line) + len(text)
+                # char 모드면 문자 수, huggingface 모드면 토큰 수로 산정 (max_tokens 단위와 일치)
+                return self._count_tokens(header_line + text)
 
             def _merge(a, b):
                 return {

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -1526,12 +1526,21 @@ class GenosSmartChunker(BaseChunker):
             sections_with_text.pop(i + 1)
 
         # ================================================================
-        # 4단계: 토큰 기준 병합
+        # 4단계: 토큰 기준 병합 (1차 — 섹션 구조 경계 기준 그룹 생성)
         # ================================================================
 
-        result_chunks = []
+        groups: list[dict] = []
         merged_texts, merged_items = [], []
         merged_header_infos, merged_header_short_infos = [], []
+
+        def flush_group():
+            if merged_texts:
+                groups.append({
+                    "texts": list(merged_texts),
+                    "items": list(merged_items),
+                    "h_infos": list(merged_header_infos),
+                    "h_short": list(merged_header_short_infos),
+                })
 
         for text, items, header_infos, header_short_infos in sections_with_text:
 
@@ -1557,15 +1566,13 @@ class GenosSmartChunker(BaseChunker):
 
             # 새로운 청크 생성
             if b_new_chunk:
-                cur_chunk = get_current_chunk(doc_chunk, merged_texts, merged_header_short_infos, merged_items)
-                if cur_chunk:
-                    result_chunks.append(cur_chunk)
+                flush_group()
 
                 # 새로운 병합 시작
                 merged_texts = [text]
-                merged_items = items
-                merged_header_infos = header_infos
-                merged_header_short_infos = header_short_infos
+                merged_items = list(items)
+                merged_header_infos = list(header_infos)
+                merged_header_short_infos = list(header_short_infos)
             else:
                 # 현재 섹션 병합
                 merged_texts.append(text)
@@ -1574,9 +1581,45 @@ class GenosSmartChunker(BaseChunker):
                 merged_header_short_infos.extend(header_short_infos)
 
         # 마지막 병합된 items 처리
-        cur_chunk = get_current_chunk(doc_chunk, merged_texts, merged_header_short_infos, merged_items)
-        if cur_chunk:
-            result_chunks.append(cur_chunk)
+        flush_group()
+
+        # ================================================================
+        # 5단계: chunk_size 한도 내 인접 그룹 greedy 병합
+        #   1차 결과(구조 경계 기준 그룹)를 순서대로, 합산 크기가 chunk_size 이하인 동안
+        #   인접 그룹끼리 결합한다. (크기는 HEADER 라인 포함 최종 텍스트 기준)
+        # ================================================================
+        if self.max_tokens > 0 and groups:
+            def _size(g):
+                text = "\n".join(g["texts"])
+                headings = self._extract_used_headers(g["h_short"]) or []
+                header_line = ("HEADER: " + ", ".join(headings) + "\n") if headings else ""
+                return len(header_line) + len(text)
+
+            def _merge(a, b):
+                return {
+                    "texts": a["texts"] + b["texts"],
+                    "items": a["items"] + b["items"],
+                    "h_infos": a["h_infos"] + b["h_infos"],
+                    "h_short": a["h_short"] + b["h_short"],
+                }
+
+            merged_groups = [groups[0]]
+            for g in groups[1:]:
+                cand = _merge(merged_groups[-1], g)
+                if _size(cand) <= self.max_tokens:
+                    merged_groups[-1] = cand
+                else:
+                    merged_groups.append(g)
+            groups = merged_groups
+
+        # ================================================================
+        # 6단계: 최종 DocChunk 생성
+        # ================================================================
+        result_chunks = []
+        for g in groups:
+            cur_chunk = get_current_chunk(doc_chunk, g["texts"], g["h_short"], g["items"])
+            if cur_chunk:
+                result_chunks.append(cur_chunk)
 
         return result_chunks
 

--- a/genon/preprocessor/facade/gitbook_doc/attachment_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/attachment_processor.md
@@ -109,6 +109,11 @@ defaults:
   save_images: true
 
 chunking:
+  # 청킹용 토크나이저 기본값(hybrid 경로 등). tokenizer_path 가 실제 존재하면 그 경로,
+  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
+  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
+  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
+
   # pdf/txt/md/ppt 등 일반 텍스트 splitter 기본값
   generic:
     chunk_size: 1000
@@ -125,8 +130,10 @@ chunking:
 
   # hwp/hwpx/docx + hybrid 분기 기본값
   hybrid:
+    # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
+    tokenizer_type: "char"
     tokenizer_id: ""
-    max_tokens: 10000000
+    chunk_size: 10000000
     merge_peers: true
 
 loaders:
@@ -169,6 +176,13 @@ whisper:
 | `dump_sdk_output` | `false` | SDK 원본 출력 덤프 여부. `use_hwp_sdk=true` 일 때만 유효 |
 | `save_images` | `true` | hwp/hwpx 처리 시 추출 이미지 저장 여부 |
 
+#### chunking (청킹용 토크나이저 기본값)
+
+| 키 | 기본값 | 설명 |
+|----|--------|------|
+| `tokenizer_path` | `/models/...all-MiniLM-L6-v2` | 청킹용 토크나이저 로컬 경로(hybrid `huggingface` 모드 및 recursive 60K 토큰 cap 계산에 사용). 경로가 실제 존재하면 그 경로 사용 |
+| `tokenizer_id` | `sentence-transformers/all-MiniLM-L6-v2` | `tokenizer_path` 가 없을 때 폴백할 HF ID (외부 네트워크 차단 환경 대비) |
+
 #### chunking.generic (pdf/txt/md/ppt 등 일반 splitter)
 
 | 키 | 기본값 | 설명 |
@@ -189,9 +203,10 @@ whisper:
 
 | 키 | 기본값 | 설명 |
 |----|--------|------|
-| `tokenizer_id` | `""` | 비우면 로컬 경로 우선, 없으면 HF ID로 fallback |
-| `max_tokens` | `10000000` | 청크당 최대 토큰. 기본값은 사실상 토큰 제한 없음 → hybrid를 레이아웃 기반 병합 도구로만 사용. 0 이하/누락 시 코드 fallback(`1e30`) |
-| `merge_peers` | `true` | 같은 제목/캡션을 가진 작은 청크를 토큰 제한 내에서 병합 |
+| `tokenizer_type` | `"char"` | 토큰 수 계산 방식. `char`(기본)=문자 수 기준(HF 토크나이저 미로드, 외부 모델 의존 없음) / `huggingface`=HF 토크나이저 기준. 그 외 값은 `char`로 폴백 |
+| `tokenizer_id` | `""` | `huggingface` 모드에서만 사용. 비우면 chunking 상위 토크나이저(로컬 경로 우선, 없으면 HF ID)로 fallback |
+| `chunk_size` | `10000000` | 청크당 최대 크기. `char` 모드면 문자 수, `huggingface` 모드면 토큰 수. 기본값은 사실상 제한 없음 → hybrid를 레이아웃 기반 병합 도구로만 사용. 0 이하/누락 시 코드 fallback(`1e30`) |
+| `merge_peers` | `true` | 같은 제목/캡션을 가진 작은 청크를 크기 제한 내에서 병합 |
 
 #### loaders.image
 
@@ -223,7 +238,7 @@ whisper:
 #### chunker_type: recursive vs hybrid
 
 - **recursive (기본)**: `DoclingDocument`를 markdown으로 export한 뒤 `RecursiveCharacterTextSplitter`로 **문자 단위** 분할합니다. 단락/헤딩/표 경계의 줄바꿈이 보존되어 문장 중간에서 잘리는 현상이 적고, 페이지 단위 정확도를 가집니다. 대부분의 경우 권장됩니다.
-- **hybrid**: 레이아웃 계층 구조를 유지하며 **토큰 수 기반**으로 청크를 조절합니다. 기본 `max_tokens=10000000`은 사실상 토큰 제한이 없는 수준이라, 이 전처리기에서는 주로 레이아웃 기반 병합 도구로 동작합니다. 청크 단위 bbox 정확도가 필요할 때 사용합니다.
+- **hybrid**: 레이아웃 계층 구조를 유지하며 청크 크기 기반으로 청크를 조절합니다. 크기 계산 방식은 `chunking.hybrid.tokenizer_type`(기본 `char`=문자 수 / `huggingface`=HF 토큰 수)으로 선택합니다. 기본 `chunk_size=10000000`은 사실상 제한이 없는 수준이라, 이 전처리기에서는 주로 레이아웃 기반 병합 도구로 동작합니다. 청크 단위 bbox 정확도가 필요할 때 사용합니다.
 - **60K 토큰 cap**: recursive 분기에서는 chunk_size와 무관하게 한 청크가 `token_chunk_size_cap`(기본 60000) 토큰을 넘으면 토큰 단위로 강제 재분할됩니다. 기본 8192자 청크에서는 보통 트리거되지 않으며, 큰 chunk_size를 지정했을 때의 안전망입니다.
 
 ### 3.3 런타임 kwargs override
@@ -261,7 +276,8 @@ defaults:
   chunker_type: "hybrid"
 chunking:
   hybrid:
-    max_tokens: 1000     # 실제 토큰 제한을 두려면 작은 값 지정
+    tokenizer_type: "char"  # char=문자 수 기준 | huggingface=HF 토큰 수 기준
+    chunk_size: 1000        # 실제 분할 제한을 두려면 작은 값 지정(char 모드면 문자 수)
     merge_peers: true
 ```
 

--- a/genon/preprocessor/facade/gitbook_doc/convert_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/convert_processor.md
@@ -179,6 +179,17 @@ pdf_pipeline:
   generate_picture_images: true
   table_structure_mode: "accurate"   # "accurate"(default) | "fast"
 
+# 청킹(GenosSmartChunker) 설정
+chunking:
+  # 청크 최대 크기. char 모드면 "최대 문자 수", huggingface 모드면 "최대 토큰 수".
+  # 우선순위: 호출 kwargs 의 chunk_size > 아래 chunk_size. 0 = 크기 기반 분할 안 함.
+  chunk_size: 0
+  # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
+  tokenizer_type: "char"
+  # 청킹용 토크나이저(huggingface 모드에서만 사용). tokenizer_path 존재 시 그 경로, 없으면 tokenizer_id(HF) 폴백
+  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
+  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
+
 # enrichment — {이름: {옵션}} 형식의 list.
 # 비활성화: ① 항목 삭제  ② 항목 주석 처리  ③ enable: false
 # 모든 url 의 <ENRICHMENT_SERVING_ID> 는 Genos에 등록한 모델서빙 ID로 변경 필요.
@@ -670,9 +681,10 @@ filename: 보고서.pdf
 | **표 분석 속도 우선** | `pdf_pipeline.table_structure_mode: "fast"` |
 | **메모리 절감** | `pdf_pipeline.generate_page_images: false`, `images_scale: 1` |
 | **레이아웃 인프라 없음** | `layout.layout_model_type: "docling_layout"` |
-| **청크 토큰 크기 조정** | 코드의 `GenosSmartChunker` `max_tokens` 조정 (운영 기준 약 2000). config 노브가 아니므로 [부록 E](#부록-코드-내부-상세) 참고 |
+| **청크 크기 조정** | `chunking.chunk_size` (yaml) 또는 호출 kwargs `chunk_size`. 우선순위 kwargs > yaml > 0 |
+| **청크 크기 계산 방식** | `chunking.tokenizer_type`: `char`(기본)=문자 수 기준 / `huggingface`=HF 토큰 수 기준 |
 
-> **청크 토큰**: convert 경로의 청크 크기는 `split_documents()` → `GenosSmartChunker(max_tokens=...)` 로 결정됩니다. 현재 facade 구현에서는 호출 kwargs(`max_chunk_size`) 또는 운영 기준 약 2000 토큰을 사용합니다. 향후 config 노브로 노출될 예정이며, 지금은 코드 변경 사항입니다.
+> **청크 크기**: convert 경로의 청크 크기는 `split_documents()` → `GenosSmartChunker(max_tokens=...)` 로 결정됩니다. 값은 호출 kwargs `chunk_size` 가 우선이고, 없으면 yaml `chunking.chunk_size`, 둘 다 없으면 `0`(크기 기반 분할 안 함)입니다. 크기 단위는 `chunking.tokenizer_type` 으로 정해집니다(`char`=문자 수, `huggingface`=HF 토큰 수). char 모드에서는 HF 토크나이저를 로드하지 않습니다.
 
 ---
 
@@ -808,7 +820,7 @@ class GenOSVectorMeta(BaseModel):
 | `created_date` 가 0 | 추출/본문 스캔 모두 실패 또는 날짜 포맷 미인식 | `enrichment.metadata.field_transforms`, 프롬프트 `output_fields` |
 | 메모리 부족(OOM) | 이미지 생성·배율 과다 | `pdf_pipeline.generate_page_images: false`, `images_scale` 하향 |
 | 표 분석 느림 | accurate 모드 | `pdf_pipeline.table_structure_mode: "fast"` |
-| 청크가 너무 큼/작음 | `GenosSmartChunker.max_tokens` | (코드 노브, [부록 E](#부록-코드-내부-상세) 참고) |
+| 청크가 너무 큼/작음 | `chunking.chunk_size`(yaml) 또는 kwargs `chunk_size` | 우선순위 kwargs > yaml > 0. 단위는 `chunking.tokenizer_type`(char=문자/huggingface=토큰) |
 | `chunk length is 0` | 청크 미생성(빈 문서/파싱 실패) | 입력 파일·OCR·레이아웃 점검 |
 
 ---
@@ -878,13 +890,14 @@ else:  # .pdf / .docx / .pptx 등 Docling 경로
 
 ```python
 class GenosSmartChunker(BaseChunker):
-    tokenizer = "/models/.../sentence-transformers-all-MiniLM-L6-v2"  # 토큰 카운팅용 (없으면 HF fallback)
-    max_tokens: int = 1024        # 클래스 기본값. split_documents() 호출 시 max_chunk_size kwargs 로 오버라이드(운영 기준 약 2000)
+    tokenizer = "/models/.../sentence-transformers-all-MiniLM-L6-v2"  # huggingface 모드 토큰 카운팅용 (없으면 HF fallback)
+    max_tokens: int = 1024        # 클래스 기본값. split_documents() 에서 chunk_size(kwargs>yaml>0)로 오버라이드
+    tokenizer_type: str = "char"  # "char"(기본)=문자 수 기준 | "huggingface"=HF 토큰 수 기준
     merge_peers: bool = True
     merge_list_items: bool = True
 ```
 
-`split_documents()` 는 `GenosSmartChunker(max_tokens=kwargs.get('max_chunk_size', 0), merge_peers=True)` 로 청커를 만들고, 청크별 시작 페이지 카운트를 누적합니다. `preprocess()` 로 모든 아이템+헤더를 1개의 DocChunk 로 수집한 뒤 `_split_document_by_tokens()` 의 4단계(+2.5 보정) 파이프라인으로 분할합니다([4.3](#43-genosbucketchunker-전략)).
+`split_documents()` 는 청크 크기를 `chunk_size = kwargs.get('chunk_size')` (없으면 yaml `chunking.chunk_size`, 둘 다 없으면 `0`)로 정하고 `GenosSmartChunker(max_tokens=chunk_size, tokenizer_type=<chunking.tokenizer_type>, merge_peers=True)` 로 청커를 만듭니다. 청킹 토크나이저 경로/계산 방식은 yaml `chunking` 섹션(`tokenizer_path`/`tokenizer_id`/`tokenizer_type`)에서 읽습니다. `preprocess()` 로 모든 아이템+헤더를 1개의 DocChunk 로 수집한 뒤 `_split_document_by_tokens()` 의 4단계(+2.5 보정) 파이프라인으로 분할합니다([4.3](#43-genosbucketchunker-전략)).
 
 ### F. `compose_vectors` 메타데이터 병합
 

--- a/genon/preprocessor/facade/gitbook_doc/intelligent_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/intelligent_processor.md
@@ -185,6 +185,17 @@ pdf_pipeline:
   generate_picture_images: true   # false 면 이미지 설명 enrichment 비활성화됨
   table_structure_mode: "accurate" # "accurate"(default) | "fast"
 
+# 청킹(GenosSmartChunker) 설정
+chunking:
+  # 청크 최대 크기. char 모드면 "최대 문자 수", huggingface 모드면 "최대 토큰 수".
+  # 우선순위: 호출 kwargs 의 chunk_size > 아래 chunk_size. 0 = 크기 기반 분할 안 함(순수 섹션 분할).
+  chunk_size: 0
+  # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
+  tokenizer_type: "char"
+  # 청킹용 토크나이저(huggingface 모드에서만 사용). tokenizer_path 존재 시 그 경로, 없으면 tokenizer_id(HF) 폴백
+  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
+  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
+
 # enrichment: {이름: {옵션}} 형식의 list.
 # 비활성화: ① 항목 삭제  ② 항목 주석 처리  ③ enable: false
 # url 의 <ENRICHMENT_SERVING_ID> 는 Genos에 등록한 모델서빙 ID로 변경. api_key 는 k8s 내부 통신 시 불필요.
@@ -587,7 +598,7 @@ filename: 보고서.pdf
 
 ### 3.7 청킹 설정
 
-intelligent 는 `GenosSmartChunker(max_tokens=0)` 으로 **순수 섹션 분할**을 수행합니다. `max_tokens=0` 은 "토큰 기반 병합·분할을 하지 않고 각 섹션을 독립 청크로 유지"한다는 의미입니다.
+intelligent 는 `GenosSmartChunker` 로 섹션 분할을 수행합니다. 청크 크기는 yaml `chunking.chunk_size`(또는 호출 kwargs `chunk_size`)로 지정하며, `chunk_size=0` 이면 **순수 섹션 분할**("크기 기반 병합·분할을 하지 않고 각 섹션을 독립 청크로 유지")이 됩니다.
 
 ```
 Bucket = 바구니(하나의 청크), max_tokens = 바구니 크기, 섹션 = 담을 물건
@@ -609,16 +620,17 @@ max_tokens=2000 (convert):          max_tokens=0 (intelligent):
 
 > `max_tokens=0` 이면 "초과 청크 균등 분할"(캡션/표내그림 조정 포함)도 스킵됩니다 — 아무리 긴 섹션도 자르지 않아 표·조항이 중간에 끊기지 않습니다.
 
-**값 변경 (코드 레벨 보조 튜닝)** — `max_tokens` 는 현재 YAML 노브가 아니라 `split_documents()` 코드에 있습니다. 조정이 필요하면:
+**값 변경 (YAML 노브)** — 청크 크기는 yaml `chunking.chunk_size` 또는 호출 kwargs `chunk_size` 로 지정합니다(우선순위 kwargs > yaml > 0). 크기 단위는 `chunking.tokenizer_type` 으로 정해집니다(`char`=문자 수 기준(기본, HF 토크나이저 미로드) / `huggingface`=HF 토큰 수 기준).
 
-```python
-# intelligent_processor.py — split_documents()
-chunker = GenosSmartChunker(max_tokens=0, merge_peers=True)  # ← 0 → 512/1024/2000 등으로 변경
+```yaml
+chunking:
+  chunk_size: 0           # 0=순수 섹션 분할 / 512·1024·2000 등=크기 기반 병합
+  tokenizer_type: "char"  # char=문자 수 기준 | huggingface=HF 토큰 수 기준
 ```
 
-| 값 | 동작 | 권장 |
+| `chunk_size` | 동작 | 권장 |
 |----|------|------|
-| `0` | 각 섹션 독립 청크 (기본) | 법률/규정, 정밀 검색 RAG |
+| `0` | 각 섹션 독립 청크 (순수 섹션 분할) | 법률/규정, 정밀 검색 RAG |
 | `512` | 작은 섹션 병합 | 짧은 조항 多 |
 | `1024` | 중간 병합 | 일반 RAG |
 | `2000` | 큰 단위 병합 | 문맥 연속성 중시 |
@@ -828,7 +840,7 @@ async def __call__(self, request, file_path, **kwargs):
     document = document._with_pictures_refs(...)
     document = self.enrichment(document, **kwargs)
     # 빈 문서면 더미 "." 삽입
-    chunks = self.split_documents(document, **kwargs)   # GenosSmartChunker(max_tokens=0)
+    chunks = self.split_documents(document, **kwargs)   # GenosSmartChunker(max_tokens=chunking.chunk_size, 기본 0)
     if len(chunks) < 1: raise GenosServiceException(1, "chunk length is 0")
     return await self.compose_vectors(document, chunks, file_path, request, converted_pdf_path=..., **kwargs)
 ```

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -783,14 +783,14 @@ _DEFAULT_TOKENIZER_LOCAL_PATH = "/models/doc_parser_models/sentence-transformers
 _DEFAULT_TOKENIZER_ID = "sentence-transformers/all-MiniLM-L6-v2"
 
 
-def _resolve_tokenizer(models_cfg: dict):
-    """models config 로부터 토크나이저를 결정한다.
+def _resolve_tokenizer(chunking_cfg: dict):
+    """chunking config 로부터 토크나이저를 결정한다.
 
     tokenizer_path 가 실제 존재하면 그 로컬 경로를, 없으면 tokenizer_id(HF) 로 폴백한다
     (외부 네트워크 차단 환경 대비). config 미지정 시 기본값은 현행 하드코딩 값과 동일.
     """
-    local = models_cfg.get("tokenizer_path") or _DEFAULT_TOKENIZER_LOCAL_PATH
-    hf_id = models_cfg.get("tokenizer_id") or _DEFAULT_TOKENIZER_ID
+    local = chunking_cfg.get("tokenizer_path") or _DEFAULT_TOKENIZER_LOCAL_PATH
+    hf_id = chunking_cfg.get("tokenizer_id") or _DEFAULT_TOKENIZER_ID
     return Path(local) if Path(local).exists() else hf_id
 
 
@@ -814,6 +814,8 @@ class GenosSmartChunker(BaseChunker):
         )
     max_tokens: int = 1024
     merge_peers: bool = True
+    # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
+    tokenizer_type: str = "char"
 
     # _inner_chunker: BaseChunker = None
     _tokenizer: PreTrainedTokenizerBase = None
@@ -822,11 +824,20 @@ class GenosSmartChunker(BaseChunker):
     @model_validator(mode="after")
     def _initialize_components(self) -> Self:
         # 토크나이저 초기화
-        self._tokenizer = (
-            self.tokenizer
-            if isinstance(self.tokenizer, PreTrainedTokenizerBase)
-            else AutoTokenizer.from_pretrained(self.tokenizer)
-        )
+        mode = (self.tokenizer_type or "char").strip().lower()
+        if mode not in {"char", "huggingface"}:
+            _log.warning(f"[GenosSmartChunker] Unknown tokenizer_type '{mode}', fallback to 'char'.")
+            mode = "char"
+        self.tokenizer_type = mode
+        if mode == "char":
+            # 문자 수 기반: HF 토크나이저 로드 불필요 (외부 모델 의존 제거)
+            self._tokenizer = None
+        else:
+            self._tokenizer = (
+                self.tokenizer
+                if isinstance(self.tokenizer, PreTrainedTokenizerBase)
+                else AutoTokenizer.from_pretrained(self.tokenizer)
+            )
         return self
 
     def preprocess(self, dl_doc: DLDocument, **kwargs: Any) -> Iterator[BaseChunk]:
@@ -958,6 +969,9 @@ class GenosSmartChunker(BaseChunker):
         """텍스트의 토큰 수 계산 (안전한 분할 처리)"""
         if not text:
             return 0
+
+        if self._tokenizer is None:   # 문자 수 기반
+            return len(text)
 
         # 텍스트를 더 작은 단위로 분할하여 계산
         max_chunk_length = 300  # 더 안전한 길이로 설정
@@ -1141,8 +1155,9 @@ class GenosSmartChunker(BaseChunker):
             return [table_text]
 
         # 단순히 토큰 수 기준으로 텍스트 분할
-        # semchunk 사용하여 토큰 제한에 맞게 분할
-        chunker = semchunk.chunkerify(self._tokenizer, chunk_size=max_tokens)
+        # semchunk 사용하여 토큰 제한에 맞게 분할 (char 모드는 문자 수 카운터 len 사용)
+        counter = len if self._tokenizer is None else self._tokenizer
+        chunker = semchunk.chunkerify(counter, chunk_size=max_tokens)
         chunks = chunker(table_text)
         return chunks if chunks else [table_text]
 
@@ -1737,10 +1752,22 @@ class DocumentProcessor:
         layout_cfg = _as_dict(cfg.get("layout"))
         pdf_cfg = _as_dict(cfg.get("pdf_pipeline"))
         models_cfg = _as_dict(cfg.get("models"))
+        chunking_cfg = _as_dict(cfg.get("chunking"))
         ec = EnrichmentConfig.from_raw(cfg.get("enrichment"), self._config_dir, parent_cfg=cfg)
 
-        # 청킹용 토크나이저 (config 기반; 미지정 시 현행 기본값)
-        self._tokenizer = _resolve_tokenizer(models_cfg)
+        # 청킹용 토크나이저 (chunking config 기반; 미지정 시 현행 기본값)
+        self._tokenizer = _resolve_tokenizer(chunking_cfg)
+
+        # 토큰 수 계산 방식 (chunking 섹션). "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
+        self._tokenizer_type = str(chunking_cfg.get("tokenizer_type", "char")).strip().lower()
+        if self._tokenizer_type not in {"char", "huggingface"}:
+            _log.warning(
+                f"[DocumentProcessor] Unknown chunking.tokenizer_type '{self._tokenizer_type}', fallback to 'char'."
+            )
+            self._tokenizer_type = "char"
+
+        # 청크 최대 크기(GenosSmartChunker.max_tokens) 기본값. kwargs 의 chunk_size 가 우선.
+        self._chunk_size = _parse_optional_int(chunking_cfg.get("chunk_size"), "chunking.chunk_size")
 
         # OCR 엔드포인트는 ocr.paddle.ocr_endpoint 가 정식 위치.
         # 구버전 호환: ocr.ocr_endpoint(상위) / 최상위 ocr_endpoint 도 폴백으로 인식.
@@ -2146,10 +2173,15 @@ class DocumentProcessor:
         return self.load_documents_with_docling(file_path, **kwargs)
 
     def split_documents(self, documents: DoclingDocument, **kwargs: dict) -> List[DocChunk]:
+        # chunk_size 우선순위: kwargs > yaml(chunking.chunk_size) > 0
+        chunk_size = _parse_optional_int(kwargs.get('chunk_size'), 'chunk_size')
+        if chunk_size is None:
+            chunk_size = self._chunk_size
         chunker: GenosSmartChunker = GenosSmartChunker(
-            max_tokens = kwargs.get('max_chunk_size', 0),
+            max_tokens = chunk_size if chunk_size is not None else 0,
             merge_peers = True,
             tokenizer = self._tokenizer,
+            tokenizer_type = self._tokenizer_type,
         )
 
         chunks: List[DocChunk] = list(chunker.chunk(dl_doc=documents, **kwargs))

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -1518,12 +1518,21 @@ class GenosSmartChunker(BaseChunker):
             sections_with_text.pop(i + 1)
 
         # ================================================================
-        # 4단계: 토큰 기준 병합
+        # 4단계: 토큰 기준 병합 (1차 — 섹션 구조 경계 기준 그룹 생성)
         # ================================================================
 
-        result_chunks = []
+        groups: list[dict] = []
         merged_texts, merged_items = [], []
         merged_header_infos, merged_header_short_infos = [], []
+
+        def flush_group():
+            if merged_texts:
+                groups.append({
+                    "texts": list(merged_texts),
+                    "items": list(merged_items),
+                    "h_infos": list(merged_header_infos),
+                    "h_short": list(merged_header_short_infos),
+                })
 
         for text, items, header_infos, header_short_infos in sections_with_text:
 
@@ -1549,15 +1558,13 @@ class GenosSmartChunker(BaseChunker):
 
             # 새로운 청크 생성
             if b_new_chunk:
-                cur_chunk = get_current_chunk(doc_chunk, merged_texts, merged_header_short_infos, merged_items)
-                if cur_chunk:
-                    result_chunks.append(cur_chunk)
+                flush_group()
 
                 # 새로운 병합 시작
                 merged_texts = [text]
-                merged_items = items
-                merged_header_infos = header_infos
-                merged_header_short_infos = header_short_infos
+                merged_items = list(items)
+                merged_header_infos = list(header_infos)
+                merged_header_short_infos = list(header_short_infos)
             else:
                 # 현재 섹션 병합
                 merged_texts.append(text)
@@ -1566,9 +1573,45 @@ class GenosSmartChunker(BaseChunker):
                 merged_header_short_infos.extend(header_short_infos)
 
         # 마지막 병합된 items 처리
-        cur_chunk = get_current_chunk(doc_chunk, merged_texts, merged_header_short_infos, merged_items)
-        if cur_chunk:
-            result_chunks.append(cur_chunk)
+        flush_group()
+
+        # ================================================================
+        # 5단계: chunk_size 한도 내 인접 그룹 greedy 병합
+        #   1차 결과(구조 경계 기준 그룹)를 순서대로, 합산 크기가 chunk_size 이하인 동안
+        #   인접 그룹끼리 결합한다. (크기는 HEADER 라인 포함 최종 텍스트 기준)
+        # ================================================================
+        if self.max_tokens > 0 and groups:
+            def _size(g):
+                text = "\n".join(g["texts"])
+                headings = self._extract_used_headers(g["h_short"]) or []
+                header_line = ("HEADER: " + ", ".join(headings) + "\n") if headings else ""
+                return len(header_line) + len(text)
+
+            def _merge(a, b):
+                return {
+                    "texts": a["texts"] + b["texts"],
+                    "items": a["items"] + b["items"],
+                    "h_infos": a["h_infos"] + b["h_infos"],
+                    "h_short": a["h_short"] + b["h_short"],
+                }
+
+            merged_groups = [groups[0]]
+            for g in groups[1:]:
+                cand = _merge(merged_groups[-1], g)
+                if _size(cand) <= self.max_tokens:
+                    merged_groups[-1] = cand
+                else:
+                    merged_groups.append(g)
+            groups = merged_groups
+
+        # ================================================================
+        # 6단계: 최종 DocChunk 생성
+        # ================================================================
+        result_chunks = []
+        for g in groups:
+            cur_chunk = get_current_chunk(doc_chunk, g["texts"], g["h_short"], g["items"])
+            if cur_chunk:
+                result_chunks.append(cur_chunk)
 
         return result_chunks
 

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -1585,7 +1585,8 @@ class GenosSmartChunker(BaseChunker):
                 text = "\n".join(g["texts"])
                 headings = self._extract_used_headers(g["h_short"]) or []
                 header_line = ("HEADER: " + ", ".join(headings) + "\n") if headings else ""
-                return len(header_line) + len(text)
+                # char 모드면 문자 수, huggingface 모드면 토큰 수로 산정 (max_tokens 단위와 일치)
+                return self._count_tokens(header_line + text)
 
             def _merge(a, b):
                 return {

--- a/genon/preprocessor/resource/attachment_processor_config.yaml
+++ b/genon/preprocessor/resource/attachment_processor_config.yaml
@@ -21,6 +21,11 @@ defaults:
   save_images: true
 
 chunking:
+  # 청킹용 토크나이저 기본값(hybrid 경로 등). tokenizer_path 가 실제 존재하면 그 경로,
+  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
+  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
+  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
+
   # pdf/txt/md/ppt 등 일반 텍스트 splitter 기본값
   generic:
     chunk_size: 1000
@@ -37,8 +42,10 @@ chunking:
 
   # hwp/hwpx/docx + hybrid 분기 기본값
   hybrid:
+    # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
+    tokenizer_type: "char"
     tokenizer_id: ""
-    max_tokens: 10000000
+    chunk_size: 10000000
     merge_peers: true
 
 loaders:
@@ -64,10 +71,3 @@ whisper:
   chunk_overlap_ms: 300
   # 끝에 / 를 주면 디렉터리로 간주해 내부에 파일명 기준 하위 폴더 생성
   tmp_dir_prefix: "./tmp_audios_"
-
-# 모델 경로 (다운로드된 기본값 사용; 미지정 시 현행 동작 유지)
-models:
-  # 청킹용 토크나이저. tokenizer_path 가 실제 존재하면 그 경로,
-  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
-  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
-  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"

--- a/genon/preprocessor/resource/convert_processor_config.yaml
+++ b/genon/preprocessor/resource/convert_processor_config.yaml
@@ -123,11 +123,19 @@ enrichment:
       max_context_chars: 1500
       prompt_template_file: prompt_image_description_default.md
 
-# 모델 경로 (다운로드된 기본값 사용; 미지정 시 현행 동작 유지)
-models:
-  # 청킹용 토크나이저. tokenizer_path 가 실제 존재하면 그 경로,
+# 청킹(GenosSmartChunker) 설정
+chunking:
+  # 청크 최대 크기(max_tokens). char 모드면 "최대 문자 수", huggingface 모드면 "최대 토큰 수".
+  # 우선순위: 호출 kwargs 의 chunk_size > 아래 chunk_size. 0 = 토큰/문자 기반 분할 안 함.
+  chunk_size: 0
+  # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
+  tokenizer_type: "char"
+  # 청킹용 토크나이저(huggingface 모드에서만 사용). tokenizer_path 가 실제 존재하면 그 경로,
   # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
   tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
   tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
+
+# 모델 경로 (다운로드된 기본값 사용; 미지정 시 현행 동작 유지)
+models:
   # docling 모델(TableFormer 등) 로컬 경로. 비우면 docling 기본 캐시 사용(현행).
   artifacts_path: ""

--- a/genon/preprocessor/resource/intelligent_processor_config.yaml
+++ b/genon/preprocessor/resource/intelligent_processor_config.yaml
@@ -118,11 +118,19 @@ enrichment:
       max_context_chars: 1500
       prompt_template_file: prompt_image_description_default.md
 
-# 모델 경로 (다운로드된 기본값 사용; 미지정 시 현행 동작 유지)
-models:
-  # 청킹용 토크나이저. tokenizer_path 가 실제 존재하면 그 경로,
+# 청킹(GenosSmartChunker) 설정
+chunking:
+  # 청크 최대 크기(max_tokens). char 모드면 "최대 문자 수", huggingface 모드면 "최대 토큰 수".
+  # 우선순위: 호출 kwargs 의 chunk_size > 아래 chunk_size. 0 = 토큰/문자 기반 분할 안 함.
+  chunk_size: 0
+  # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
+  tokenizer_type: "char"
+  # 청킹용 토크나이저(huggingface 모드에서만 사용). tokenizer_path 가 실제 존재하면 그 경로,
   # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
   tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
   tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
+
+# 모델 경로 (다운로드된 기본값 사용; 미지정 시 현행 동작 유지)
+models:
   # docling 모델(TableFormer 등) 로컬 경로. 비우면 docling 기본 캐시 사용(현행).
   artifacts_path: ""

--- a/genon/preprocessor/resource_dev/attachment_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/attachment_processor_config.yaml
@@ -21,6 +21,11 @@ defaults:
   save_images: true
 
 chunking:
+  # 청킹용 토크나이저 기본값(hybrid 경로 등). tokenizer_path 가 실제 존재하면 그 경로,
+  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
+  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
+  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
+
   # pdf/txt/md/ppt 등 일반 텍스트 splitter 기본값
   generic:
     chunk_size: 1000
@@ -37,8 +42,10 @@ chunking:
 
   # hwp/hwpx/docx + hybrid 분기 기본값
   hybrid:
+    # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
+    tokenizer_type: "char"
     tokenizer_id: ""
-    max_tokens: 1000000000000000000000000000000
+    chunk_size: 10000000
     merge_peers: true
 
 loaders:
@@ -63,10 +70,3 @@ whisper:
   chunk_overlap_ms: 300
   # 끝에 / 를 주면 디렉터리로 간주해 내부에 파일명 기준 하위 폴더 생성
   tmp_dir_prefix: "./tmp_audios_"
-
-# 모델 경로 (다운로드된 기본값 사용; 미지정 시 현행 동작 유지)
-models:
-  # 청킹용 토크나이저. tokenizer_path 가 실제 존재하면 그 경로,
-  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
-  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
-  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"

--- a/genon/preprocessor/resource_dev/convert_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/convert_processor_config.yaml
@@ -151,11 +151,19 @@ enrichment:
       enable: false
       config_file: custom_field_authors.yaml   # resource_path 자동 = 이 yaml 파일 디렉토리
 
-# 모델 경로 (다운로드된 기본값 사용; 미지정 시 현행 동작 유지)
-models:
-  # 청킹용 토크나이저. tokenizer_path 가 실제 존재하면 그 경로,
+# 청킹(GenosSmartChunker) 설정
+chunking:
+  # 청크 최대 크기(max_tokens). char 모드면 "최대 문자 수", huggingface 모드면 "최대 토큰 수".
+  # 우선순위: 호출 kwargs 의 chunk_size > 아래 chunk_size. 0 = 토큰/문자 기반 분할 안 함.
+  chunk_size: 0
+  # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
+  tokenizer_type: "char"
+  # 청킹용 토크나이저(huggingface 모드에서만 사용). tokenizer_path 가 실제 존재하면 그 경로,
   # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
   tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
   tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
+
+# 모델 경로 (다운로드된 기본값 사용; 미지정 시 현행 동작 유지)
+models:
   # docling 모델(TableFormer 등) 로컬 경로. 비우면 docling 기본 캐시 사용(현행).
   artifacts_path: ""

--- a/genon/preprocessor/resource_dev/intelligent_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/intelligent_processor_config.yaml
@@ -164,11 +164,19 @@ enrichment:
       enable: false
       config_file: custom_field_authors.yaml   # resource_path 자동 = 이 yaml 파일 디렉토리
 
-# 모델 경로 (다운로드된 기본값 사용; 미지정 시 현행 동작 유지)
-models:
-  # 청킹용 토크나이저. tokenizer_path 가 실제 존재하면 그 경로,
+# 청킹(GenosSmartChunker) 설정
+chunking:
+  # 청크 최대 크기(max_tokens). char 모드면 "최대 문자 수", huggingface 모드면 "최대 토큰 수".
+  # 우선순위: 호출 kwargs 의 chunk_size > 아래 chunk_size. 0 = 토큰/문자 기반 분할 안 함.
+  chunk_size: 0
+  # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
+  tokenizer_type: "char"
+  # 청킹용 토크나이저(huggingface 모드에서만 사용). tokenizer_path 가 실제 존재하면 그 경로,
   # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
   tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
   tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
+
+# 모델 경로 (다운로드된 기본값 사용; 미지정 시 현행 동작 유지)
+models:
   # docling 모델(TableFormer 등) 로컬 경로. 비우면 docling 기본 캐시 사용(현행).
   artifacts_path: ""

--- a/genon/preprocessor/tests/unit/test_attachment_hybrid_chunker.py
+++ b/genon/preprocessor/tests/unit/test_attachment_hybrid_chunker.py
@@ -1,0 +1,52 @@
+"""
+attachment_processor 의 HybridChunker tokenizer_type(문자 수 기반 vs HF 토크나이저) 선택 기능 테스트.
+
+의존성(docling 등) 미가용 환경에서는 importorskip 으로 자동 skip 된다(CI gate).
+"""
+
+import pytest
+
+
+def _load_hybrid_chunker():
+    mod = pytest.importorskip("facade.attachment_processor")
+    return mod.HybridChunker
+
+
+@pytest.mark.unit
+class TestHybridChunkerTokenizerType:
+    def test_default_is_char(self):
+        """tokenizer_type 미지정 시 기본값은 char 이며 HF 토크나이저를 로드하지 않는다."""
+        HybridChunker = _load_hybrid_chunker()
+        chunker = HybridChunker(max_tokens=100)
+        assert chunker.tokenizer_type == "char"
+        assert chunker._tokenizer is None
+
+    def test_count_text_tokens_is_char_length(self):
+        """char 모드에서 _count_text_tokens 는 문자 수(len)를 반환한다(str/list 모두)."""
+        HybridChunker = _load_hybrid_chunker()
+        chunker = HybridChunker(max_tokens=100)
+        assert chunker._count_text_tokens(None) == 0
+        assert chunker._count_text_tokens("가나다라") == 4
+        assert chunker._count_text_tokens(["ab", "cde"]) == 5  # 2 + 3
+
+    def test_invalid_value_falls_back_to_char(self):
+        HybridChunker = _load_hybrid_chunker()
+        chunker = HybridChunker(max_tokens=100, tokenizer_type="bogus")
+        assert chunker.tokenizer_type == "char"
+        assert chunker._tokenizer is None
+
+    def test_value_is_normalized(self):
+        HybridChunker = _load_hybrid_chunker()
+        chunker = HybridChunker(max_tokens=100, tokenizer_type="  CHAR ")
+        assert chunker.tokenizer_type == "char"
+
+    def test_huggingface_mode_loads_tokenizer(self):
+        """huggingface 모드에서는 HF 토크나이저가 로드된다(미가용 시 skip)."""
+        HybridChunker = _load_hybrid_chunker()
+        try:
+            chunker = HybridChunker(max_tokens=100, tokenizer_type="huggingface")
+        except Exception as e:  # noqa: BLE001 - 모델/네트워크 미가용
+            pytest.skip(f"HF tokenizer unavailable: {e}")
+        assert chunker.tokenizer_type == "huggingface"
+        assert chunker._tokenizer is not None
+        assert chunker._count_text_tokens("hello world example text") > 0

--- a/genon/preprocessor/tests/unit/test_attachment_hybrid_config.py
+++ b/genon/preprocessor/tests/unit/test_attachment_hybrid_config.py
@@ -1,0 +1,81 @@
+"""
+attachment_processor 의 chunking 섹션 config 로딩 단위 테스트.
+
+chunking.hybrid.chunk_size / chunking.hybrid.tokenizer_type 가 _default_kwargs 로,
+chunking.tokenizer_path/tokenizer_id 가 self._tokenizer 로 흐르는지 확인한다.
+의존성(docling 등) 미가용 환경에서는 importorskip 으로 자동 skip 된다(CI gate).
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_CONFIG_NAME = "attachment_processor_config.yaml"
+
+
+def _load_processor():
+    mod = pytest.importorskip("facade.attachment_processor")
+    return mod.DocumentProcessor
+
+
+def _make_config(tmp_path: Path, *, hybrid_chunk_size=None, hybrid_tokenizer_type=None,
+                 tokenizer_path=None) -> str:
+    """출고 attachment config 를 복사하고 chunking 하위 키만 덮어쓴 임시 config 경로 반환."""
+    repo_resource = Path(__file__).resolve().parents[2] / "resource" / _CONFIG_NAME
+    cfg = yaml.safe_load(repo_resource.read_text(encoding="utf-8"))
+    chunking = cfg.setdefault("chunking", {})
+    hybrid = chunking.setdefault("hybrid", {})
+    if hybrid_chunk_size is not None:
+        hybrid["chunk_size"] = hybrid_chunk_size
+    if hybrid_tokenizer_type is not None:
+        hybrid["tokenizer_type"] = hybrid_tokenizer_type
+    if tokenizer_path is not None:
+        chunking["tokenizer_path"] = tokenizer_path
+    out = tmp_path / _CONFIG_NAME
+    out.write_text(yaml.safe_dump(cfg, allow_unicode=True), encoding="utf-8")
+    return str(out)
+
+
+def _init_processor(config_path: str):
+    DocumentProcessor = _load_processor()
+    try:
+        return DocumentProcessor(config_path=config_path)
+    except Exception as e:  # noqa: BLE001 - 모델/네트워크 등 환경 의존
+        pytest.skip(f"DocumentProcessor init unavailable: {e}")
+
+
+@pytest.mark.unit
+def test_hybrid_chunk_size_loaded(tmp_path):
+    """chunking.hybrid.chunk_size 가 _default_kwargs['hybrid_chunk_size'] 로 로드된다."""
+    proc = _init_processor(_make_config(tmp_path, hybrid_chunk_size=4096))
+    assert proc._default_kwargs["hybrid_chunk_size"] == 4096
+
+
+@pytest.mark.unit
+def test_hybrid_tokenizer_type_default_char(tmp_path):
+    """tokenizer_type 미지정 시 기본 char 로 로드된다."""
+    proc = _init_processor(_make_config(tmp_path))
+    assert proc._default_kwargs["hybrid_tokenizer_type"] == "char"
+
+
+@pytest.mark.unit
+def test_hybrid_tokenizer_type_explicit(tmp_path):
+    """chunking.hybrid.tokenizer_type 값이 그대로 로드된다."""
+    proc = _init_processor(_make_config(tmp_path, hybrid_tokenizer_type="huggingface"))
+    assert proc._default_kwargs["hybrid_tokenizer_type"] == "huggingface"
+
+
+@pytest.mark.unit
+def test_hybrid_tokenizer_type_invalid_falls_back(tmp_path):
+    """알 수 없는 tokenizer_type 은 char 로 폴백한다."""
+    proc = _init_processor(_make_config(tmp_path, hybrid_tokenizer_type="bogus"))
+    assert proc._default_kwargs["hybrid_tokenizer_type"] == "char"
+
+
+@pytest.mark.unit
+def test_tokenizer_resolved_from_chunking_section(tmp_path):
+    """chunking.tokenizer_path 미존재 시 tokenizer_id(HF) 로 폴백하여 self._tokenizer 결정."""
+    proc = _init_processor(_make_config(tmp_path, tokenizer_path="/nonexistent/path/xyz"))
+    # 경로가 없으므로 HF id(str) 로 폴백
+    assert proc._tokenizer == "sentence-transformers/all-MiniLM-L6-v2"

--- a/genon/preprocessor/tests/unit/test_chunk_size_config.py
+++ b/genon/preprocessor/tests/unit/test_chunk_size_config.py
@@ -1,0 +1,106 @@
+"""
+chunking.chunk_size 의 yaml/kwargs 지정 및 우선순위(kwargs > yaml > 0) 단위 테스트.
+
+의존성(docling 등) 미가용 환경에서는 importorskip 으로 자동 skip 된다(CI gate).
+intelligent_processor / convert_processor 두 곳의 DocumentProcessor 가 동일하게 동작하는지 확인한다.
+"""
+
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+_MODULES = ["intelligent_processor", "convert_processor"]
+
+# facade 모듈명 → 출고 config 파일명
+_DEFAULT_CONFIG = {
+    "intelligent_processor": "intelligent_processor_config.yaml",
+    "convert_processor": "convert_processor_config.yaml",
+}
+
+
+def _load_processor(module_name: str):
+    mod = pytest.importorskip(f"facade.{module_name}")
+    return mod.DocumentProcessor
+
+
+def _make_config(tmp_path: Path, module_name: str, chunk_size) -> str:
+    """출고 config 를 복사하고 chunking.chunk_size 만 덮어쓴 임시 config 경로 반환."""
+    repo_resource = Path(__file__).resolve().parents[2] / "resource" / _DEFAULT_CONFIG[module_name]
+    cfg = yaml.safe_load(repo_resource.read_text(encoding="utf-8"))
+    cfg.setdefault("chunking", {})
+    if chunk_size is None:
+        cfg["chunking"].pop("chunk_size", None)
+    else:
+        cfg["chunking"]["chunk_size"] = chunk_size
+    out = tmp_path / _DEFAULT_CONFIG[module_name]
+    out.write_text(yaml.safe_dump(cfg, allow_unicode=True), encoding="utf-8")
+    return str(out)
+
+
+def _init_processor(module_name: str, config_path: str):
+    DocumentProcessor = _load_processor(module_name)
+    try:
+        return DocumentProcessor(config_path=config_path)
+    except Exception as e:  # noqa: BLE001 - 모델/네트워크 등 환경 의존
+        pytest.skip(f"DocumentProcessor init unavailable: {e}")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module_name", _MODULES)
+def test_yaml_chunk_size_is_loaded(tmp_path, module_name):
+    """yaml chunking.chunk_size 값이 self._chunk_size 로 로드된다."""
+    proc = _init_processor(module_name, _make_config(tmp_path, module_name, 1234))
+    assert proc._chunk_size == 1234
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module_name", _MODULES)
+def test_yaml_chunk_size_zero(tmp_path, module_name):
+    """출고 기본값 0 도 정상 로드된다(None 이 아님)."""
+    proc = _init_processor(module_name, _make_config(tmp_path, module_name, 0))
+    assert proc._chunk_size == 0
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module_name", _MODULES)
+def test_yaml_chunk_size_absent_is_none(tmp_path, module_name):
+    """chunk_size 미설정 시 self._chunk_size 는 None (split 단계에서 0 으로 처리)."""
+    proc = _init_processor(module_name, _make_config(tmp_path, module_name, None))
+    assert proc._chunk_size is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module_name", _MODULES)
+def test_priority_kwargs_over_yaml(tmp_path, module_name):
+    """split_documents 의 max_tokens 우선순위: kwargs.chunk_size > yaml > 0.
+
+    실제 분할을 수행하지 않고, GenosSmartChunker 생성 시 전달되는 max_tokens 만 가로채 검증한다.
+    """
+    mod = pytest.importorskip(f"facade.{module_name}")
+    proc = _init_processor(module_name, _make_config(tmp_path, module_name, 500))
+
+    captured = {}
+    OrigChunker = mod.GenosSmartChunker
+
+    class _SpyChunker(OrigChunker):
+        def __init__(self, **kw):
+            captured["max_tokens"] = kw.get("max_tokens")
+            super().__init__(**kw)
+
+        def chunk(self, *a, **k):  # 실제 청킹은 생략
+            return iter(())
+
+    mod.GenosSmartChunker = _SpyChunker
+    try:
+        # kwargs 에 chunk_size 전달 → kwargs 우선
+        list(proc.split_documents(documents=None, chunk_size=77))
+        assert captured["max_tokens"] == 77
+
+        # kwargs 미전달 → yaml(500)
+        captured.clear()
+        list(proc.split_documents(documents=None))
+        assert captured["max_tokens"] == 500
+    finally:
+        mod.GenosSmartChunker = OrigChunker

--- a/genon/preprocessor/tests/unit/test_chunker_tokenizer_type.py
+++ b/genon/preprocessor/tests/unit/test_chunker_tokenizer_type.py
@@ -1,0 +1,75 @@
+"""
+GenosSmartChunker 의 tokenizer_type(문자 수 기반 vs HF 토크나이저) 선택 기능 단위 테스트.
+
+의존성(docling 등)이 없는 환경에서는 importorskip 으로 자동 skip 된다(CI gate).
+intelligent_processor / convert_processor 두 곳의 GenosSmartChunker 가 동일하게 동작하는지 확인한다.
+"""
+
+import pytest
+
+
+def _load_chunker(module_name: str):
+    mod = pytest.importorskip(f"facade.{module_name}")
+    return mod.GenosSmartChunker
+
+
+_MODULES = ["intelligent_processor", "convert_processor"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module_name", _MODULES)
+class TestTokenizerTypeChar:
+    def test_default_is_char(self, module_name):
+        """tokenizer_type 미지정 시 기본값은 char 이며 HF 토크나이저를 로드하지 않는다."""
+        GenosSmartChunker = _load_chunker(module_name)
+        chunker = GenosSmartChunker(max_tokens=100)
+        assert chunker.tokenizer_type == "char"
+        assert chunker._tokenizer is None
+
+    def test_count_tokens_is_char_length(self, module_name):
+        """char 모드에서 _count_tokens 는 문자 수(len)를 반환한다."""
+        GenosSmartChunker = _load_chunker(module_name)
+        chunker = GenosSmartChunker(max_tokens=100)
+        assert chunker._count_tokens("") == 0
+        assert chunker._count_tokens("가나다라") == 4
+        assert chunker._count_tokens("abcde\nfghij") == len("abcde\nfghij")
+
+    def test_invalid_value_falls_back_to_char(self, module_name):
+        """알 수 없는 tokenizer_type 은 char 로 폴백한다."""
+        GenosSmartChunker = _load_chunker(module_name)
+        chunker = GenosSmartChunker(max_tokens=100, tokenizer_type="bogus")
+        assert chunker.tokenizer_type == "char"
+        assert chunker._tokenizer is None
+
+    def test_value_is_normalized(self, module_name):
+        """대소문자/공백은 정규화된다."""
+        GenosSmartChunker = _load_chunker(module_name)
+        chunker = GenosSmartChunker(max_tokens=100, tokenizer_type="  CHAR ")
+        assert chunker.tokenizer_type == "char"
+
+    def test_split_table_text_by_chars(self, module_name):
+        """char 모드 테이블 분할은 문자 수 기준으로 chunk_size 를 넘지 않는다."""
+        GenosSmartChunker = _load_chunker(module_name)
+        chunker = GenosSmartChunker(max_tokens=100)
+        text = "a" * 250
+        parts = chunker._split_table_text(text, max_tokens=100)
+        assert all(len(p) <= 100 for p in parts)
+        assert "".join(parts) == text
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module_name", _MODULES)
+def test_huggingface_mode_uses_tokenizer(module_name):
+    """huggingface 모드에서는 HF 토크나이저가 로드되고 tokenize 경로로 카운트한다.
+
+    토크나이저(모델/네트워크) 미가용 환경에서는 skip.
+    """
+    GenosSmartChunker = _load_chunker(module_name)
+    try:
+        chunker = GenosSmartChunker(max_tokens=100, tokenizer_type="huggingface")
+    except Exception as e:  # noqa: BLE001 - 모델/네트워크 미가용
+        pytest.skip(f"HF tokenizer unavailable: {e}")
+    assert chunker.tokenizer_type == "huggingface"
+    assert chunker._tokenizer is not None
+    # tokenize 경로(문자 수와 다른 토큰 수)로 동작하는지 확인
+    assert chunker._count_tokens("hello world example text") > 0


### PR DESCRIPTION
# 청킹 토큰 카운트를 문자 수 기반으로 + chunk_size 설정화 + 청크 결합 개선

## 배경
GenosSmartChunker 의 청크 크기 산정이 HuggingFace 토크나이저(`sentence-transformers/all-MiniLM-L6-v2`)에만
의존해 외부 모델 의존이 생기고, 토큰 수↔실제 길이의 관계가 직관적이지 않았다. 또한 청크 최대 크기(`max_tokens`)가
YAML 노브가 아니라 코드에만 존재했고, 큰 값을 줘도 섹션 헤더 경계마다 청크가 잘게 분리되어 과편화가 발생했다.

이 PR 은 ① 문자 수 기반 토큰 카운트 옵션, ② `chunk_size` 의 YAML/kwargs 설정화, ③ 청킹 설정 섹션 정리,
④ 크기 한도까지 인접 청크를 결합하는 2차 병합을 추가한다.

## 주요 변경

### 1. 문자 수 기반 토큰 카운트 옵션 (`tokenizer_type`)
- `GenosSmartChunker`(intelligent/convert) 와 `HybridChunker`(attachment)에 `tokenizer_type` 추가.
  - `"char"`(기본): 문자 수(`len`)로 카운트, HF 토크나이저 **미로드**(외부 모델/네트워크 의존 제거).
  - `"huggingface"`: 기존 HF 토크나이저 기준 토큰 수.
- 토큰 카운트 지점(`_count_tokens`/`_count_text_tokens`/`_count_chunk_tokens`)과 `semchunk` 분할 카운터를 모드별 분기.

### 2. `chunk_size` 설정화 (YAML + kwargs)
- `chunk_size`(=`max_tokens`)를 YAML `chunking.chunk_size` 와 호출 kwargs `chunk_size` 양쪽에서 지정 가능.
- 우선순위: **kwargs `chunk_size` > YAML `chunking.chunk_size` > 0**(0 = 크기 기반 분할 안 함).
- char 모드면 "최대 문자 수", huggingface 모드면 "최대 토큰 수" 의미.

### 3. 청킹 설정 섹션(`chunking:`) 정리
- intelligent/convert: `chunking.chunk_size`, `chunking.tokenizer_type`, `chunking.tokenizer_path`,
  `chunking.tokenizer_id` 로 청킹 관련 설정을 한곳에 응집(기존 `models:` 의 토크나이저 키 이동).
- attachment: `models.tokenizer_path/id` 를 `chunking:` 최상위로 이동(빈 `models:` 제거),
  `chunking.hybrid.max_tokens` → `chunking.hybrid.chunk_size` 로 이름 변경, `chunking.hybrid.tokenizer_type` 추가.
- 적용 config: `resource/` 및 `resource_dev/` 의 intelligent/convert/attachment yaml.

### 4. chunk_size 한도까지 인접 청크 greedy 결합 (과편화 해소)
- 기존: 섹션 헤더 레벨 경계마다 청크가 분리되어 `chunk_size` 를 크게 줘도 절/장 단위로 잘게 쪼개짐.
- 변경: 구조 경계 기준 1차 분할 후, **인접 청크를 합산 크기(HEADER 라인 포함)가 `chunk_size` 이하인 동안
  순서대로 결합**하는 2차 greedy 병합을 추가(`max_tokens > 0` 일 때만 수행).
- 결과: `chunk_size` 가 크면 1청크에 수렴, 중간이면 한도까지 채움, 작으면 현행처럼 세분 유지. O(n), 종료 보장.
- 각 청크는 자신의 heading breadcrumb 를 모두 보유 → 메타데이터 손실 없음.

## 동작 변경 / 호환성 주의
- **기본 `tokenizer_type` 가 `char`** → 미설정/기존 config 에서도 카운트 기준이 "HF 토큰 → 문자 수"로 바뀜(의도된 변경).
- **2차 greedy 병합이 기본 동작** → `chunk_size > 0` 이면 intelligent/convert 의 청크 수가 감소하고,
  한도 여유 시 장(章) 경계를 넘어 병합될 수 있음(헤딩 메타데이터는 보존). `chunk_size: 0` 이면 현행 순수 섹션 분할 유지.
- attachment hybrid 의 `max_tokens` 노브명이 `chunk_size` 로 변경됨(기존 키 사용처는 갱신 필요).

## 설정 예시 (intelligent/convert)
```yaml
chunking:
  chunk_size: 0           # 0=섹션 분할 / N=N자(char)·N토큰(huggingface) 한도까지 결합
  tokenizer_type: "char"  # char(기본) | huggingface
  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
```

## 테스트
- `tests/unit/test_chunker_tokenizer_type.py` — GenosSmartChunker char/huggingface 동작·폴백.
- `tests/unit/test_chunk_size_config.py` — `chunk_size` kwargs>yaml>0 우선순위(spy).
- `tests/unit/test_attachment_hybrid_chunker.py` — HybridChunker tokenizer_type 동작.
- `tests/unit/test_attachment_hybrid_config.py` — attachment chunking 섹션 config 로딩.
- 모두 `importorskip` 게이트(의존성 미가용 환경에서는 skip, CI 에서 실행).

## 문서
- `gitbook_doc/{attachment,convert,intelligent}_processor.md` 의 청킹/토크나이저 설정 설명을 현행화
  (chunking 섹션, tokenizer_type, chunk_size 우선순위 반영).

## 검증 방법
1. `python -m py_compile` (intelligent/convert/attachment processor).
2. 단위 테스트 실행(CI/정상 환경): `pytest genon/preprocessor/tests/unit -m unit`.
3. `shkim_labs/test.sh` 로 샘플 PDF 처리 → `result.json` 의 `n_char` 가 `chunk_size` 한도까지 결합되고
   `char`/`huggingface` 모드가 의도대로 동작하는지 확인.
