### PR TITLE
fix(facade): convert_processor HWP/HWPX 폴백 추가 + attachment 형평성 (#285)

### DIFF
--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -79,6 +79,7 @@ from docling.backend.genos_msword_backend import GenosMsWordDocumentBackend
 from docling.backend.genos_hwp_backend import GenosHwpDocumentBackend
 from docling.backend.hwp_backend import HwpDocumentBackend
 from docling.backend.xml.hwpx_backend import HwpxDocumentBackend
+from docling.exceptions import HwpConversionError
 
 try:
     from genos_utils import upload_files
@@ -1368,6 +1369,16 @@ class HwpProcessor:
         conv_result: ConversionResult = converter.convert(Path(file_path).resolve(), raises_on_error=True)
         return conv_result.document
 
+    @staticmethod
+    def _hwp_sdk_text_is_empty(document: DoclingDocument) -> bool:
+        """GenosHwp SDK 결과 문서에 본문 텍스트가 전혀 없는지 판단(레거시 폴백 트리거용).
+
+        SDK 가 exit 0 으로 "성공"해도 본문을 한 글자도 못 뽑는 경우가 있다(일부 .hwp/.hwpx;
+        DRM/암호화 등). 텍스트 run 이 하나도 없으면 True. (convert_processor 와 형평성)
+        """
+        texts = getattr(document, "texts", None) or []
+        return not any((getattr(t, "text", "") or "").strip() for t in texts)
+
     def split_documents(self, document: DoclingDocument, **kwargs: dict):
         """chunker_type에 따라 HybridChunker 또는 RecursiveCharacterTextSplitter로 분할.
 
@@ -1488,6 +1499,28 @@ class HwpProcessor:
                     raise sdk_err
             else:
                 raise
+
+        # 1-b. SDK 가 예외 없이(exit 0) 끝났어도 본문 텍스트가 비어 있으면(빈 doc_items 로
+        #      다운스트림이 깨지거나 무의미한 표 청크만 나오는 경우) 레거시 백엔드로 폴백한다.
+        #      그래도 본문을 못 얻으면 예외로 올려 DocumentProcessor.__call__ 의 PDF 변환 폴백에
+        #      위임한다. (convert_processor 와 형평성 — convert 는 GenosSmartChunker 예외로 잡히지만
+        #      attachment 는 recursive splitter 라 예외가 안 나므로 여기서 명시적으로 처리한다.)
+        if ext in ('.hwp', '.hwpx') and self._hwp_sdk_text_is_empty(document):
+            backend_name = "HwpDocumentBackend" if ext == '.hwp' else "HwpxDocumentBackend"
+            _log.warning(f"[HwpProcessor] GenosHwp SDK 결과에 본문 텍스트가 없어 {backend_name} 폴백 시도: {file_path}")
+            fallback_doc = None
+            try:
+                fallback_doc = self.load_documents(file_path, **dict(kwargs, use_hwp_sdk=False))
+            except Exception as fallback_err:
+                _log.warning(f"[HwpProcessor] {backend_name} 폴백 실패, 상위 PDF 폴백으로 위임: {fallback_err}")
+            if fallback_doc is not None and not self._hwp_sdk_text_is_empty(fallback_doc):
+                _log.info(f"[HwpProcessor] {backend_name} 폴백 성공(본문 텍스트 확보)")
+                document = fallback_doc
+            else:
+                _log.info(f"[HwpProcessor] {backend_name} 폴백으로도 본문 복구 실패, 상위 PDF 폴백으로 위임")
+                raise HwpConversionError(
+                    f"HWP/HWPX SDK 결과가 비어 있고 레거시 백엔드로도 본문 복구 실패: {file_path}"
+                )
 
         # 2. 이미지 참조 경로 설정
         artifacts_dir, reference_path = self.get_paths(file_path)

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -41,6 +41,9 @@ from langchain_core.documents import Document
 from docling.backend.docling_parse_v4_backend import DoclingParseV4DocumentBackend
 from docling.backend.pypdfium2_backend import PyPdfiumDocumentBackend
 from docling.backend.genos_msword_backend import GenosMsWordDocumentBackend
+# HWP/HWPX 레거시 백엔드 (GenosHwp SDK 실패 시 폴백용; olefile/xml 순수 파이썬, SDK 미사용)
+from docling.backend.hwp_backend import HwpDocumentBackend
+from docling.backend.xml.hwpx_backend import HwpxDocumentBackend
 from docling.datamodel.base_models import InputFormat
 from docling.pipeline.simple_pipeline import SimplePipeline
 # from docling.datamodel.document import ConversionStatus
@@ -62,12 +65,14 @@ from docling.document_converter import (
     DocumentConverter,
     PdfFormatOption,
     FormatOption,
-    WordFormatOption
+    WordFormatOption,
+    HwpxFormatOption
 )
 from docling.datamodel.pipeline_options import DataEnrichmentOptions
 from docling.prompts.prompt_manager import LLMApiError
 from docling.utils.document_enrichment import enrich_document, check_document
 from docling.datamodel.document import ConversionResult
+from docling.exceptions import HwpConversionError
 from docling_core.transforms.chunker import (
     BaseChunk,
     BaseChunker,
@@ -2215,8 +2220,84 @@ class DocumentProcessor:
             conv_result: ConversionResult = self.ocr_second_converter.convert(file_path, raises_on_error=True)
         return conv_result.document
 
+    def _load_hwp_with_legacy_backend(self, file_path: str, **kwargs: dict) -> DoclingDocument:
+        """HWP/HWPX 레거시 백엔드(SDK 미사용) 전용 변환 — GenosHwp SDK 폴백용.
+
+        HWP/HWPX 는 docling 기본 백엔드(GenosHwpDocumentBackend=convtext SDK)로 처리되는데,
+        SDK 가 UNSUPPORTED_TYPE(exit code 3) 등으로 실패할 때 이 메서드로 폴백한다.
+        .hwp → HwpDocumentBackend, .hwpx → HwpxDocumentBackend (둘 다 olefile/xml 기반
+        순수 파이썬이라 SDK 의존이 없음). attachment_processor.HwpProcessor 의 폴백과 동일 구성.
+        """
+        pipeline_options = PipelineOptions()
+        pipeline_options.save_images = kwargs.get('save_images', True)
+        converter = DocumentConverter(
+            format_options={
+                InputFormat.HWP: HwpxFormatOption(
+                    pipeline_options=pipeline_options,
+                    backend=HwpDocumentBackend,
+                ),
+                InputFormat.XML_HWPX: HwpxFormatOption(
+                    pipeline_options=pipeline_options,
+                    backend=HwpxDocumentBackend,
+                ),
+            }
+        )
+        conv_result: ConversionResult = converter.convert(
+            Path(file_path).resolve(), raises_on_error=True
+        )
+        return conv_result.document
+
+    @staticmethod
+    def _hwp_sdk_text_is_empty(document: DoclingDocument) -> bool:
+        """GenosHwp SDK 결과 문서에 본문 텍스트가 전혀 없는지 판단(레거시 폴백 트리거용).
+
+        SDK 가 exit 0 으로 "성공"해도 본문을 한 글자도 못 뽑는 경우가 있다(일부 .hwp/.hwpx).
+        이때 doc_items 가 비어 다운스트림 GenosSmartChunker 의 DocMeta(min_length=1) 검증이
+        깨진다(too_short). 텍스트 run 이 하나도 없으면 True.
+        """
+        texts = getattr(document, "texts", None) or []
+        return not any((getattr(t, "text", "") or "").strip() for t in texts)
+
     def load_documents(self, file_path: str, **kwargs: dict) -> DoclingDocument:
-        return self.load_documents_with_docling(file_path, **kwargs)
+        ext = os.path.splitext(file_path)[-1].lower()
+        is_hwp = ext in ('.hwp', '.hwpx')
+        backend_name = "HwpDocumentBackend" if ext == '.hwp' else "HwpxDocumentBackend"
+        try:
+            document = self.load_documents_with_docling(file_path, **kwargs)
+        except Exception as sdk_err:
+            # (1) GenosHwp SDK 가 예외로 실패(예: exit code 3) → HWP/HWPX 만 레거시 폴백.
+            if not is_hwp:
+                raise
+            _log.warning(f"[DocumentProcessor] GenosHwp SDK 변환 실패: {sdk_err}")
+            try:
+                _log.info(f"[DocumentProcessor] {backend_name}로 폴백 시도: {file_path}")
+                document = self._load_hwp_with_legacy_backend(file_path, **kwargs)
+                _log.info(f"[DocumentProcessor] {backend_name} 폴백 성공")
+                return document
+            except Exception as fallback_err:
+                _log.warning(f"[DocumentProcessor] {backend_name} 폴백도 실패: {fallback_err}")
+                raise sdk_err
+
+        # (2) SDK 가 예외 없이(exit 0) 끝났지만 본문 텍스트가 비어 있으면(빈 doc_items 로
+        #     다운스트림 DocMeta 검증이 깨지는 케이스) 레거시 백엔드로 폴백 시도한다.
+        #     폴백 결과도 비었거나 폴백이 실패하면 원 SDK 결과를 그대로 유지(무회귀).
+        if is_hwp and self._hwp_sdk_text_is_empty(document):
+            _log.warning(
+                f"[DocumentProcessor] GenosHwp SDK 결과에 본문 텍스트가 없어 {backend_name} 폴백 시도: {file_path}"
+            )
+            try:
+                fallback_doc = self._load_hwp_with_legacy_backend(file_path, **kwargs)
+                if not self._hwp_sdk_text_is_empty(fallback_doc):
+                    _log.info(f"[DocumentProcessor] {backend_name} 폴백 성공(본문 텍스트 확보)")
+                    return fallback_doc
+                _log.info(f"[DocumentProcessor] {backend_name} 폴백 결과도 비어 상위 PDF 폴백으로 위임")
+            except Exception as fallback_err:
+                _log.warning(f"[DocumentProcessor] {backend_name} 폴백 실패, 상위 PDF 폴백으로 위임: {fallback_err}")
+            # SDK·레거시 모두 본문을 못 얻음 → 예외로 올려 __call__ 의 PDF 변환 폴백에 위임한다.
+            raise HwpConversionError(
+                f"HWP/HWPX SDK 결과가 비어 있고 레거시 백엔드로도 본문 복구 실패: {file_path}"
+            )
+        return document
 
     def get_loader_langchain(self, file_path: str, use_pdf_sdk: bool = True):
         """PPT 파일용 langchain 로더"""
@@ -2796,6 +2877,24 @@ class DocumentProcessor:
         logging.getLogger().setLevel(level)
 
     async def __call__(self, request: Request, file_path: str, **kwargs: dict):
+        # HWP/HWPX: docling(SDK + 레거시 백엔드) 처리가 전체 실패하면 PDF 변환으로 최종 폴백한다.
+        # attachment_processor.DocumentProcessor.__call__ 의 PDF 폴백과 동일 취지 —
+        # convert_to_pdf 는 rhwp ↔ LibreOffice HWP→PDF 체인이며, 변환된 PDF 를 PDF 경로로 재처리한다.
+        # (헌법.hwp 처럼 SDK 가 exit 3 으로 거부하거나 02.hwp 처럼 빈 결과를 내는 경우를 살린다.)
+        ext = Path(file_path).suffix.lower()
+        if ext in ('.hwp', '.hwpx'):
+            try:
+                return await self._process_request(request, file_path, **kwargs)
+            except Exception as hwp_err:
+                _log.warning(f"[DocumentProcessor] HWP/HWPX 처리 실패, PDF 변환 폴백 시도: {hwp_err}")
+                converted = convert_to_pdf(file_path, use_pdf_sdk=kwargs.get('use_pdf_sdk', True))
+                if converted:
+                    _log.info(f"[DocumentProcessor] PDF 변환 성공, PDF 경로로 재처리: {converted}")
+                    return await self._process_request(request, converted, **kwargs)
+                raise hwp_err
+        return await self._process_request(request, file_path, **kwargs)
+
+    async def _process_request(self, request: Request, file_path: str, **kwargs: dict):
         runtime_level = kwargs.get('log_level')
         self.setup_logging(runtime_level if runtime_level is not None else self._log_level)
 


### PR DESCRIPTION
### Background
변환용 전처리기(convert_processor)로 일부 HWP/HWPX 변환 시 에러로 멈춤. 동일 문서를 첨부용(attachment_processor)으로 처리하면 정상.

| 파일 | 기존 convert 에러 |
|---|---|
| 헌법.hwp | `SDK 실행 실패 (exit code=3)` (UNSUPPORTED_TYPE) |
| 02.hwp / 03.hwpx | `DocMeta doc_items too_short` (빈 doc_items) |

### 원인
- 두 전처리기 모두 HWP/HWPX 를 GenosHwp SDK 로 처리하는데, SDK 가 실패(헌법)하거나 본문을 못 뽑는(02/03) 경우가 있음.
- attachment 에는 SDK 실패 시 **레거시 백엔드 → PDF 변환(rhwp) 폴백**이 있어 살아남지만, convert 에는 그 폴백이 없어 그대로 멈춤.

### 변경
- **convert_processor.py**: attachment 의 폴백을 이식
  - SDK 실패/빈 결과 → 레거시 백엔드(.hwp→HwpDocumentBackend, .hwpx→HwpxDocumentBackend)
  - 그래도 실패 → `convert_to_pdf`(rhwp→LibreOffice) 후 PDF 로 재처리하는 최종 폴백
- **attachment_processor.py**: SDK 가 빈 텍스트를 낼 때도 폴백 타도록 트리거 추가 (convert 와 형평성 — 기존엔 빈 표 청크만 나오던 케이스도 실내용으로 복구)

### 검증
샘플 3종 모두 정상 처리(실제 본문 추출 확인):

| 파일 | before | after |
|---|---|---|
| 헌법.hwp | SDK exit3 에러 | OK (rhwp PDF) |
| 02.hwp | DocMeta 에러 | OK (rhwp PDF) |
| 03.hwpx | DocMeta 에러 | OK (HwpxDocumentBackend) |

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)
