### PR TITLE
fix(#278): DotsOCR 무한 출력으로 인한 hang + 깨진 JSON 방어

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -392,11 +392,20 @@ class GenosLayoutOptions(BaseModel):
     api_key: str = ""
     model: str = "dots-mocr"
     max_completion_tokens: int = 16384
-    timeout: int = 3600
+    # per-request 타임아웃(초). 3600 은 과도 → 1200(20분)으로 축소.
+    # 큐 대기 시간까지 포함되므로 너무 짧으면 정상 다(多)페이지 문서가 죽을 수 있어
+    # 500~600 은 위험. 출력 잘림은 max_completion_tokens 가 정하지 timeout 이 아님.
+    timeout: int = 1200
     retry_count: int = 2  # Number of retries on abnormal VLM responses
     temperature: float = 0.1
     top_p: float = 0.9
     repetition_penalty: float = 1.15  # >1.0 to suppress VLM token-repetition degeneration
+    # 폭주(timeout/length) 감지 시 layout_only 보정 on/off
+    length_fallback_enabled: bool = True
+    # 보정 시 페이지 재렌더 DPI (dots.ocr 권장 200, 상한 11,289,600px)
+    fallback_dpi: int = 200
+    # dotsocr 가 표 HTML 을 못 준 빈 테이블을 TableFormer 로 채울지 (CPU ~1.7s/표)
+    table_fallback_enabled: bool = True
 
 
 class LayoutOptions(BaseLayoutOptions):

--- a/docling/models/genos_dots_ocr_layout_model.py
+++ b/docling/models/genos_dots_ocr_layout_model.py
@@ -128,6 +128,17 @@ class GenosDotsOCRLayoutModel(BasePageModel):
         self.repetition_penalty = getattr(
             self.dotsocr_options, "repetition_penalty", 1.15
         )
+        # finish_reason=="length"(VLM 무한 출력) 감지 시 보정 경로 on/off + 재렌더 DPI.
+        # 보정: layout_only 프롬프트로 박스만 받고(폭주 없음) PaddleOCR로 텍스트 채움.
+        self.length_fallback_enabled = bool(
+            getattr(self.dotsocr_options, "length_fallback_enabled", True)
+        )
+        self.fallback_dpi = getattr(self.dotsocr_options, "fallback_dpi", 200) or 200
+        # 빈 테이블(dotsocr 이 표 HTML 미제공)을 TableFormer 로 채울지. CPU latency ~1.7s/표.
+        self.table_fallback_enabled = bool(
+            getattr(self.dotsocr_options, "table_fallback_enabled", True)
+        )
+        self._tableformer_model = "unset"  # lazy init sentinel
 
     def _use_dotsocr_table_structure(self) -> bool:
         return (
@@ -633,85 +644,78 @@ class GenosDotsOCRLayoutModel(BasePageModel):
             # 바이트 스트림을 base64로 인코딩
             base64_image = base64.b64encode(buffer.getvalue()).decode("utf-8")
 
-            total_attempts = self.retry_count + 1
-            response = None
+            # VLM 호출은 1회만 한다(이전의 retry 루프 제거). 통합 프롬프트가 실패하는
+            # 두 경우 — (a) read timeout(엔드포인트 살아있는데 응답이 느림=무한출력/행),
+            # (b) finish_reason=="length"(토큰 상한까지 폭주) — 에는 같은 프롬프트로
+            # 재시도해봐야 또 폭주하므로, 텍스트를 안 받아쓰는 layout_only 로 폴백한다.
+            # 연결 실패/HTTP 오류 등은 layout_only 도 같은 엔드포인트라 소용없으니 그대로 전파(raise).
             result = None
             usage = None
+            finish_reason = None
+            do_fallback = False
             _vlm_started_at = time.monotonic()
-            for attempt in range(1, total_attempts + 1):
-                try:
-                    response_text, usage = call_vlm_server(
-                        prompt=prompt,
-                        base64_image=base64_image,
-                        url=self.dotocr_endpoint,
-                        api_key=self.api_key,
-                        model=self.model,
-                        max_completion_tokens=self.max_completion_tokens,
-                        timeout=self.timeout,
-                        temperature=self.temperature,
-                        top_p=self.top_p,
-                        repetition_penalty=self.repetition_penalty,
-                    )
-                    if not isinstance(response_text, str) or not response_text.strip():
-                        raise ValueError("Empty VLM response text")
-
-                    # _log.debug(f"dotsocr raw response (page={page.page_no}, attempt={attempt}): {response_text}")
-                    response = _parse_vlm_json_response(response_text)
-                except Exception:
-                    if attempt >= total_attempts:
-                        raise
-                    _log.warning(
-                        "DotsOCR layout request failed (page=%s, attempt=%d/%d). Retrying...",
-                        page.page_no,
-                        attempt,
-                        total_attempts,
-                        exc_info=True,
-                    )
-                    continue
-
-                result = _extract_layout_result_items(response)
-                if isinstance(result, list):
-                    if attempt > 1:
-                        _log.info(
-                            "DotsOCR layout request recovered after retry (page=%s, attempt=%d/%d).",
-                            page.page_no,
-                            attempt,
-                            total_attempts,
-                        )
-                    break
-
-                if attempt < total_attempts:
-                    _log.warning(
-                        "Unexpected VLM response schema (page=%s, attempt=%d/%d). Retrying. Parsed type=%s; value=%r",
-                        page.page_no,
-                        attempt,
-                        total_attempts,
-                        type(response).__name__,
-                        response,
-                    )
-                    continue
-
-                _log.warning(
-                    "Unexpected VLM response schema after retries (page=%s, attempts=%d). Falling back to empty predictions. Parsed type=%s; value=%r",
-                    page.page_no,
-                    total_attempts,
-                    type(response).__name__,
-                    response,
+            try:
+                response_text, usage, finish_reason = call_vlm_server(
+                    prompt=prompt,
+                    base64_image=base64_image,
+                    url=self.dotocr_endpoint,
+                    api_key=self.api_key,
+                    model=self.model,
+                    max_completion_tokens=self.max_completion_tokens,
+                    timeout=self.timeout,
+                    temperature=self.temperature,
+                    top_p=self.top_p,
+                    repetition_penalty=self.repetition_penalty,
                 )
+                if not isinstance(response_text, str) or not response_text.strip():
+                    raise ValueError("Empty VLM response text")
+                response = _parse_vlm_json_response(response_text)
+                result = _extract_layout_result_items(response)
+                if not isinstance(result, list):
+                    _log.warning(
+                        "Unexpected VLM response schema (page=%s). Falling back to empty predictions. type=%s",
+                        page.page_no,
+                        type(response).__name__,
+                    )
+                    result = []
+                if finish_reason == "length":
+                    # 토큰 상한까지 폭주 → 응답이 잘려있음. layout_only 폴백.
+                    do_fallback = True
+            except VLMReadTimeout:
+                _log.warning(
+                    "DotsOCR read timeout (page=%s) → layout_only 폴백", page.page_no
+                )
+                do_fallback = True
                 result = []
+            # (그 외 예외: 연결실패/HTTP/파싱 오류 → 전파 → load_documents 2차 컨버터)
 
             assert isinstance(result, list)
             _vlm_elapsed = time.monotonic() - _vlm_started_at
             _record_stage_elapsed(conv_res, "dotsocr_vlm_call", _vlm_elapsed)
             if isinstance(usage, dict):
                 _log.info(
-                    "DotsOCR VLM usage (page=%s): prompt_tokens=%s, completion_tokens=%s, total_tokens=%s, elapsed=%.3fs",
+                    "DotsOCR VLM usage (page=%s): finish_reason=%s, prompt_tokens=%s, completion_tokens=%s, total_tokens=%s, elapsed=%.3fs",
                     page.page_no,
+                    finish_reason,
                     usage.get("prompt_tokens"),
                     usage.get("completion_tokens"),
                     usage.get("total_tokens"),
                     _vlm_elapsed,
                 )
+
+            # 폴백: layout_only 로 박스만 다시 얻는다(텍스트 미생성 → 폭주 불가).
+            # 텍스트는 다운스트림(PDF text metadata, 글리프/빈페이지 시 force-OCR)이 채우고,
+            # 빈 표는 후처리에서 TableFormer 가 채운다. → 여기선 박스 구조만 확보.
+            if self.length_fallback_enabled and do_fallback:
+                _log.warning(
+                    "DotsOCR 폭주 감지 (page=%s, finish_reason=%s) → layout_only 보정",
+                    page.page_no,
+                    finish_reason,
+                )
+                fb_result, fb_image = self._layout_only_fallback(conv_res, page)
+                if fb_result is not None:
+                    result = fb_result
+                    page_image = fb_image  # 이후 bbox 리스케일이 이 이미지 기준이 되도록 교체
 
             _parse_started_at = time.monotonic()
             clusters = []
@@ -922,6 +926,12 @@ class GenosDotsOCRLayoutModel(BasePageModel):
                     clusters=processed_clusters,
                     table_html_by_cluster_id=raw_table_html_by_cluster_id,
                 )
+                # 폭주 폴백 등으로 dotsocr 가 표 HTML 을 못 준 빈 테이블은 TableFormer 로 채운다.
+                # (dotsocr 가 준 표는 그대로 두고, 비어있는 것만 보강)
+                if self.table_fallback_enabled:
+                    self._fill_empty_tables_with_tableformer(
+                        conv_res, page, processed_clusters
+                    )
                 _record_stage_elapsed(
                     conv_res,
                     "dotsocr_table_build",
@@ -945,6 +955,111 @@ class GenosDotsOCRLayoutModel(BasePageModel):
                 )
 
         return page
+
+    # ── 폭주(timeout/length) 보정 ────────────────────────────────────────────
+    def _layout_only_fallback(self, conv_res: ConversionResult, page: Page):
+        """통합 프롬프트가 폭주(timeout/length)했을 때: 페이지를 fallback_dpi 로 재렌더 →
+        layout_only 프롬프트로 박스(bbox+category)만 확보(텍스트 미생성 → 폭주 불가).
+        텍스트는 다운스트림(PDF metadata, force-OCR)이, 빈 표는 후처리 TableFormer 가 채운다.
+        반환: (items, fb_image) 또는 실패 시 (None, None)."""
+        try:
+            scale = float(self.fallback_dpi) / 72.0
+            fb_image = page.get_image(scale=scale)
+            if fb_image is None:
+                return None, None
+            buf = io.BytesIO()
+            fb_image.save(buf, format="PNG")
+            buf.seek(0)
+            fb_b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+
+            text, _usage, _fr = call_vlm_server(
+                prompt=prompt_layout_only,
+                base64_image=fb_b64,
+                url=self.dotocr_endpoint,
+                api_key=self.api_key,
+                model=self.model,
+                max_completion_tokens=self.max_completion_tokens,
+                timeout=self.timeout,
+                temperature=self.temperature,
+                top_p=self.top_p,
+                repetition_penalty=self.repetition_penalty,
+            )
+            items = _extract_layout_result_items(_parse_vlm_json_response(text))
+            if not isinstance(items, list):
+                return None, None
+            _log.info(
+                "폭주 보정 완료 (page=%s): layout_only %d박스 (텍스트는 다운스트림이 채움)",
+                page.page_no,
+                len(items),
+            )
+            return items, fb_image
+        except Exception:
+            _log.warning(
+                "폭주 보정 실패 (page=%s) → 원본 결과 유지", page.page_no, exc_info=True
+            )
+            return None, None
+
+    def _get_tableformer(self):
+        """TableStructureModel(TableFormer) lazy 생성. 생성 실패 시 None."""
+        if self._tableformer_model != "unset":
+            return self._tableformer_model
+        self._tableformer_model = None
+        try:
+            from docling.models.table_structure_model import TableStructureModel
+
+            self._tableformer_model = TableStructureModel(
+                enabled=True,
+                artifacts_path=getattr(self.pipeline_options, "artifacts_path", None),
+                options=self.pipeline_options.table_structure_options,
+                accelerator_options=self.pipeline_options.accelerator_options,
+            )
+        except Exception:
+            _log.warning("TableFormer 생성 실패 → 빈 테이블 보강 생략", exc_info=True)
+            self._tableformer_model = None
+        return self._tableformer_model
+
+    def _fill_empty_tables_with_tableformer(
+        self, conv_res: ConversionResult, page: Page, clusters: list
+    ) -> None:
+        """dotsocr 가 표 HTML 을 못 준 빈 테이블 클러스터만 TableFormer 로 채운다(in-place).
+        dotsocr 가 준 표(이미 table_map 에 있음)는 건드리지 않는다."""
+        ts = page.predictions.tablestructure
+        if ts is None:
+            return
+        empty_tables = [
+            c
+            for c in clusters
+            if c.label in self.TABLE_LABELS and c.id not in ts.table_map
+        ]
+        if not empty_tables:
+            return
+        tf = self._get_tableformer()
+        if tf is None:
+            return
+        # TableStructureModel.__call__ 은 page.predictions.layout.clusters 의 TABLE 들을
+        # 전부 재예측하고 tablestructure 를 새로 만든다. 그래서 빈 테이블만 남기고 호출 →
+        # 결과를 dotsocr tablestructure 에 merge → 원래 상태 복원.
+        saved_layout = page.predictions.layout
+        saved_ts = ts
+        try:
+            page.predictions.layout = LayoutPrediction(clusters=empty_tables)
+            list(tf(conv_res, [page]))  # generator 소비 → page.predictions.tablestructure 채움
+            tf_ts = page.predictions.tablestructure
+            n = 0
+            if tf_ts is not None:
+                for cid, tbl in tf_ts.table_map.items():
+                    saved_ts.table_map[cid] = tbl
+                    n += 1
+            _log.info(
+                "빈 테이블 %d개 TableFormer 보강 (page=%s)", n, page.page_no
+            )
+        except Exception:
+            _log.warning(
+                "TableFormer 빈 테이블 보강 실패 (page=%s)", page.page_no, exc_info=True
+            )
+        finally:
+            page.predictions.layout = saved_layout
+            page.predictions.tablestructure = saved_ts
 
     def __call__(
         self, conv_res: ConversionResult, page_batch: Iterable[Page]
@@ -1005,6 +1120,15 @@ prompt = """Please output the layout information from the PDF image, including e
 5. Final Output: The entire output must be a single JSON object.
 """
 
+# layout_only: dots.ocr 공식 prompt_layout_only_en (텍스트 미생성 → 무한 출력 불가).
+# finish_reason=="length" 보정 경로에서 사용. 텍스트는 PaddleOCR 로 따로 채운다.
+prompt_layout_only = """Please output the layout information from this PDF image, including each layout's bbox and its category. The bbox should be in the format [x1, y1, x2, y2]. The layout categories for the PDF document include ['Caption', 'Footnote', 'Formula', 'List-item', 'Page-footer', 'Page-header', 'Picture', 'Section-header', 'Table', 'Text', 'Title']. Do not output the corresponding text. The layout result should be in JSON format."""
+
+
+class VLMReadTimeout(Exception):
+    """VLM 응답이 read timeout 내 안 옴(엔드포인트는 살아있음). 폴백 트리거용."""
+
+
 def call_vlm_server(
     prompt: str,
     base64_image: str,
@@ -1016,7 +1140,7 @@ def call_vlm_server(
     temperature: float = 0.1,
     top_p: float = 0.9,
     repetition_penalty: float = 1.15,
-) -> tuple[str, dict | None]:
+) -> tuple[str, dict | None, str | None]:
     image_data_url = f"data:image/png;base64,{base64_image}"
     prompt_with_image_token = f"<|img|><|imgpad|><|endofimg|>{prompt}"
 
@@ -1065,7 +1189,13 @@ def call_vlm_server(
         response.raise_for_status()
         data = response.json()
         usage = data.get("usage") if isinstance(data, dict) else None
-        return data["choices"][0]["message"]["content"], usage
+        choice0 = data["choices"][0]
+        # finish_reason: "stop"=정상 종료 / "length"=상한까지 무한 출력(degeneration 신호)
+        return choice0["message"]["content"], usage, choice0.get("finish_reason")
+    except requests.exceptions.ReadTimeout as e:
+        # 엔드포인트는 살아있는데 응답이 timeout 내 안 옴(=무한 출력/행 정황).
+        # 연결 자체 실패(ConnectionError/ConnectTimeout)와 구분해 폴백 분기에 쓴다.
+        raise VLMReadTimeout(f"VLM read timeout: {e}") from e
     except requests.exceptions.RequestException as e:
         raise RuntimeError(f"HTTP 요청 오류: {e}") from e
     except KeyError as e:

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -82,6 +82,145 @@ def _has_any_pdf_converter() -> bool:
         return True
 
 
+# 지원 포맷의 매직 헤더(allowlist). 각 값은 아래 공식 출처로 근거 확인 + 실제 샘플로 검증함.
+#   - 정본 매직 DB: file/file(libmagic) magic/Magdir — 실제 본 모듈이 쓰는 python-magic의 DB.
+#     (PDF=Magdir/pdf "%PDF-", PNG/GIF=Magdir/images, JPEG=Magdir/jpeg 0xffd8ff, ZIP=Magdir/msooxml "PK\3\4")
+#   - 포맷 공식 스펙: PDF=ISO 32000(%PDF-), PNG=W3C PNG/RFC2083(89 50 4E 47 0D 0A 1A 0A),
+#     ZIP=PKWARE APPNOTE(local file header 0x04034b50), OLE2/CFB=[MS-CFB] §2.2 Header(D0CF11E0A1B11AE1).
+# zip(PK)=docx/xlsx/pptx/hwpx, OLE2(d0cf..)=hwp/doc/ppt/xls(레거시).
+_KNOWN_MAGIC_PREFIXES = (
+    b"%PDF-",                                # pdf
+    b"\x89PNG\r\n\x1a\n",                    # png
+    b"\xff\xd8\xff",                         # jpeg/jpg
+    b"GIF87a", b"GIF89a",                    # gif
+    b"BM",                                    # bmp
+    b"II*\x00", b"MM\x00*",                  # tiff
+    b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08",  # zip 계열(ooxml/hwpx)
+    b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1",     # OLE2/CFB(hwp5/doc/ppt/xls)
+    b"ID3",                                   # mp3(id3v2)
+    b"RIFF",                                  # wav/avi/webp
+    b"OggS",                                  # ogg
+    b"fLaC",                                  # flac
+    b"\x1f\x8b",                             # gzip
+    b"7z\xbc\xaf\x27\x1c",                  # 7z
+    b"Rar!\x1a\x07",                        # rar
+    b"<?xml",                                 # xml
+)
+
+# 텍스트로 봐줄 수 없는 제어 바이트(탭/개행/CR/FF 제외). 텍스트 파일엔 거의 없음.
+_TEXT_ALLOWED_CTRL = {0x09, 0x0A, 0x0C, 0x0D}
+
+
+def _looks_like_text(head: bytes) -> bool:
+    """csv/txt/json/md/html 등 매직넘버 없는 텍스트 파일인지 휴리스틱 판정.
+    NUL 이 있거나 제어문자 비율이 높으면 바이너리(=텍스트 아님)."""
+    if not head:
+        return False
+    if b"\x00" in head:
+        return False
+    ctrl = sum(
+        1 for c in head if (c < 0x20 and c not in _TEXT_ALLOWED_CTRL) or c == 0x7F
+    )
+    return (ctrl / len(head)) < 0.05
+
+
+def _is_encrypted_pdf(file_path: str) -> bool:
+    """PDF /Encrypt(비밀번호/DRM 암호화) 여부. ISO 32000 기준, pypdf is_encrypted 사용."""
+    try:
+        from pypdf import PdfReader
+
+        return bool(PdfReader(file_path).is_encrypted)
+    except Exception:
+        return False  # 파싱 실패는 여기서 단정 안 함(후속 단계에서 처리)
+
+
+def _is_encrypted_office(file_path: str) -> bool:
+    """암호화된 OOXML(docx/xlsx/pptx)은 OLE2 컨테이너의 'EncryptedPackage' 스트림으로
+    저장된다(MS-OFFCRYPTO). olefile 로 그 스트림 존재를 확인."""
+    try:
+        import olefile
+
+        if not olefile.isOleFile(file_path):
+            return False
+        ole = olefile.OleFileIO(file_path)
+        try:
+            return ole.exists("EncryptedPackage")
+        finally:
+            ole.close()
+    except Exception:
+        return False
+
+
+def _is_protected_hwp(file_path: str) -> bool:
+    """암호화/배포용(DRM) HWP 감지. HWP 5.0 'FileHeader' 스트림(OLE2 내, 256B)의
+    flags(offset 36, uint32 LE) bit1=password, bit2=distribution(배포용/DRM).
+    이런 HWP 는 본문 스트림이 암호화돼 변환기가 정상 처리 못 함. (근거: HWP 5.0 스펙)"""
+    try:
+        import olefile
+        import struct
+
+        if not olefile.isOleFile(file_path):
+            return False
+        ole = olefile.OleFileIO(file_path)
+        try:
+            if not ole.exists("FileHeader"):
+                return False
+            data = ole.openstream("FileHeader").read()
+            if len(data) < 40 or data[:17] != b"HWP Document File":
+                return False
+            flags = struct.unpack("<I", data[36:40])[0]
+            return bool(flags & 0x02) or bool(flags & 0x04)  # password or distribution(DRM)
+        finally:
+            ole.close()
+    except Exception:
+        return False
+
+
+def _detect_unsupported_file(file_path: str) -> str | None:
+    """입력 파일이 정상 처리 가능한지 판정(이슈 #278). 차단 사유 문자열 또는 정상이면 None.
+
+    근거(공식):
+    - 포맷 인식: 매직헤더 allowlist (file/file libmagic 정본 DB + 각 포맷 공식 스펙).
+      _KNOWN_MAGIC_PREFIXES 위 주석에 출처 명시. 확장자와 무관하게 실제 바이트로 본다.
+    - 암호화 자체는 바이트 패턴으로 못 본다(암호문=고엔트로피 랜덤). 포맷별 구조로 판정:
+      PDF=/Encrypt(pypdf is_encrypted, ISO 32000), Office=OLE2의 EncryptedPackage(MS-OFFCRYPTO),
+      HWP=FileHeader flags(HWP 5.0 스펙).
+    - Fasoo 등 독점 DRM은 표준 감지법이 없다 → 알려진 매직헤더에 안 맞고 텍스트도 아닌
+      바이너리(=고엔트로피 garbage)로 걸러낸다.
+    """
+    try:
+        with open(file_path, "rb") as f:
+            head = f.read(512)
+    except Exception:
+        return None  # 읽기 실패는 여기서 판단 안 함(후속 단계에서 처리)
+    if not head:
+        return "빈 파일"
+
+    is_pdf = head.startswith(b"%PDF-")
+    is_ole2 = head.startswith(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1")
+    # ── Layer 1: 알려진 포맷 매직헤더인가 ──
+    known = (
+        is_pdf
+        or is_ole2
+        or head[4:8] == b"ftyp"  # mp4/mov/m4a (ISO-BMFF, offset 4)
+        or (len(head) >= 2 and head[0] == 0xFF and (head[1] & 0xE0) == 0xE0)  # mp3 frame sync
+        or any(head.startswith(sig) for sig in _KNOWN_MAGIC_PREFIXES)
+    )
+    if not known:
+        if _looks_like_text(head):
+            return None  # csv/txt/json/md/html 등 텍스트 파일
+        return "지원하지 않거나 손상된 파일(DRM 암호화 등)"
+
+    # ── Layer 2: 알려진 포맷이지만 비밀번호/암호화된 경우 ──
+    if is_pdf and _is_encrypted_pdf(file_path):
+        return "암호화된 PDF 문서"
+    if is_ole2 and _is_encrypted_office(file_path):
+        return "암호화된 Office 문서"
+    if is_ole2 and _is_protected_hwp(file_path):
+        return "암호화/배포용(DRM) HWP 문서"
+    return None
+
+
 # docling imports
 
 from docling.backend.docling_parse_v4_backend import DoclingParseV4DocumentBackend
@@ -1986,7 +2125,7 @@ class DocumentProcessor:
             genos_layout_cfg.get("timeout"), "layout.genos_layout.timeout"
         )
         if layout_timeout is None or layout_timeout <= 0:
-            layout_timeout = 3600
+            layout_timeout = 1200
         layout_retry_count = _parse_optional_int(
             genos_layout_cfg.get("retry_count"), "layout.genos_layout.retry_count"
         )
@@ -2008,12 +2147,32 @@ class DocumentProcessor:
         )
         if layout_repetition_penalty is None or layout_repetition_penalty <= 0:
             layout_repetition_penalty = 1.15
+        layout_length_fallback = _parse_optional_bool(
+            genos_layout_cfg.get("length_fallback_enabled"),
+            "layout.genos_layout.length_fallback_enabled",
+        )
+        if layout_length_fallback is None:
+            layout_length_fallback = True
+        layout_fallback_dpi = _parse_optional_int(
+            genos_layout_cfg.get("fallback_dpi"), "layout.genos_layout.fallback_dpi"
+        )
+        if layout_fallback_dpi is None or layout_fallback_dpi <= 0:
+            layout_fallback_dpi = 200
+        layout_table_fallback = _parse_optional_bool(
+            genos_layout_cfg.get("table_fallback_enabled"),
+            "layout.genos_layout.table_fallback_enabled",
+        )
+        if layout_table_fallback is None:
+            layout_table_fallback = True
         self.pipe_line_options.layout_options.genos_layout_options.model = layout_model
         self.pipe_line_options.layout_options.genos_layout_options.timeout = layout_timeout
         self.pipe_line_options.layout_options.genos_layout_options.retry_count = layout_retry_count
         self.pipe_line_options.layout_options.genos_layout_options.temperature = layout_temperature
         self.pipe_line_options.layout_options.genos_layout_options.top_p = layout_top_p
         self.pipe_line_options.layout_options.genos_layout_options.repetition_penalty = layout_repetition_penalty
+        self.pipe_line_options.layout_options.genos_layout_options.length_fallback_enabled = layout_length_fallback
+        self.pipe_line_options.layout_options.genos_layout_options.fallback_dpi = layout_fallback_dpi
+        self.pipe_line_options.layout_options.genos_layout_options.table_fallback_enabled = layout_table_fallback
 
         self.pipe_line_options.do_table_structure = True
         self.pipe_line_options.table_structure_options.do_cell_matching = True
@@ -2521,6 +2680,27 @@ class DocumentProcessor:
 
         return False
 
+    def check_empty_text(self, document: DoclingDocument) -> bool:
+        """텍스트 클러스터(박스)는 있는데 그 텍스트가 전부 비어 있는 페이지가 있는지 확인.
+
+        length 폴백(layout_only)이나 텍스트레이어 부재 등으로 박스만 있고 텍스트가
+        안 채워진 페이지를 잡아 강제 OCR 로 보낸다(이슈 #278 B-2).
+        """
+        from collections import defaultdict
+        page_item_count: dict = defaultdict(int)
+        page_text_len: dict = defaultdict(int)
+        for item, level in document.iterate_items():
+            if isinstance(item, TextItem) and hasattr(item, 'prov') and item.prov:
+                page_no = item.prov[0].page_no
+                page_item_count[page_no] += 1
+                page_text_len[page_no] += len((item.text or "").strip())
+        for page_no, n_items in page_item_count.items():
+            # 텍스트 아이템이 있는데 그 페이지 텍스트 총량이 0 → 비어있는 페이지
+            if n_items > 0 and page_text_len[page_no] == 0:
+                _log.info(f"[intelligent] page {page_no} 텍스트가 비어있음 → 강제 OCR 필요")
+                return True
+        return False
+
     def check_appendix_keywords(self, content: str, appendix_list: list) -> str: # !! appendix feature (2025-09-30, geonhee kim) !!
         if not content or not appendix_list:
             return ""
@@ -2728,6 +2908,18 @@ class DocumentProcessor:
         _log.info(f"file_path: {file_path}")
         _log.info(f"kwargs: {kwargs}")
 
+        # 비정상 파일 사전 감지(이슈 #278): 지원 포맷 매직헤더에 하나도 안 맞고 텍스트도
+        # 아니면(=DRM 암호화/손상 바이너리) 변환 시 garbage PDF → VLM 무한 출력/행을
+        # 유발하므로 변환 전에 컷한다. 확장자와 무관하게 실제 헤더로 판정.
+        bad_reason = _detect_unsupported_file(file_path)
+        if bad_reason:
+            _log.warning(
+                f"[intelligent] 비정상 파일 감지({bad_reason}) — 처리 중단: {file_path}"
+            )
+            raise GenosServiceException(
+                1, f"{bad_reason} 입니다. 정상 문서로 다시 업로드하세요: {os.path.basename(file_path)}"
+            )
+
         # 입력이 PDF가 아닐 때 동작:
         # - auto_convert_to_pdf=True (default): PDF SDK/LibreOffice 로 자동 변환 후 진입
         # - auto_convert_to_pdf=False: 변환 없이 그대로 진행 (변경 전 동작; PDF 가정)
@@ -2761,7 +2953,7 @@ class DocumentProcessor:
         else:
             document: DoclingDocument = self.load_documents(file_path, **kwargs)
             if self.ocr_mode == "auto":
-                if not check_document(document, self.enrichment_options) or self.check_glyphs(document):
+                if not check_document(document, self.enrichment_options) or self.check_glyphs(document) or self.check_empty_text(document):
                     # OCR이 필요하다고 판단되면 OCR 수행
                     document: DoclingDocument = self.load_documents_with_docling_ocr(file_path, **kwargs)
 

--- a/genon/preprocessor/resource/intelligent_processor_config.yaml
+++ b/genon/preprocessor/resource/intelligent_processor_config.yaml
@@ -41,11 +41,14 @@ layout:
     page_batch_size: 128
     max_completion_tokens: 16384
     model: "dots-mocr"          # 서빙 모델명
-    timeout: 3600               # VLM 요청 타임아웃(초)
+    timeout: 1200               # VLM 요청 타임아웃(초)
     retry_count: 2              # 비정상 VLM 응답 재시도 횟수
     temperature: 0.1            # 생성 temperature
     top_p: 0.9                  # 생성 top_p (0<top_p<=1)
     repetition_penalty: 1.15    # >1.0, 토큰 반복(degeneration) 억제
+    length_fallback_enabled: true  # 폭주(finish_reason=length)/타임아웃 감지 시 layout_only 보정 on/off
+    fallback_dpi: 200           # 보정 시 페이지 재렌더 DPI (dots.ocr 권장 200)
+    table_fallback_enabled: true   # dotsocr가 표 HTML을 못 준 빈 테이블을 TableFormer로 보강 (CPU ~1.7s/표)
 
 # PDF 파이프라인 (docling PDF 파싱 성능/품질 노브)
 pdf_pipeline:

--- a/genon/preprocessor/resource_dev/intelligent_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/intelligent_processor_config.yaml
@@ -43,11 +43,14 @@ layout:
     page_batch_size: 128
     max_completion_tokens: 16384
     model: "dots-mocr"          # 서빙 모델명
-    timeout: 3600               # VLM 요청 타임아웃(초)
+    timeout: 1200               # VLM 요청 타임아웃(초)
     retry_count: 2              # 비정상 VLM 응답 재시도 횟수
     temperature: 0.1            # 생성 temperature
     top_p: 0.9                  # 생성 top_p (0<top_p<=1)
     repetition_penalty: 1.15    # >1.0, 토큰 반복(degeneration) 억제
+    length_fallback_enabled: true  # 폭주(finish_reason=length)/타임아웃 감지 시 layout_only 보정 on/off
+    fallback_dpi: 200           # 보정 시 페이지 재렌더 DPI (dots.ocr 권장 200)
+    table_fallback_enabled: true   # dotsocr가 표 HTML을 못 준 빈 테이블을 TableFormer로 보강 (CPU ~1.7s/표)
 
 
 # ── PDF 파이프라인 ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
# PR 초안 — 이슈 #278

| 항목 | 값 |
|---|---|
| 제목 | `fix(#278): DotsOCR 무한 출력으로 인한 hang + 깨진 JSON 방어` |
| base ← compare | `develop` ← `task/278-dotsocr-무한출력-폴백` |
| 연결 이슈 | Closes [#278](https://github.com/genonai/doc_parser/issues/278) |

---

## 1. 배경 / 원인

지능형 전처리기에서 일부 문서가 **무한 hang** 과 **깨진 JSON** 을 냄. 둘은 별개가 아니라 **같은 원인의 공통 결과**임.

- DotsOCR(VLM)가 글씨가 빽빽하거나 garbage인 페이지에서 토큰을 상한(`max_completion_tokens=16384`)까지 **멈추지 않고 끝없이 출력**함 → 응답에 `finish_reason == "length"`.
- 상한에서 잘리니 → (a) 한 페이지에 수십 초~분이 걸려 페이지 수만큼 누적 = **hang**, (b) JSON이 닫히지 않아 = **깨진 JSON**.
- DRM/암호화 블롭이 LibreOffice 변환에서 수십~수백 페이지 garbage PDF로 부풀면 이 현상이 페이지마다 반복됨.

> dots.ocr 공식 문서도 *"character-to-pixel ratio가 과도하게 높을 때"* 파싱 실패를 명시 — [dots.ocr blog · Limitation](https://github.com/rednote-hilab/dots.ocr/blob/master/assets/blog.md#limitation--future-work).
> `max_completion_tokens`(16384)는 큰 표의 정상 HTML 출력에 필요하므로 줄이지 않음.

---

## 2. 변경 요약

| # | 변경 | 핵심 |
|---|---|---|
| 1 | 무한 출력·타임아웃 폴백 | retry 제거 + `length`/ReadTimeout 시 `layout_only`로 박스만 확보 |
| 2 | 입력단 비정상·암호화 파일 컷 | 매직헤더 allowlist + 포맷별 암호화 구조 감지 |
| 3 | 빈 텍스트 페이지 force-OCR | 박스만 있고 텍스트 0인 페이지 감지 |
| 4 | 빈 표 TableFormer 보강 | dotsocr가 구조를 못 준 표만 |
| 5 | per-page timeout 단축 | 3600 → 1200s |

---

## 3. 포맷 조사 (변경 #2의 근거)

DRM 여부를 확장자로 못 믿으므로, **실제 파일 첫 바이트(매직헤더)** 로 지원 포맷인지 판정함. 각 매직 값은 위키가 아니라 **공식 출처**로 근거를 잡음.

### 3.1 매직헤더 allowlist · 공식 출처

1차 정본은 실제 본 모듈이 쓰는 **[`file/file`(libmagic)](https://github.com/file/file) 매직 DB**(v546이 우리 샘플 전부 정확 식별), 2차는 각 포맷 공식 스펙.

| 포맷 | 확장자 | 매직헤더 (hex) | 공식 출처 |
|---|---|---|---|
| PDF | .pdf | `25 50 44 46 2D` (`%PDF-`) | [libmagic Magdir/pdf](https://github.com/file/file/blob/master/magic/Magdir/pdf) · [ISO 32000 (Adobe 공개본)](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) |
| PNG | .png | `89 50 4E 47 0D 0A 1A 0A` | [libmagic Magdir/images](https://github.com/file/file/blob/master/magic/Magdir/images) · [W3C PNG §5.2](https://www.w3.org/TR/png/#5PNG-file-signature) · [RFC 2083](https://www.rfc-editor.org/rfc/rfc2083) |
| JPEG | .jpg/.jpeg | `FF D8 FF` | [libmagic Magdir/jpeg](https://github.com/file/file/blob/master/magic/Magdir/jpeg) · [ITU-T T.871 (JFIF)](https://www.itu.int/rec/T-REC-T.871) |
| GIF | .gif | `47 49 46 38 37/39 61` (`GIF87a`/`GIF89a`) | [libmagic Magdir/images](https://github.com/file/file/blob/master/magic/Magdir/images) |
| ZIP 계열 | .docx/.xlsx/.pptx/.hwpx | `50 4B 03 04` (`PK␃␄`) | [PKWARE APPNOTE (local file header 0x04034b50)](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT) · [ECMA-376 (OOXML)](https://ecma-international.org/publications-and-standards/standards/ecma-376/) |
| OLE2 / CFB | .hwp/.doc/.ppt/.xls | `D0 CF 11 E0 A1 B1 1A E1` | [\[MS-CFB\] §2.2 The Header](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cfb/68530324-9d3d-4441-9ea9-66a2c8f79567) |
| MP3 | .mp3 | `49 44 33` (`ID3`) 또는 frame sync | [ID3v2 스펙](https://id3.org/id3v2.3.0) |
| WAV / AVI / WebP | .wav 등 | `52 49 46 46` (`RIFF`) | [libmagic Magdir/riff](https://github.com/file/file/blob/master/magic/Magdir/riff) |
| 기타 | — | TIFF·BMP·OGG·FLAC·gzip·7z·rar·XML | libmagic 동일 DB |

> 텍스트 파일(csv/txt/json/md/html)은 매직이 없어 별도 휴리스틱으로 통과시킴 — NUL/제어문자 비율이 매우 낮으면 텍스트로 판정.

### 3.2 암호화 / DRM 감지

allowlist를 통과한 "정상 컨테이너"라도 암호화면 변환이 본문을 못 읽음. **암호화 자체는 바이트 패턴으로 못 봄**(암호문=고엔트로피 랜덤) → 포맷별 **구조**로 판정.

| 포맷 | 감지 방법 | 라이브러리 | 근거 |
|---|---|---|---|
| PDF | `/Encrypt` 딕셔너리 존재 | [`pypdf`](https://pypdf.readthedocs.io/) `is_encrypted` | [ISO 32000](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) |
| MS-Office | OLE2 내 `EncryptedPackage` 스트림 | [`olefile`](https://github.com/decalage2/olefile) | [\[MS-OFFCRYPTO\]](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-offcrypto/) |
| HWP | `FileHeader` 스트림 flags(offset 36) — bit1=password, bit2=distribution(DRM) | [`olefile`](https://github.com/decalage2/olefile) / [`pyhwp`](https://pyhwp.readthedocs.io/) | HWP 5.0 스펙(2010 공개, KR) · [ClamAV HWP 분석](https://blog.clamav.net/2016/03/clamav-0991-hangul-word-processor-hwp.html) |

### 3.3 커버리지 — 정직하게

| 구분 | 잡히는 것 | 비고 |
|---|---|---|
| 전체-래핑 DRM (Fasoo 등) | **전 포맷** | 유효 매직이 안 나옴 → 3.1 allowlist에서 컷 |
| 컨테이너 정상 + 암호화 | **PDF · MS-Office · HWP** | 3.2 구조 감지 |
| 그 외(이미지/오디오/텍스트) 암호화 | 표준 감지법 없음 | "문서 암호화" 개념 자체가 없음. 단 #278의 hang 위협은 아님(변환단계서 fail-safe) |

> 추가 패키지 설치 불필요 — `pypdf`/`olefile`/`pyhwp` 모두 이미 의존성에 있음. 정상 HWP는 flags=0x01(compressed)만이라 오탐 없음(실파일 검증).

---

## 4. 프롬프트 실측 (변경 #1의 근거)

운영 DotsOCR에 실제 호출해 프롬프트별 거동을 측정. **텍스트를 받아쓰는 프롬프트는 garbage에서 전부 폭주, `layout_only`만 안전**.

| 프롬프트 | 출력 | garbage 페이지 거동 | 폴백 채택 |
|---|---|---|---|
| `layout_all` | 박스 + 텍스트 + 표HTML | **폭주**(finish=length), DPI(200·300) 무관 | ✕ |
| `ocr` | 평문 텍스트 | **폭주** | ✕ |
| `grounding_ocr` | 박스별 텍스트 | **폭주** | ✕ |
| `layout_only` | 박스(bbox+category)만 | **안전**(finish=stop, ~3s) — 텍스트 미생성이라 폭주 구조적 불가 | **○** |

- 실측 원문: `out/realvlm/prompt_comparison.md` (dev 산출물, 레포 미포함).
- `layout_only`도 reading order대로 출력(10페이지 검증) → genos 경로는 VLM 순서를 보존하므로 그대로 사용.
- 텍스트는 폴백에서 채우지 않고 다운스트림(force-OCR / PDF 텍스트 셀)에 맡김.

---

## 5. 표 처리 — TableFormer 비용 (변경 #4의 근거)

빈 표를 그냥 두면 표 내용이 통째로 유실됨. 보강 비용이 작아 상시 적용으로 결정.

| 모드 / 디바이스 | 표본 | 평균 |
|---|---|---|
| TableFormer accurate / CPU | 표 55개 · 문서 6개 | **~1.77s / 표** |

- 실측 원문: `out/tf_latency/tf_latency_result.json` (dev 산출물, 레포 미포함).
- 빈 표 클러스터에만 [`TableStructureModel`](https://github.com/docling-project/docling)을 임시로 돌려 merge → 결합 범위 최소화.

---

## 6. 변경 파일

| 파일 | 내용 |
|---|---|
| `docling/models/genos_dots_ocr_layout_model.py` | `finish_reason` 반환, `VLMReadTimeout`, `layout_only` 폴백, 빈 표 TableFormer 보강 |
| `docling/datamodel/pipeline_options.py` | `timeout` 1200, `length_fallback_enabled`/`fallback_dpi`/`table_fallback_enabled` |
| `genon/preprocessor/facade/intelligent_processor.py` | `_detect_unsupported_file`, `check_empty_text`, 진입부 컷 |
| `genon/preprocessor/resource{,_dev}/intelligent_processor_config.yaml` | layout timeout 1200 + 폴백 옵션 3종 노출(`length_fallback_enabled`/`fallback_dpi`/`table_fallback_enabled`) |

---

## 7. 검증

| 시나리오 | 방법 | 결과 |
|---|---|---|
| `length` → layout_only 폴백 | docker + mock VLM | OK |
| ReadTimeout → layout_only 폴백 | docker + mock VLM | OK |
| 빈 표 → TableFormer 보강 | docker | OK |
| 비정상/암호화 파일 컷 | DRM 2종 + 암호화 PDF + 정상 12종 | 차단/통과 정확 |
| 매직헤더 식별 | libmagic 교차검증 | 샘플 전부 일치 |

### 운영 검증 필요 (로컬 구조적 불가)
- 실 VLM 다페이지 폴백 동작
- 다운스트림 force-OCR 텍스트 품질(고밀도 페이지)
- 실제 암호화 HWP 차단

---

## 8. 옵션 / 롤백

- 폴백은 플래그로 on/off: `length_fallback_enabled`, `table_fallback_enabled`.
- HWP `distribution`(배포용) 비트까지 차단 — 배포용이지만 읽히는 HWP가 운영에 있으면 `password` 비트만으로 좁힐 수 있음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
