### PR TITLE
ocr_all_table_cells 메소드의 code 139(SIGSEGV) 발생 방지

### DIFF
--- a/genon/preprocessor/facade/chunking_processor.py
+++ b/genon/preprocessor/facade/chunking_processor.py
@@ -2761,9 +2761,10 @@ class DocumentProcessor:
         Returns:
             OCR이 완료된 문서의 DoclingDocument 객체
         """
-        import fitz
+        import io
         import base64
         import requests
+        from PIL import Image
 
         def post_ocr_bytes(img_bytes: bytes, timeout=60) -> dict:
             HEADERS = {"Accept": "application/json", "Content-Type": "application/json"}
@@ -2809,10 +2810,10 @@ class DocumentProcessor:
             return rec_texts[:n], rec_scores[:n], rec_boxes[:n]
 
         try:
-            doc = fitz.open(pdf_path)
-
             for table_idx, table_item in enumerate(document.tables):
                 if not table_item.data or not table_item.data.table_cells:
+                    continue
+                if not table_item.prov:
                     continue
 
                 b_ocr = False
@@ -2825,48 +2826,65 @@ class DocumentProcessor:
                     # 글리프 깨진 텍스트가 없는 경우, OCR을 수행하지 않음
                     continue
 
+                # docling 이 이미 렌더해 둔 페이지 이미지(generate_page_images=True)를
+                # 재사용해 셀 영역을 crop 한다. PyMuPDF 재렌더(get_pixmap)는 일부 PDF 에서
+                # 네이티브 크래시(SIGSEGV, worker code 139)를 유발하므로 사용하지 않는다.
+                page_no = table_item.prov[0].page_no
+                page = document.pages.get(page_no)
+                if page is None or page.size is None or page.image is None:
+                    continue
+                page_image = page.image.pil_image
+                if page_image is None:
+                    continue
+                W, H = page_image.size
+
                 for cell_idx, cell in enumerate(table_item.data.table_cells):
+                    try:
+                        if cell.bbox is None:
+                            continue
 
-                    # Provenance 정보에서 위치 정보 추출
-                    if not table_item.prov:
+                        # docling 셀 bbox(BOTTOMLEFT) → 페이지 이미지 픽셀 좌표(TOPLEFT)
+                        crop = (
+                            cell.bbox
+                            .to_top_left_origin(page_height=page.size.height)
+                            .scale_to_size(old_size=page.size, new_size=page.image.size)
+                        )
+                        x0, y0, x1, y1 = crop.as_tuple()
+                        # 정규화 + 페이지 경계 클램프 + degenerate skip
+                        x0, x1 = sorted((x0, x1))
+                        y0, y1 = sorted((y0, y1))
+                        x0 = max(0, min(x0, W)); x1 = max(0, min(x1, W))
+                        y0 = max(0, min(y0, H)); y1 = max(0, min(y1, H))
+                        if (x1 - x0) < 1 or (y1 - y0) < 1:
+                            continue
+
+                        cell_img = page_image.crop((x0, y0, x1, y1))
+
+                        # 아주 작은 셀은 OCR 가독성을 위해 확대(기존 target_height=20, ≤4x)
+                        ch = y1 - y0
+                        zoom = min(max(20.0 / ch, 1.0), 4.0) if ch > 0 else 1.0
+                        if zoom > 1.0:
+                            cell_img = cell_img.resize(
+                                (max(1, round((x1 - x0) * zoom)), max(1, round(ch * zoom))),
+                                Image.LANCZOS,
+                            )
+
+                        buf = io.BytesIO()
+                        cell_img.save(buf, format="PNG")
+                        img_data = buf.getvalue()
+
+                        result = post_ocr_bytes(img_data, timeout=self._table_cell_ocr_timeout)
+                        rec_texts, rec_scores, rec_boxes = extract_ocr_fields(result)
+
+                        cell.text = ""
+                        for t in rec_texts:
+                            if len(cell.text) > 0:
+                                cell.text += " "
+                            cell.text += t if t else ""
+                    except Exception as cell_err:
+                        # 한 셀 실패가 나머지 셀/표를 막지 않도록 격리
+                        print(f"OCR cell processing failed (table={table_idx}, cell={cell_idx}): {cell_err}")
                         continue
-
-                    page_no = table_item.prov[0].page_no - 1
-                    bbox = cell.bbox
-
-                    page = doc.load_page(page_no)
-
-                    # 셀의 바운딩 박스를 사용하여 이미지에서 해당 영역을 잘라냄
-                    cell_bbox = fitz.Rect(
-                        bbox.l, min(bbox.t, bbox.b),
-                        bbox.r, max(bbox.t, bbox.b)
-                    )
-
-                    # bbox 높이 계산 (PDF 좌표계 단위)
-                    bbox_height = cell_bbox.height
-
-                    # 목표 픽셀 높이
-                    target_height = 20
-
-                    # zoom factor 계산
-                    # (너무 작은 bbox일 경우 0으로 나누는 걸 방지)
-                    zoom_factor = target_height / bbox_height if bbox_height > 0 else 1.0
-                    zoom_factor = min(zoom_factor, 4.0)  # 최대 확대 비율 제한
-                    zoom_factor = max(zoom_factor, 1)  # 최소 확대 비율 제한
-
-                    # 페이지를 이미지로 렌더링
-                    mat = fitz.Matrix(zoom_factor, zoom_factor)
-                    pix = page.get_pixmap(matrix=mat, clip=cell_bbox)
-                    img_data = pix.tobytes("png")
-
-                    result = post_ocr_bytes(img_data, timeout=self._table_cell_ocr_timeout)
-                    rec_texts, rec_scores, rec_boxes = extract_ocr_fields(result)
-
-                    cell.text = ""
-                    for t in rec_texts:
-                        if len(cell.text) > 0:
-                            cell.text += " "
-                        cell.text += t if t else ""
         except Exception as e:
             print(f"OCR processing failed: {e}")
             pass

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -2975,9 +2975,10 @@ class DocumentProcessor:
         Returns:
             OCR이 완료된 문서의 DoclingDocument 객체
         """
-        import fitz
+        import io
         import base64
         import requests
+        from PIL import Image
 
         def post_ocr_bytes(img_bytes: bytes, timeout=60) -> dict:
             HEADERS = {"Accept": "application/json", "Content-Type": "application/json"}
@@ -3023,10 +3024,10 @@ class DocumentProcessor:
             return rec_texts[:n], rec_scores[:n], rec_boxes[:n]
 
         try:
-            doc = fitz.open(pdf_path)
-
             for table_idx, table_item in enumerate(document.tables):
                 if not table_item.data or not table_item.data.table_cells:
+                    continue
+                if not table_item.prov:
                     continue
 
                 b_ocr = False
@@ -3039,48 +3040,65 @@ class DocumentProcessor:
                     # 글리프 깨진 텍스트가 없는 경우, OCR을 수행하지 않음
                     continue
 
+                # docling 이 이미 렌더해 둔 페이지 이미지(generate_page_images=True)를
+                # 재사용해 셀 영역을 crop 한다. PyMuPDF 재렌더(get_pixmap)는 일부 PDF 에서
+                # 네이티브 크래시(SIGSEGV, worker code 139)를 유발하므로 사용하지 않는다.
+                page_no = table_item.prov[0].page_no
+                page = document.pages.get(page_no)
+                if page is None or page.size is None or page.image is None:
+                    continue
+                page_image = page.image.pil_image
+                if page_image is None:
+                    continue
+                W, H = page_image.size
+
                 for cell_idx, cell in enumerate(table_item.data.table_cells):
+                    try:
+                        if cell.bbox is None:
+                            continue
 
-                    # Provenance 정보에서 위치 정보 추출
-                    if not table_item.prov:
+                        # docling 셀 bbox(BOTTOMLEFT) → 페이지 이미지 픽셀 좌표(TOPLEFT)
+                        crop = (
+                            cell.bbox
+                            .to_top_left_origin(page_height=page.size.height)
+                            .scale_to_size(old_size=page.size, new_size=page.image.size)
+                        )
+                        x0, y0, x1, y1 = crop.as_tuple()
+                        # 정규화 + 페이지 경계 클램프 + degenerate skip
+                        x0, x1 = sorted((x0, x1))
+                        y0, y1 = sorted((y0, y1))
+                        x0 = max(0, min(x0, W)); x1 = max(0, min(x1, W))
+                        y0 = max(0, min(y0, H)); y1 = max(0, min(y1, H))
+                        if (x1 - x0) < 1 or (y1 - y0) < 1:
+                            continue
+
+                        cell_img = page_image.crop((x0, y0, x1, y1))
+
+                        # 아주 작은 셀은 OCR 가독성을 위해 확대(기존 target_height=20, ≤4x)
+                        ch = y1 - y0
+                        zoom = min(max(20.0 / ch, 1.0), 4.0) if ch > 0 else 1.0
+                        if zoom > 1.0:
+                            cell_img = cell_img.resize(
+                                (max(1, round((x1 - x0) * zoom)), max(1, round(ch * zoom))),
+                                Image.LANCZOS,
+                            )
+
+                        buf = io.BytesIO()
+                        cell_img.save(buf, format="PNG")
+                        img_data = buf.getvalue()
+
+                        result = post_ocr_bytes(img_data, timeout=self._table_cell_ocr_timeout)
+                        rec_texts, rec_scores, rec_boxes = extract_ocr_fields(result)
+
+                        cell.text = ""
+                        for t in rec_texts:
+                            if len(cell.text) > 0:
+                                cell.text += " "
+                            cell.text += t if t else ""
+                    except Exception as cell_err:
+                        # 한 셀 실패가 나머지 셀/표를 막지 않도록 격리
+                        print(f"OCR cell processing failed (table={table_idx}, cell={cell_idx}): {cell_err}")
                         continue
-
-                    page_no = table_item.prov[0].page_no - 1
-                    bbox = cell.bbox
-
-                    page = doc.load_page(page_no)
-
-                    # 셀의 바운딩 박스를 사용하여 이미지에서 해당 영역을 잘라냄
-                    cell_bbox = fitz.Rect(
-                        bbox.l, min(bbox.t, bbox.b),
-                        bbox.r, max(bbox.t, bbox.b)
-                    )
-
-                    # bbox 높이 계산 (PDF 좌표계 단위)
-                    bbox_height = cell_bbox.height
-
-                    # 목표 픽셀 높이
-                    target_height = 20
-
-                    # zoom factor 계산
-                    # (너무 작은 bbox일 경우 0으로 나누는 걸 방지)
-                    zoom_factor = target_height / bbox_height if bbox_height > 0 else 1.0
-                    zoom_factor = min(zoom_factor, 4.0)  # 최대 확대 비율 제한
-                    zoom_factor = max(zoom_factor, 1)  # 최소 확대 비율 제한
-
-                    # 페이지를 이미지로 렌더링
-                    mat = fitz.Matrix(zoom_factor, zoom_factor)
-                    pix = page.get_pixmap(matrix=mat, clip=cell_bbox)
-                    img_data = pix.tobytes("png")
-
-                    result = post_ocr_bytes(img_data, timeout=self._table_cell_ocr_timeout)
-                    rec_texts, rec_scores, rec_boxes = extract_ocr_fields(result)
-
-                    cell.text = ""
-                    for t in rec_texts:
-                        if len(cell.text) > 0:
-                            cell.text += " "
-                        cell.text += t if t else ""
         except Exception as e:
             print(f"OCR processing failed: {e}")
             pass

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -2960,9 +2960,10 @@ class DocumentProcessor:
         Returns:
             OCR이 완료된 문서의 DoclingDocument 객체
         """
-        import fitz
+        import io
         import base64
         import requests
+        from PIL import Image
 
         def post_ocr_bytes(img_bytes: bytes, timeout=60) -> dict:
             HEADERS = {"Accept": "application/json", "Content-Type": "application/json"}
@@ -3008,10 +3009,10 @@ class DocumentProcessor:
             return rec_texts[:n], rec_scores[:n], rec_boxes[:n]
 
         try:
-            doc = fitz.open(pdf_path)
-
             for table_idx, table_item in enumerate(document.tables):
                 if not table_item.data or not table_item.data.table_cells:
+                    continue
+                if not table_item.prov:
                     continue
 
                 b_ocr = False
@@ -3024,48 +3025,65 @@ class DocumentProcessor:
                     # 글리프 깨진 텍스트가 없는 경우, OCR을 수행하지 않음
                     continue
 
+                # docling 이 이미 렌더해 둔 페이지 이미지(generate_page_images=True)를
+                # 재사용해 셀 영역을 crop 한다. PyMuPDF 재렌더(get_pixmap)는 일부 PDF 에서
+                # 네이티브 크래시(SIGSEGV, worker code 139)를 유발하므로 사용하지 않는다.
+                page_no = table_item.prov[0].page_no
+                page = document.pages.get(page_no)
+                if page is None or page.size is None or page.image is None:
+                    continue
+                page_image = page.image.pil_image
+                if page_image is None:
+                    continue
+                W, H = page_image.size
+
                 for cell_idx, cell in enumerate(table_item.data.table_cells):
+                    try:
+                        if cell.bbox is None:
+                            continue
 
-                    # Provenance 정보에서 위치 정보 추출
-                    if not table_item.prov:
+                        # docling 셀 bbox(BOTTOMLEFT) → 페이지 이미지 픽셀 좌표(TOPLEFT)
+                        crop = (
+                            cell.bbox
+                            .to_top_left_origin(page_height=page.size.height)
+                            .scale_to_size(old_size=page.size, new_size=page.image.size)
+                        )
+                        x0, y0, x1, y1 = crop.as_tuple()
+                        # 정규화 + 페이지 경계 클램프 + degenerate skip
+                        x0, x1 = sorted((x0, x1))
+                        y0, y1 = sorted((y0, y1))
+                        x0 = max(0, min(x0, W)); x1 = max(0, min(x1, W))
+                        y0 = max(0, min(y0, H)); y1 = max(0, min(y1, H))
+                        if (x1 - x0) < 1 or (y1 - y0) < 1:
+                            continue
+
+                        cell_img = page_image.crop((x0, y0, x1, y1))
+
+                        # 아주 작은 셀은 OCR 가독성을 위해 확대(기존 target_height=20, ≤4x)
+                        ch = y1 - y0
+                        zoom = min(max(20.0 / ch, 1.0), 4.0) if ch > 0 else 1.0
+                        if zoom > 1.0:
+                            cell_img = cell_img.resize(
+                                (max(1, round((x1 - x0) * zoom)), max(1, round(ch * zoom))),
+                                Image.LANCZOS,
+                            )
+
+                        buf = io.BytesIO()
+                        cell_img.save(buf, format="PNG")
+                        img_data = buf.getvalue()
+
+                        result = post_ocr_bytes(img_data, timeout=self._table_cell_ocr_timeout)
+                        rec_texts, rec_scores, rec_boxes = extract_ocr_fields(result)
+
+                        cell.text = ""
+                        for t in rec_texts:
+                            if len(cell.text) > 0:
+                                cell.text += " "
+                            cell.text += t if t else ""
+                    except Exception as cell_err:
+                        # 한 셀 실패가 나머지 셀/표를 막지 않도록 격리
+                        print(f"OCR cell processing failed (table={table_idx}, cell={cell_idx}): {cell_err}")
                         continue
-
-                    page_no = table_item.prov[0].page_no - 1
-                    bbox = cell.bbox
-
-                    page = doc.load_page(page_no)
-
-                    # 셀의 바운딩 박스를 사용하여 이미지에서 해당 영역을 잘라냄
-                    cell_bbox = fitz.Rect(
-                        bbox.l, min(bbox.t, bbox.b),
-                        bbox.r, max(bbox.t, bbox.b)
-                    )
-
-                    # bbox 높이 계산 (PDF 좌표계 단위)
-                    bbox_height = cell_bbox.height
-
-                    # 목표 픽셀 높이
-                    target_height = 20
-
-                    # zoom factor 계산
-                    # (너무 작은 bbox일 경우 0으로 나누는 걸 방지)
-                    zoom_factor = target_height / bbox_height if bbox_height > 0 else 1.0
-                    zoom_factor = min(zoom_factor, 4.0)  # 최대 확대 비율 제한
-                    zoom_factor = max(zoom_factor, 1)  # 최소 확대 비율 제한
-
-                    # 페이지를 이미지로 렌더링
-                    mat = fitz.Matrix(zoom_factor, zoom_factor)
-                    pix = page.get_pixmap(matrix=mat, clip=cell_bbox)
-                    img_data = pix.tobytes("png")
-
-                    result = post_ocr_bytes(img_data, timeout=self._table_cell_ocr_timeout)
-                    rec_texts, rec_scores, rec_boxes = extract_ocr_fields(result)
-
-                    cell.text = ""
-                    for t in rec_texts:
-                        if len(cell.text) > 0:
-                            cell.text += " "
-                        cell.text += t if t else ""
         except Exception as e:
             print(f"OCR processing failed: {e}")
             pass

--- a/genon/preprocessor/facade/legacy/BOK_적재용_규정.py
+++ b/genon/preprocessor/facade/legacy/BOK_적재용_규정.py
@@ -1639,9 +1639,10 @@ class DocumentProcessor:
         Returns:
             OCR이 완료된 문서의 DoclingDocument 객체
         """
-        import fitz
+        import io
         import base64
         import requests
+        from PIL import Image
 
         def post_ocr_bytes(img_bytes: bytes, timeout=60) -> dict:
             HEADERS = {"Accept": "application/json", "Content-Type": "application/json"}
@@ -1687,10 +1688,10 @@ class DocumentProcessor:
             return rec_texts[:n], rec_scores[:n], rec_boxes[:n]
 
         try:
-            doc = fitz.open(pdf_path)
-
             for table_idx, table_item in enumerate(document.tables):
                 if not table_item.data or not table_item.data.table_cells:
+                    continue
+                if not table_item.prov:
                     continue
 
                 b_ocr = False
@@ -1703,48 +1704,65 @@ class DocumentProcessor:
                     # 글리프 깨진 텍스트가 없는 경우, OCR을 수행하지 않음
                     continue
 
+                # docling 이 이미 렌더해 둔 페이지 이미지(generate_page_images=True)를
+                # 재사용해 셀 영역을 crop 한다. PyMuPDF 재렌더(get_pixmap)는 일부 PDF 에서
+                # 네이티브 크래시(SIGSEGV, worker code 139)를 유발하므로 사용하지 않는다.
+                page_no = table_item.prov[0].page_no
+                page = document.pages.get(page_no)
+                if page is None or page.size is None or page.image is None:
+                    continue
+                page_image = page.image.pil_image
+                if page_image is None:
+                    continue
+                W, H = page_image.size
+
                 for cell_idx, cell in enumerate(table_item.data.table_cells):
+                    try:
+                        if cell.bbox is None:
+                            continue
 
-                    # Provenance 정보에서 위치 정보 추출
-                    if not table_item.prov:
+                        # docling 셀 bbox(BOTTOMLEFT) → 페이지 이미지 픽셀 좌표(TOPLEFT)
+                        crop = (
+                            cell.bbox
+                            .to_top_left_origin(page_height=page.size.height)
+                            .scale_to_size(old_size=page.size, new_size=page.image.size)
+                        )
+                        x0, y0, x1, y1 = crop.as_tuple()
+                        # 정규화 + 페이지 경계 클램프 + degenerate skip
+                        x0, x1 = sorted((x0, x1))
+                        y0, y1 = sorted((y0, y1))
+                        x0 = max(0, min(x0, W)); x1 = max(0, min(x1, W))
+                        y0 = max(0, min(y0, H)); y1 = max(0, min(y1, H))
+                        if (x1 - x0) < 1 or (y1 - y0) < 1:
+                            continue
+
+                        cell_img = page_image.crop((x0, y0, x1, y1))
+
+                        # 아주 작은 셀은 OCR 가독성을 위해 확대(기존 target_height=20, ≤4x)
+                        ch = y1 - y0
+                        zoom = min(max(20.0 / ch, 1.0), 4.0) if ch > 0 else 1.0
+                        if zoom > 1.0:
+                            cell_img = cell_img.resize(
+                                (max(1, round((x1 - x0) * zoom)), max(1, round(ch * zoom))),
+                                Image.LANCZOS,
+                            )
+
+                        buf = io.BytesIO()
+                        cell_img.save(buf, format="PNG")
+                        img_data = buf.getvalue()
+
+                        result = post_ocr_bytes(img_data, timeout=OCR_TABLE_CELL_TIMEOUT)
+                        rec_texts, rec_scores, rec_boxes = extract_ocr_fields(result)
+
+                        cell.text = ""
+                        for t in rec_texts:
+                            if len(cell.text) > 0:
+                                cell.text += " "
+                            cell.text += t if t else ""
+                    except Exception as cell_err:
+                        # 한 셀 실패가 나머지 셀/표를 막지 않도록 격리
+                        print(f"OCR cell processing failed (table={table_idx}, cell={cell_idx}): {cell_err}")
                         continue
-
-                    page_no = table_item.prov[0].page_no - 1
-                    bbox = cell.bbox
-
-                    page = doc.load_page(page_no)
-
-                    # 셀의 바운딩 박스를 사용하여 이미지에서 해당 영역을 잘라냄
-                    cell_bbox = fitz.Rect(
-                        bbox.l, min(bbox.t, bbox.b),
-                        bbox.r, max(bbox.t, bbox.b)
-                    )
-
-                    # bbox 높이 계산 (PDF 좌표계 단위)
-                    bbox_height = cell_bbox.height
-
-                    # 목표 픽셀 높이
-                    target_height = 20
-
-                    # zoom factor 계산
-                    # (너무 작은 bbox일 경우 0으로 나누는 걸 방지)
-                    zoom_factor = target_height / bbox_height if bbox_height > 0 else 1.0
-                    zoom_factor = min(zoom_factor, 4.0)  # 최대 확대 비율 제한
-                    zoom_factor = max(zoom_factor, 1)  # 최소 확대 비율 제한
-
-                    # 페이지를 이미지로 렌더링
-                    mat = fitz.Matrix(zoom_factor, zoom_factor)
-                    pix = page.get_pixmap(matrix=mat, clip=cell_bbox)
-                    img_data = pix.tobytes("png")
-
-                    result = post_ocr_bytes(img_data, timeout=OCR_TABLE_CELL_TIMEOUT)
-                    rec_texts, rec_scores, rec_boxes = extract_ocr_fields(result)
-
-                    cell.text = ""
-                    for t in rec_texts:
-                        if len(cell.text) > 0:
-                            cell.text += " "
-                        cell.text += t if t else ""
         except Exception as e:
             print(f"OCR processing failed: {e}")
             pass

--- a/genon/preprocessor/facade/legacy/BOK_적재용_외부.py
+++ b/genon/preprocessor/facade/legacy/BOK_적재용_외부.py
@@ -1547,9 +1547,10 @@ class DocumentProcessor:
         Returns:
             OCR이 완료된 문서의 DoclingDocument 객체
         """
-        import fitz
+        import io
         import base64
         import requests
+        from PIL import Image
 
         def post_ocr_bytes(img_bytes: bytes, timeout=60) -> dict:
             HEADERS = {"Accept": "application/json", "Content-Type": "application/json"}
@@ -1595,10 +1596,10 @@ class DocumentProcessor:
             return rec_texts[:n], rec_scores[:n], rec_boxes[:n]
 
         try:
-            doc = fitz.open(pdf_path)
-
             for table_idx, table_item in enumerate(document.tables):
                 if not table_item.data or not table_item.data.table_cells:
+                    continue
+                if not table_item.prov:
                     continue
 
                 b_ocr = False
@@ -1611,48 +1612,65 @@ class DocumentProcessor:
                     # 글리프 깨진 텍스트가 없는 경우, OCR을 수행하지 않음
                     continue
 
+                # docling 이 이미 렌더해 둔 페이지 이미지(generate_page_images=True)를
+                # 재사용해 셀 영역을 crop 한다. PyMuPDF 재렌더(get_pixmap)는 일부 PDF 에서
+                # 네이티브 크래시(SIGSEGV, worker code 139)를 유발하므로 사용하지 않는다.
+                page_no = table_item.prov[0].page_no
+                page = document.pages.get(page_no)
+                if page is None or page.size is None or page.image is None:
+                    continue
+                page_image = page.image.pil_image
+                if page_image is None:
+                    continue
+                W, H = page_image.size
+
                 for cell_idx, cell in enumerate(table_item.data.table_cells):
+                    try:
+                        if cell.bbox is None:
+                            continue
 
-                    # Provenance 정보에서 위치 정보 추출
-                    if not table_item.prov:
+                        # docling 셀 bbox(BOTTOMLEFT) → 페이지 이미지 픽셀 좌표(TOPLEFT)
+                        crop = (
+                            cell.bbox
+                            .to_top_left_origin(page_height=page.size.height)
+                            .scale_to_size(old_size=page.size, new_size=page.image.size)
+                        )
+                        x0, y0, x1, y1 = crop.as_tuple()
+                        # 정규화 + 페이지 경계 클램프 + degenerate skip
+                        x0, x1 = sorted((x0, x1))
+                        y0, y1 = sorted((y0, y1))
+                        x0 = max(0, min(x0, W)); x1 = max(0, min(x1, W))
+                        y0 = max(0, min(y0, H)); y1 = max(0, min(y1, H))
+                        if (x1 - x0) < 1 or (y1 - y0) < 1:
+                            continue
+
+                        cell_img = page_image.crop((x0, y0, x1, y1))
+
+                        # 아주 작은 셀은 OCR 가독성을 위해 확대(기존 target_height=20, ≤4x)
+                        ch = y1 - y0
+                        zoom = min(max(20.0 / ch, 1.0), 4.0) if ch > 0 else 1.0
+                        if zoom > 1.0:
+                            cell_img = cell_img.resize(
+                                (max(1, round((x1 - x0) * zoom)), max(1, round(ch * zoom))),
+                                Image.LANCZOS,
+                            )
+
+                        buf = io.BytesIO()
+                        cell_img.save(buf, format="PNG")
+                        img_data = buf.getvalue()
+
+                        result = post_ocr_bytes(img_data, timeout=OCR_TABLE_CELL_TIMEOUT)
+                        rec_texts, rec_scores, rec_boxes = extract_ocr_fields(result)
+
+                        cell.text = ""
+                        for t in rec_texts:
+                            if len(cell.text) > 0:
+                                cell.text += " "
+                            cell.text += t if t else ""
+                    except Exception as cell_err:
+                        # 한 셀 실패가 나머지 셀/표를 막지 않도록 격리
+                        print(f"OCR cell processing failed (table={table_idx}, cell={cell_idx}): {cell_err}")
                         continue
-
-                    page_no = table_item.prov[0].page_no - 1
-                    bbox = cell.bbox
-
-                    page = doc.load_page(page_no)
-
-                    # 셀의 바운딩 박스를 사용하여 이미지에서 해당 영역을 잘라냄
-                    cell_bbox = fitz.Rect(
-                        bbox.l, min(bbox.t, bbox.b),
-                        bbox.r, max(bbox.t, bbox.b)
-                    )
-
-                    # bbox 높이 계산 (PDF 좌표계 단위)
-                    bbox_height = cell_bbox.height
-
-                    # 목표 픽셀 높이
-                    target_height = 20
-
-                    # zoom factor 계산
-                    # (너무 작은 bbox일 경우 0으로 나누는 걸 방지)
-                    zoom_factor = target_height / bbox_height if bbox_height > 0 else 1.0
-                    zoom_factor = min(zoom_factor, 4.0)  # 최대 확대 비율 제한
-                    zoom_factor = max(zoom_factor, 1)  # 최소 확대 비율 제한
-
-                    # 페이지를 이미지로 렌더링
-                    mat = fitz.Matrix(zoom_factor, zoom_factor)
-                    pix = page.get_pixmap(matrix=mat, clip=cell_bbox)
-                    img_data = pix.tobytes("png")
-
-                    result = post_ocr_bytes(img_data, timeout=OCR_TABLE_CELL_TIMEOUT)
-                    rec_texts, rec_scores, rec_boxes = extract_ocr_fields(result)
-
-                    cell.text = ""
-                    for t in rec_texts:
-                        if len(cell.text) > 0:
-                            cell.text += " "
-                        cell.text += t if t else ""
         except Exception as e:
             print(f"OCR processing failed: {e}")
             pass

--- a/genon/preprocessor/facade/parser_processor.py
+++ b/genon/preprocessor/facade/parser_processor.py
@@ -1593,8 +1593,9 @@ class IntelligentDocumentProcessor:
 
     def ocr_all_table_cells(self, document: DoclingDocument, pdf_path) -> DoclingDocument:
         """글리프 깨진 텍스트가 있는 테이블에 대해서만 OCR을 수행합니다."""
-        import fitz as _fitz
+        import io as _io
         import base64 as _base64
+        from PIL import Image as _Image
 
         def post_ocr_bytes(img_bytes: bytes, timeout=60) -> dict:
             HEADERS = {"Accept": "application/json", "Content-Type": "application/json"}
@@ -1622,10 +1623,10 @@ class IntelligentDocumentProcessor:
             return rec_texts[:n], rec_scores[:n], rec_boxes[:n]
 
         try:
-            doc = _fitz.open(pdf_path)
-
             for table_idx, table_item in enumerate(document.tables):
                 if not table_item.data or not table_item.data.table_cells:
+                    continue
+                if not table_item.prov:
                     continue
 
                 b_ocr = False
@@ -1637,37 +1638,65 @@ class IntelligentDocumentProcessor:
                 if b_ocr is False:
                     continue
 
+                # docling 이 이미 렌더해 둔 페이지 이미지(generate_page_images=True)를
+                # 재사용해 셀 영역을 crop 한다. PyMuPDF 재렌더(get_pixmap)는 일부 PDF 에서
+                # 네이티브 크래시(SIGSEGV, worker code 139)를 유발하므로 사용하지 않는다.
+                page_no = table_item.prov[0].page_no
+                page = document.pages.get(page_no)
+                if page is None or page.size is None or page.image is None:
+                    continue
+                page_image = page.image.pil_image
+                if page_image is None:
+                    continue
+                W, H = page_image.size
+
                 for cell_idx, cell in enumerate(table_item.data.table_cells):
-                    if not table_item.prov:
+                    try:
+                        if cell.bbox is None:
+                            continue
+
+                        # docling 셀 bbox(BOTTOMLEFT) → 페이지 이미지 픽셀 좌표(TOPLEFT)
+                        crop = (
+                            cell.bbox
+                            .to_top_left_origin(page_height=page.size.height)
+                            .scale_to_size(old_size=page.size, new_size=page.image.size)
+                        )
+                        x0, y0, x1, y1 = crop.as_tuple()
+                        # 정규화 + 페이지 경계 클램프 + degenerate skip
+                        x0, x1 = sorted((x0, x1))
+                        y0, y1 = sorted((y0, y1))
+                        x0 = max(0, min(x0, W)); x1 = max(0, min(x1, W))
+                        y0 = max(0, min(y0, H)); y1 = max(0, min(y1, H))
+                        if (x1 - x0) < 1 or (y1 - y0) < 1:
+                            continue
+
+                        cell_img = page_image.crop((x0, y0, x1, y1))
+
+                        # 아주 작은 셀은 OCR 가독성을 위해 확대(기존 target_height=20, ≤4x)
+                        ch = y1 - y0
+                        zoom = min(max(20.0 / ch, 1.0), 4.0) if ch > 0 else 1.0
+                        if zoom > 1.0:
+                            cell_img = cell_img.resize(
+                                (max(1, round((x1 - x0) * zoom)), max(1, round(ch * zoom))),
+                                _Image.LANCZOS,
+                            )
+
+                        buf = _io.BytesIO()
+                        cell_img.save(buf, format="PNG")
+                        img_data = buf.getvalue()
+
+                        result = post_ocr_bytes(img_data, timeout=self._table_cell_ocr_timeout)
+                        rec_texts, rec_scores, rec_boxes = extract_ocr_fields(result)
+
+                        cell.text = ""
+                        for t in rec_texts:
+                            if len(cell.text) > 0:
+                                cell.text += " "
+                            cell.text += t if t else ""
+                    except Exception as cell_err:
+                        # 한 셀 실패가 나머지 셀/표를 막지 않도록 격리
+                        print(f"OCR cell processing failed (table={table_idx}, cell={cell_idx}): {cell_err}")
                         continue
-
-                    page_no = table_item.prov[0].page_no - 1
-                    bbox = cell.bbox
-
-                    page = doc.load_page(page_no)
-                    cell_bbox = _fitz.Rect(
-                        bbox.l, min(bbox.t, bbox.b),
-                        bbox.r, max(bbox.t, bbox.b)
-                    )
-
-                    bbox_height = cell_bbox.height
-                    target_height = 20
-                    zoom_factor = target_height / bbox_height if bbox_height > 0 else 1.0
-                    zoom_factor = min(zoom_factor, 4.0)
-                    zoom_factor = max(zoom_factor, 1)
-
-                    mat = _fitz.Matrix(zoom_factor, zoom_factor)
-                    pix = page.get_pixmap(matrix=mat, clip=cell_bbox)
-                    img_data = pix.tobytes("png")
-
-                    result = post_ocr_bytes(img_data, timeout=self._table_cell_ocr_timeout)
-                    rec_texts, rec_scores, rec_boxes = extract_ocr_fields(result)
-
-                    cell.text = ""
-                    for t in rec_texts:
-                        if len(cell.text) > 0:
-                            cell.text += " "
-                        cell.text += t if t else ""
         except Exception as e:
             print(f"OCR processing failed: {e}")
             pass


### PR DESCRIPTION
# fix(#302): 표 셀 재OCR 중 Gunicorn worker SIGSEGV(code 139) 수정

## 개요

일부 표 포함 PDF에서 Docling 변환 후 `ocr_all_table_cells()` 후처리 중
Gunicorn worker가 **code 139(SIGSEGV)** 로 종료되는 문제를 수정합니다.

표 셀 재OCR의 이미지 소스를 **PyMuPDF 재렌더(`page.get_pixmap`)** 에서
**Docling이 이미 렌더해 둔 페이지 이미지의 PIL crop** 으로 교체하여 크래시 원인을 제거하고,
동시에 좌표계 버그까지 함께 바로잡습니다.

---

## 문제

`page.get_pixmap(matrix=..., clip=cell_bbox)` 호출에서 Gunicorn worker가 SIGSEGV로 즉사.
특정 PDF에서만 재현되며, 표 하나 때문에 워커 프로세스 전체가 내려감.

## 원인

- `get_pixmap()` 은 네이티브 **MuPDF 래스터라이저(C)** 를 호출한다. 여기서 발생하는 SIGSEGV는
  Python 예외가 아니므로 함수의 `try/except Exception` 으로 **잡히지 않아** worker가 그대로 죽는다.
- MuPDF 1.27(PyMuPDF 1.27.2.2)이 일부 PDF의 콘텐츠 스트림/폰트/이미지 래스터화 중 크래시하며,
  기존 코드가 **셀마다 페이지를 재렌더**(`doc.load_page` 가 셀 루프 내부)해 노출을 셀 수만큼 증폭시켰다.

### 기여 결함
1. clip을 `page.rect` 로 클램프하지 않음, `None`/영높이 bbox 미검증.
2. `load_page` 셀 루프 내부 + `pixmap` 미해제 → 동일 페이지 반복 로딩/네이티브 메모리 누수.

---

## 변경

`ocr_all_table_cells()` 내부의 PyMuPDF 렌더링 경로를 제거하고, Docling이 파이프라인에서
이미 생성한 페이지 이미지(`generate_page_images=True`)를 재사용해 셀 영역을 crop 한다.
이는 순수 파이썬(PIL)이라 **네이티브 크래시가 원천적으로 불가능**하며,
Docling-core `DocItem.get_image` 가 쓰는 좌표 처리(`to_top_left_origin` + `scale_to_size`)를
그대로 미러링해 좌표계 버그도 동시에 해결한다.

- `fitz.open`/`load_page`/`fitz.Rect`/`fitz.Matrix`/`get_pixmap`/`pix.tobytes` **전부 제거**.
- `document.pages.get(page_no).image.pil_image` 에서
  `cell.bbox.to_top_left_origin(page_height).scale_to_size(...)` → `PILImage.crop()`.
- `cell.bbox is None`/페이지 이미지 부재/degenerate·off-page bbox **skip**, 페이지 경계 **클램프**.
- 작은 셀 OCR 가독성 보완용 `LANCZOS` 업스케일(기존 target_height=20, ≤4x 의도 유지).
- **셀 단위 `try/except` 격리** — 한 셀 실패가 나머지 셀/표를 중단시키지 않도록(기존은 첫 실패에서 전체 중단).

### 적용 파일 (총 6개)

facade는 self-contained 단일 마운트 구조라 공통 모듈화가 불가하여 동일 수정을 각 파일에 복제:

- `facade/intelligent_processor.py`, `facade/convert_processor.py`, `facade/chunking_processor.py`
- `facade/parser_processor.py` (임베디드 `IntelligentDocumentProcessor`)
- `facade/legacy/BOK_적재용_규정.py`, `facade/legacy/BOK_적재용_외부.py`

---

## 검증

`intelligent_processor` 파이프라인으로 표 포함 PDF(`10.여비규정_...pdf`)를 실제 OCR 엔드포인트로
end-to-end 실행(mock 아님):

- **SIGSEGV 없이 완주**(worker code 139 미발생).
- 표 4개의 모든 셀 crop→OCR→갱신 정상 동작(총 150셀 처리).
- crop 이미지가 실제 셀 영역과 정확히 일치(좌표계 뒤집힘 해소 확인),
  OCR 인식 텍스트가 원본과 일치(`구 분`, `일비 (1일당)`, `실비의 50%` 등).

> 참고: 표 셀 재OCR은 셀 bbox가 채워지는 `docling_layout`(TableFormer) 경로에서만 유효하다.
> 기본 `genos_layout`(DotsOCR)은 셀 bbox가 None이라 해당 후처리가 애초에 동작하지 않는다
> (검증 시 `docling_layout` 로 일시 전환하여 crop 경로를 확인).

## 영향 범위 / 호환성

- 표 셀 재OCR 트리거 조건(글리프 검사)·후속 청킹 로직은 **변경 없음** — 이미지 소스만 교체.
- PyMuPDF 재렌더 대비 화질은 `images_scale`(기본 2) 고정이나, 작은 셀은 LANCZOS 업스케일로 보완.
- 크래시 안전성·좌표 정확도 향상, 셀 단위 격리로 부분 실패에 견고.

## 관련 이슈
- #302 (표 셀 재OCR SIGSEGV / code 139)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table-cell OCR reliability by reusing already-rendered page images instead of re-rendering each cell.
  * Added safer handling for missing table metadata and skipped invalid or empty cell regions.
  * Small cells are now enlarged before OCR to improve text recognition.
  * Individual cell OCR failures no longer stop processing of the rest of the table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->