### PR TITLE
feat(#307): 비정상/암호화 파일 사전 감지를 parser/convert/attachment 전처리기에도 적용

### DIFF
--- a/docling/models/genos_dots_ocr_layout_model.py
+++ b/docling/models/genos_dots_ocr_layout_model.py
@@ -6,6 +6,7 @@ import requests
 import copy
 import logging
 import re
+import threading
 import time
 import warnings
 from collections.abc import Iterable
@@ -139,6 +140,7 @@ class GenosDotsOCRLayoutModel(BasePageModel):
             getattr(self.dotsocr_options, "table_fallback_enabled", True)
         )
         self._tableformer_model = "unset"  # lazy init sentinel
+        self._tableformer_lock = threading.Lock()
 
     def _use_dotsocr_table_structure(self) -> bool:
         return (
@@ -669,18 +671,21 @@ class GenosDotsOCRLayoutModel(BasePageModel):
                 )
                 if not isinstance(response_text, str) or not response_text.strip():
                     raise ValueError("Empty VLM response text")
-                response = _parse_vlm_json_response(response_text)
-                result = _extract_layout_result_items(response)
-                if not isinstance(result, list):
-                    _log.warning(
-                        "Unexpected VLM response schema (page=%s). Falling back to empty predictions. type=%s",
-                        page.page_no,
-                        type(response).__name__,
-                    )
-                    result = []
                 if finish_reason == "length":
-                    # 토큰 상한까지 폭주 → 응답이 잘려있음. layout_only 폴백.
+                    # 토큰 상한까지 폭주 → 응답이 잘려있음(JSON도 truncate).
+                    # 파싱하면 깨진 JSON에서 예외가 날 수 있으니 건너뛰고 바로 layout_only 폴백.
                     do_fallback = True
+                    result = []
+                else:
+                    response = _parse_vlm_json_response(response_text)
+                    result = _extract_layout_result_items(response)
+                    if not isinstance(result, list):
+                        _log.warning(
+                            "Unexpected VLM response schema (page=%s). Falling back to empty predictions. type=%s",
+                            page.page_no,
+                            type(response).__name__,
+                        )
+                        result = []
             except VLMReadTimeout:
                 _log.warning(
                     "DotsOCR read timeout (page=%s) → layout_only 폴백", page.page_no
@@ -1000,23 +1005,30 @@ class GenosDotsOCRLayoutModel(BasePageModel):
             return None, None
 
     def _get_tableformer(self):
-        """TableStructureModel(TableFormer) lazy 생성. 생성 실패 시 None."""
+        """TableStructureModel(TableFormer) lazy 생성. 생성 실패 시 None.
+
+        페이지가 동시 처리되므로 lock + 더블체크로 생성한다. (락 없이 None 중간상태를
+        다른 워커가 보면 그 페이지의 빈 테이블 보강을 영구히 건너뛰게 됨)"""
         if self._tableformer_model != "unset":
             return self._tableformer_model
-        self._tableformer_model = None
-        try:
-            from docling.models.table_structure_model import TableStructureModel
+        with self._tableformer_lock:
+            if self._tableformer_model != "unset":
+                return self._tableformer_model
+            model = None
+            try:
+                from docling.models.table_structure_model import TableStructureModel
 
-            self._tableformer_model = TableStructureModel(
-                enabled=True,
-                artifacts_path=getattr(self.pipeline_options, "artifacts_path", None),
-                options=self.pipeline_options.table_structure_options,
-                accelerator_options=self.pipeline_options.accelerator_options,
-            )
-        except Exception:
-            _log.warning("TableFormer 생성 실패 → 빈 테이블 보강 생략", exc_info=True)
-            self._tableformer_model = None
-        return self._tableformer_model
+                model = TableStructureModel(
+                    enabled=True,
+                    artifacts_path=getattr(self.pipeline_options, "artifacts_path", None),
+                    options=self.pipeline_options.table_structure_options,
+                    accelerator_options=self.pipeline_options.accelerator_options,
+                )
+            except Exception:
+                _log.warning("TableFormer 생성 실패 → 빈 테이블 보강 생략", exc_info=True)
+                model = None
+            self._tableformer_model = model
+            return self._tableformer_model
 
     def _fill_empty_tables_with_tableformer(
         self, conv_res: ConversionResult, page: Page, clusters: list

--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -25,6 +25,149 @@ from fastapi import Request
 
 _log = logging.getLogger(__name__)
 
+
+# ── 비정상/암호화 파일 사전 감지 (이슈 #278/#307) ─────────────────────────────
+# intelligent_processor.py 의 동일 블록을 복제한 것. facade 는 단일 파일로 배포되므로
+# import 공유 대신 복제한다. 수정 시 네 파일(intelligent/parser/convert/attachment) 동기화 필요.
+# 지원 포맷의 매직 헤더(allowlist). 각 값은 아래 공식 출처로 근거 확인 + 실제 샘플로 검증함.
+#   - 정본 매직 DB: file/file(libmagic) magic/Magdir — 실제 본 모듈이 쓰는 python-magic의 DB.
+#     (PDF=Magdir/pdf "%PDF-", PNG/GIF=Magdir/images, JPEG=Magdir/jpeg 0xffd8ff, ZIP=Magdir/msooxml "PK\3\4")
+#   - 포맷 공식 스펙: PDF=ISO 32000(%PDF-), PNG=W3C PNG/RFC2083(89 50 4E 47 0D 0A 1A 0A),
+#     ZIP=PKWARE APPNOTE(local file header 0x04034b50), OLE2/CFB=[MS-CFB] §2.2 Header(D0CF11E0A1B11AE1).
+# zip(PK)=docx/xlsx/pptx/hwpx, OLE2(d0cf..)=hwp/doc/ppt/xls(레거시).
+_KNOWN_MAGIC_PREFIXES = (
+    b"%PDF-",                                # pdf
+    b"\x89PNG\r\n\x1a\n",                    # png
+    b"\xff\xd8\xff",                         # jpeg/jpg
+    b"GIF87a", b"GIF89a",                    # gif
+    b"BM",                                    # bmp
+    b"II*\x00", b"MM\x00*",                  # tiff
+    b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08",  # zip 계열(ooxml/hwpx)
+    b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1",     # OLE2/CFB(hwp5/doc/ppt/xls)
+    b"ID3",                                   # mp3(id3v2)
+    b"RIFF",                                  # wav/avi/webp
+    b"OggS",                                  # ogg
+    b"fLaC",                                  # flac
+    b"\x1f\x8b",                             # gzip
+    b"7z\xbc\xaf\x27\x1c",                  # 7z
+    b"Rar!\x1a\x07",                        # rar
+    b"<?xml",                                 # xml
+)
+
+# 텍스트로 봐줄 수 없는 제어 바이트(탭/개행/CR/FF 제외). 텍스트 파일엔 거의 없음.
+_TEXT_ALLOWED_CTRL = {0x09, 0x0A, 0x0C, 0x0D}
+
+
+def _looks_like_text(head: bytes) -> bool:
+    """csv/txt/json/md/html 등 매직넘버 없는 텍스트 파일인지 휴리스틱 판정.
+    NUL 이 있거나 제어문자 비율이 높으면 바이너리(=텍스트 아님)."""
+    if not head:
+        return False
+    if b"\x00" in head:
+        return False
+    ctrl = sum(
+        1 for c in head if (c < 0x20 and c not in _TEXT_ALLOWED_CTRL) or c == 0x7F
+    )
+    return (ctrl / len(head)) < 0.05
+
+
+def _is_encrypted_pdf(file_path: str) -> bool:
+    """PDF /Encrypt(비밀번호/DRM 암호화) 여부. ISO 32000 기준, pypdf is_encrypted 사용."""
+    try:
+        from pypdf import PdfReader
+
+        return bool(PdfReader(file_path).is_encrypted)
+    except Exception:
+        return False  # 파싱 실패는 여기서 단정 안 함(후속 단계에서 처리)
+
+
+def _is_encrypted_office(file_path: str) -> bool:
+    """암호화된 OOXML(docx/xlsx/pptx)은 OLE2 컨테이너의 'EncryptedPackage' 스트림으로
+    저장된다(MS-OFFCRYPTO). olefile 로 그 스트림 존재를 확인."""
+    try:
+        import olefile
+
+        if not olefile.isOleFile(file_path):
+            return False
+        ole = olefile.OleFileIO(file_path)
+        try:
+            return ole.exists("EncryptedPackage")
+        finally:
+            ole.close()
+    except Exception:
+        return False
+
+
+def _is_protected_hwp(file_path: str) -> bool:
+    """암호화/배포용(DRM) HWP 감지. HWP 5.0 'FileHeader' 스트림(OLE2 내, 256B)의
+    flags(offset 36, uint32 LE) bit1=password, bit2=distribution(배포용/DRM).
+    이런 HWP 는 본문 스트림이 암호화돼 변환기가 정상 처리 못 함. (근거: HWP 5.0 스펙)"""
+    try:
+        import olefile
+        import struct
+
+        if not olefile.isOleFile(file_path):
+            return False
+        ole = olefile.OleFileIO(file_path)
+        try:
+            if not ole.exists("FileHeader"):
+                return False
+            data = ole.openstream("FileHeader").read()
+            if len(data) < 40 or data[:17] != b"HWP Document File":
+                return False
+            flags = struct.unpack("<I", data[36:40])[0]
+            return bool(flags & 0x02) or bool(flags & 0x04)  # password or distribution(DRM)
+        finally:
+            ole.close()
+    except Exception:
+        return False
+
+
+def _detect_unsupported_file(file_path: str) -> str | None:
+    """입력 파일이 정상 처리 가능한지 판정(이슈 #278). 차단 사유 문자열 또는 정상이면 None.
+
+    근거(공식):
+    - 포맷 인식: 매직헤더 allowlist (file/file libmagic 정본 DB + 각 포맷 공식 스펙).
+      _KNOWN_MAGIC_PREFIXES 위 주석에 출처 명시. 확장자와 무관하게 실제 바이트로 본다.
+    - 암호화 자체는 바이트 패턴으로 못 본다(암호문=고엔트로피 랜덤). 포맷별 구조로 판정:
+      PDF=/Encrypt(pypdf is_encrypted, ISO 32000), Office=OLE2의 EncryptedPackage(MS-OFFCRYPTO),
+      HWP=FileHeader flags(HWP 5.0 스펙).
+    - Fasoo 등 독점 DRM은 표준 감지법이 없다 → 알려진 매직헤더에 안 맞고 텍스트도 아닌
+      바이너리(=고엔트로피 garbage)로 걸러낸다.
+    """
+    try:
+        with open(file_path, "rb") as f:
+            head = f.read(512)
+    except Exception:
+        return None  # 읽기 실패는 여기서 판단 안 함(후속 단계에서 처리)
+    if not head:
+        return "빈 파일"
+
+    is_pdf = head.startswith(b"%PDF-")
+    is_ole2 = head.startswith(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1")
+    # ── Layer 1: 알려진 포맷 매직헤더인가 ──
+    known = (
+        is_pdf
+        or is_ole2
+        or head[4:8] == b"ftyp"  # mp4/mov/m4a (ISO-BMFF, offset 4)
+        or (len(head) >= 2 and head[0] == 0xFF and (head[1] & 0xE0) == 0xE0)  # mp3 frame sync
+        or any(head.startswith(sig) for sig in _KNOWN_MAGIC_PREFIXES)
+    )
+    if not known:
+        if _looks_like_text(head):
+            return None  # csv/txt/json/md/html 등 텍스트 파일
+        return "지원하지 않거나 손상된 파일(DRM 암호화 등)"
+
+    # ── Layer 2: 알려진 포맷이지만 비밀번호/암호화된 경우 ──
+    if is_pdf and _is_encrypted_pdf(file_path):
+        return "암호화된 PDF 문서"
+    if is_ole2 and _is_encrypted_office(file_path):
+        return "암호화된 Office 문서"
+    if is_ole2 and _is_protected_hwp(file_path):
+        return "암호화/배포용(DRM) HWP 문서"
+    return None
+
+
 from glob import glob
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_community.document_loaders import (
@@ -1982,6 +2125,16 @@ class DocumentProcessor:
 
         _log.info(f"file_path: {file_path}")
         _log.info(f"kwargs: {kwargs}")
+
+        # 비정상/암호화 파일 사전 감지(이슈 #278/#307): 지원 포맷 매직헤더에 하나도 안 맞고
+        # 텍스트도 아니면(=DRM 암호화/손상 바이너리) 파싱/변환 단계의 garbage 처리를 유발하므로
+        # 진입부에서 컷한다. 확장자와 무관하게 실제 헤더로 판정.
+        bad_reason = _detect_unsupported_file(file_path)
+        if bad_reason:
+            _log.warning(f"[attachment] 비정상 파일 감지({bad_reason}) — 처리 중단: {file_path}")
+            raise GenosServiceException(
+                "1", f"{bad_reason} 입니다. 정상 문서로 다시 업로드하세요: {os.path.basename(file_path)}"
+            )
 
         ext = os.path.splitext(file_path)[-1].lower()
         if ext in ('.wav', '.mp3', '.m4a'):

--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -63,6 +63,9 @@ def _looks_like_text(head: bytes) -> bool:
     NUL 이 있거나 제어문자 비율이 높으면 바이너리(=텍스트 아님)."""
     if not head:
         return False
+    # UTF-16/32 텍스트는 NUL 바이트가 흔하므로 BOM 이면 먼저 텍스트로 인정.
+    if head.startswith((b"\xff\xfe", b"\xfe\xff")):  # UTF-16 LE/BE (UTF-32 BOM 도 이 prefix로 시작)
+        return True
     if b"\x00" in head:
         return False
     ctrl = sum(

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -16,6 +16,149 @@ from fastapi import Request
 
 _log = logging.getLogger(__name__)
 
+
+# ── 비정상/암호화 파일 사전 감지 (이슈 #278/#307) ─────────────────────────────
+# intelligent_processor.py 의 동일 블록을 복제한 것. facade 는 단일 파일로 배포되므로
+# import 공유 대신 복제한다. 수정 시 네 파일(intelligent/parser/convert/attachment) 동기화 필요.
+# 지원 포맷의 매직 헤더(allowlist). 각 값은 아래 공식 출처로 근거 확인 + 실제 샘플로 검증함.
+#   - 정본 매직 DB: file/file(libmagic) magic/Magdir — 실제 본 모듈이 쓰는 python-magic의 DB.
+#     (PDF=Magdir/pdf "%PDF-", PNG/GIF=Magdir/images, JPEG=Magdir/jpeg 0xffd8ff, ZIP=Magdir/msooxml "PK\3\4")
+#   - 포맷 공식 스펙: PDF=ISO 32000(%PDF-), PNG=W3C PNG/RFC2083(89 50 4E 47 0D 0A 1A 0A),
+#     ZIP=PKWARE APPNOTE(local file header 0x04034b50), OLE2/CFB=[MS-CFB] §2.2 Header(D0CF11E0A1B11AE1).
+# zip(PK)=docx/xlsx/pptx/hwpx, OLE2(d0cf..)=hwp/doc/ppt/xls(레거시).
+_KNOWN_MAGIC_PREFIXES = (
+    b"%PDF-",                                # pdf
+    b"\x89PNG\r\n\x1a\n",                    # png
+    b"\xff\xd8\xff",                         # jpeg/jpg
+    b"GIF87a", b"GIF89a",                    # gif
+    b"BM",                                    # bmp
+    b"II*\x00", b"MM\x00*",                  # tiff
+    b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08",  # zip 계열(ooxml/hwpx)
+    b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1",     # OLE2/CFB(hwp5/doc/ppt/xls)
+    b"ID3",                                   # mp3(id3v2)
+    b"RIFF",                                  # wav/avi/webp
+    b"OggS",                                  # ogg
+    b"fLaC",                                  # flac
+    b"\x1f\x8b",                             # gzip
+    b"7z\xbc\xaf\x27\x1c",                  # 7z
+    b"Rar!\x1a\x07",                        # rar
+    b"<?xml",                                 # xml
+)
+
+# 텍스트로 봐줄 수 없는 제어 바이트(탭/개행/CR/FF 제외). 텍스트 파일엔 거의 없음.
+_TEXT_ALLOWED_CTRL = {0x09, 0x0A, 0x0C, 0x0D}
+
+
+def _looks_like_text(head: bytes) -> bool:
+    """csv/txt/json/md/html 등 매직넘버 없는 텍스트 파일인지 휴리스틱 판정.
+    NUL 이 있거나 제어문자 비율이 높으면 바이너리(=텍스트 아님)."""
+    if not head:
+        return False
+    if b"\x00" in head:
+        return False
+    ctrl = sum(
+        1 for c in head if (c < 0x20 and c not in _TEXT_ALLOWED_CTRL) or c == 0x7F
+    )
+    return (ctrl / len(head)) < 0.05
+
+
+def _is_encrypted_pdf(file_path: str) -> bool:
+    """PDF /Encrypt(비밀번호/DRM 암호화) 여부. ISO 32000 기준, pypdf is_encrypted 사용."""
+    try:
+        from pypdf import PdfReader
+
+        return bool(PdfReader(file_path).is_encrypted)
+    except Exception:
+        return False  # 파싱 실패는 여기서 단정 안 함(후속 단계에서 처리)
+
+
+def _is_encrypted_office(file_path: str) -> bool:
+    """암호화된 OOXML(docx/xlsx/pptx)은 OLE2 컨테이너의 'EncryptedPackage' 스트림으로
+    저장된다(MS-OFFCRYPTO). olefile 로 그 스트림 존재를 확인."""
+    try:
+        import olefile
+
+        if not olefile.isOleFile(file_path):
+            return False
+        ole = olefile.OleFileIO(file_path)
+        try:
+            return ole.exists("EncryptedPackage")
+        finally:
+            ole.close()
+    except Exception:
+        return False
+
+
+def _is_protected_hwp(file_path: str) -> bool:
+    """암호화/배포용(DRM) HWP 감지. HWP 5.0 'FileHeader' 스트림(OLE2 내, 256B)의
+    flags(offset 36, uint32 LE) bit1=password, bit2=distribution(배포용/DRM).
+    이런 HWP 는 본문 스트림이 암호화돼 변환기가 정상 처리 못 함. (근거: HWP 5.0 스펙)"""
+    try:
+        import olefile
+        import struct
+
+        if not olefile.isOleFile(file_path):
+            return False
+        ole = olefile.OleFileIO(file_path)
+        try:
+            if not ole.exists("FileHeader"):
+                return False
+            data = ole.openstream("FileHeader").read()
+            if len(data) < 40 or data[:17] != b"HWP Document File":
+                return False
+            flags = struct.unpack("<I", data[36:40])[0]
+            return bool(flags & 0x02) or bool(flags & 0x04)  # password or distribution(DRM)
+        finally:
+            ole.close()
+    except Exception:
+        return False
+
+
+def _detect_unsupported_file(file_path: str) -> str | None:
+    """입력 파일이 정상 처리 가능한지 판정(이슈 #278). 차단 사유 문자열 또는 정상이면 None.
+
+    근거(공식):
+    - 포맷 인식: 매직헤더 allowlist (file/file libmagic 정본 DB + 각 포맷 공식 스펙).
+      _KNOWN_MAGIC_PREFIXES 위 주석에 출처 명시. 확장자와 무관하게 실제 바이트로 본다.
+    - 암호화 자체는 바이트 패턴으로 못 본다(암호문=고엔트로피 랜덤). 포맷별 구조로 판정:
+      PDF=/Encrypt(pypdf is_encrypted, ISO 32000), Office=OLE2의 EncryptedPackage(MS-OFFCRYPTO),
+      HWP=FileHeader flags(HWP 5.0 스펙).
+    - Fasoo 등 독점 DRM은 표준 감지법이 없다 → 알려진 매직헤더에 안 맞고 텍스트도 아닌
+      바이너리(=고엔트로피 garbage)로 걸러낸다.
+    """
+    try:
+        with open(file_path, "rb") as f:
+            head = f.read(512)
+    except Exception:
+        return None  # 읽기 실패는 여기서 판단 안 함(후속 단계에서 처리)
+    if not head:
+        return "빈 파일"
+
+    is_pdf = head.startswith(b"%PDF-")
+    is_ole2 = head.startswith(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1")
+    # ── Layer 1: 알려진 포맷 매직헤더인가 ──
+    known = (
+        is_pdf
+        or is_ole2
+        or head[4:8] == b"ftyp"  # mp4/mov/m4a (ISO-BMFF, offset 4)
+        or (len(head) >= 2 and head[0] == 0xFF and (head[1] & 0xE0) == 0xE0)  # mp3 frame sync
+        or any(head.startswith(sig) for sig in _KNOWN_MAGIC_PREFIXES)
+    )
+    if not known:
+        if _looks_like_text(head):
+            return None  # csv/txt/json/md/html 등 텍스트 파일
+        return "지원하지 않거나 손상된 파일(DRM 암호화 등)"
+
+    # ── Layer 2: 알려진 포맷이지만 비밀번호/암호화된 경우 ──
+    if is_pdf and _is_encrypted_pdf(file_path):
+        return "암호화된 PDF 문서"
+    if is_ole2 and _is_encrypted_office(file_path):
+        return "암호화된 Office 문서"
+    if is_ole2 and _is_protected_hwp(file_path):
+        return "암호화/배포용(DRM) HWP 문서"
+    return None
+
+
 # from utils import assert_cancelled
 import fitz
 import math, bisect
@@ -3284,6 +3427,16 @@ class DocumentProcessor:
         # attachment_processor.DocumentProcessor.__call__ 의 PDF 폴백과 동일 취지 —
         # convert_to_pdf 는 rhwp ↔ LibreOffice HWP→PDF 체인이며, 변환된 PDF 를 PDF 경로로 재처리한다.
         # (헌법.hwp 처럼 SDK 가 exit 3 으로 거부하거나 02.hwp 처럼 빈 결과를 내는 경우를 살린다.)
+        # 비정상/암호화 파일 사전 감지(이슈 #278/#307): 지원 포맷 매직헤더에 하나도 안 맞고
+        # 텍스트도 아니면(=DRM 암호화/손상 바이너리) 파싱/변환 단계의 garbage 처리를 유발하므로
+        # 진입부에서 컷한다. 확장자와 무관하게 실제 헤더로 판정.
+        bad_reason = _detect_unsupported_file(file_path)
+        if bad_reason:
+            _log.warning(f"[convert] 비정상 파일 감지({bad_reason}) — 처리 중단: {file_path}")
+            raise GenosServiceException(
+                "1", f"{bad_reason} 입니다. 정상 문서로 다시 업로드하세요: {os.path.basename(file_path)}"
+            )
+
         ext = Path(file_path).suffix.lower()
         if ext in ('.hwp', '.hwpx'):
             try:

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -54,6 +54,9 @@ def _looks_like_text(head: bytes) -> bool:
     NUL 이 있거나 제어문자 비율이 높으면 바이너리(=텍스트 아님)."""
     if not head:
         return False
+    # UTF-16/32 텍스트는 NUL 바이트가 흔하므로 BOM 이면 먼저 텍스트로 인정.
+    if head.startswith((b"\xff\xfe", b"\xfe\xff")):  # UTF-16 LE/BE (UTF-32 BOM 도 이 prefix로 시작)
+        return True
     if b"\x00" in head:
         return False
     ctrl = sum(

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -82,6 +82,9 @@ def _has_any_pdf_converter() -> bool:
         return True
 
 
+# ── 비정상/암호화 파일 사전 감지 (이슈 #278/#307) ─────────────────────────────
+# 이 블록은 parser/convert/attachment_processor 에도 복제되어 있다(단일 파일 배포 구조).
+# 수정 시 네 파일 동기화 필요.
 # 지원 포맷의 매직 헤더(allowlist). 각 값은 아래 공식 출처로 근거 확인 + 실제 샘플로 검증함.
 #   - 정본 매직 DB: file/file(libmagic) magic/Magdir — 실제 본 모듈이 쓰는 python-magic의 DB.
 #     (PDF=Magdir/pdf "%PDF-", PNG/GIF=Magdir/images, JPEG=Magdir/jpeg 0xffd8ff, ZIP=Magdir/msooxml "PK\3\4")

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -119,6 +119,9 @@ def _looks_like_text(head: bytes) -> bool:
     NUL 이 있거나 제어문자 비율이 높으면 바이너리(=텍스트 아님)."""
     if not head:
         return False
+    # UTF-16/32 텍스트는 NUL 바이트가 흔하므로 BOM 이면 먼저 텍스트로 인정.
+    if head.startswith((b"\xff\xfe", b"\xfe\xff")):  # UTF-16 LE/BE (UTF-32 BOM 도 이 prefix로 시작)
+        return True
     if b"\x00" in head:
         return False
     ctrl = sum(
@@ -2896,7 +2899,7 @@ class DocumentProcessor:
         from collections import defaultdict
         page_item_count: dict = defaultdict(int)
         page_text_len: dict = defaultdict(int)
-        for item, level in document.iterate_items():
+        for item, _level in document.iterate_items():
             if isinstance(item, TextItem) and hasattr(item, 'prov') and item.prov:
                 page_no = item.prov[0].page_no
                 page_item_count[page_no] += 1
@@ -3327,7 +3330,7 @@ class DocumentProcessor:
                 f"[intelligent] 비정상 파일 감지({bad_reason}) — 처리 중단: {file_path}"
             )
             raise GenosServiceException(
-                1, f"{bad_reason} 입니다. 정상 문서로 다시 업로드하세요: {os.path.basename(file_path)}"
+                "1", f"{bad_reason} 입니다. 정상 문서로 다시 업로드하세요: {os.path.basename(file_path)}"
             )
 
         ext = os.path.splitext(file_path)[1].lower()

--- a/genon/preprocessor/facade/parser_processor.py
+++ b/genon/preprocessor/facade/parser_processor.py
@@ -125,6 +125,149 @@ except ImportError:
 
 _log = logging.getLogger(__name__)
 
+
+# ── 비정상/암호화 파일 사전 감지 (이슈 #278/#307) ─────────────────────────────
+# intelligent_processor.py 의 동일 블록을 복제한 것. facade 는 단일 파일로 배포되므로
+# import 공유 대신 복제한다. 수정 시 네 파일(intelligent/parser/convert/attachment) 동기화 필요.
+# 지원 포맷의 매직 헤더(allowlist). 각 값은 아래 공식 출처로 근거 확인 + 실제 샘플로 검증함.
+#   - 정본 매직 DB: file/file(libmagic) magic/Magdir — 실제 본 모듈이 쓰는 python-magic의 DB.
+#     (PDF=Magdir/pdf "%PDF-", PNG/GIF=Magdir/images, JPEG=Magdir/jpeg 0xffd8ff, ZIP=Magdir/msooxml "PK\3\4")
+#   - 포맷 공식 스펙: PDF=ISO 32000(%PDF-), PNG=W3C PNG/RFC2083(89 50 4E 47 0D 0A 1A 0A),
+#     ZIP=PKWARE APPNOTE(local file header 0x04034b50), OLE2/CFB=[MS-CFB] §2.2 Header(D0CF11E0A1B11AE1).
+# zip(PK)=docx/xlsx/pptx/hwpx, OLE2(d0cf..)=hwp/doc/ppt/xls(레거시).
+_KNOWN_MAGIC_PREFIXES = (
+    b"%PDF-",                                # pdf
+    b"\x89PNG\r\n\x1a\n",                    # png
+    b"\xff\xd8\xff",                         # jpeg/jpg
+    b"GIF87a", b"GIF89a",                    # gif
+    b"BM",                                    # bmp
+    b"II*\x00", b"MM\x00*",                  # tiff
+    b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08",  # zip 계열(ooxml/hwpx)
+    b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1",     # OLE2/CFB(hwp5/doc/ppt/xls)
+    b"ID3",                                   # mp3(id3v2)
+    b"RIFF",                                  # wav/avi/webp
+    b"OggS",                                  # ogg
+    b"fLaC",                                  # flac
+    b"\x1f\x8b",                             # gzip
+    b"7z\xbc\xaf\x27\x1c",                  # 7z
+    b"Rar!\x1a\x07",                        # rar
+    b"<?xml",                                 # xml
+)
+
+# 텍스트로 봐줄 수 없는 제어 바이트(탭/개행/CR/FF 제외). 텍스트 파일엔 거의 없음.
+_TEXT_ALLOWED_CTRL = {0x09, 0x0A, 0x0C, 0x0D}
+
+
+def _looks_like_text(head: bytes) -> bool:
+    """csv/txt/json/md/html 등 매직넘버 없는 텍스트 파일인지 휴리스틱 판정.
+    NUL 이 있거나 제어문자 비율이 높으면 바이너리(=텍스트 아님)."""
+    if not head:
+        return False
+    if b"\x00" in head:
+        return False
+    ctrl = sum(
+        1 for c in head if (c < 0x20 and c not in _TEXT_ALLOWED_CTRL) or c == 0x7F
+    )
+    return (ctrl / len(head)) < 0.05
+
+
+def _is_encrypted_pdf(file_path: str) -> bool:
+    """PDF /Encrypt(비밀번호/DRM 암호화) 여부. ISO 32000 기준, pypdf is_encrypted 사용."""
+    try:
+        from pypdf import PdfReader
+
+        return bool(PdfReader(file_path).is_encrypted)
+    except Exception:
+        return False  # 파싱 실패는 여기서 단정 안 함(후속 단계에서 처리)
+
+
+def _is_encrypted_office(file_path: str) -> bool:
+    """암호화된 OOXML(docx/xlsx/pptx)은 OLE2 컨테이너의 'EncryptedPackage' 스트림으로
+    저장된다(MS-OFFCRYPTO). olefile 로 그 스트림 존재를 확인."""
+    try:
+        import olefile
+
+        if not olefile.isOleFile(file_path):
+            return False
+        ole = olefile.OleFileIO(file_path)
+        try:
+            return ole.exists("EncryptedPackage")
+        finally:
+            ole.close()
+    except Exception:
+        return False
+
+
+def _is_protected_hwp(file_path: str) -> bool:
+    """암호화/배포용(DRM) HWP 감지. HWP 5.0 'FileHeader' 스트림(OLE2 내, 256B)의
+    flags(offset 36, uint32 LE) bit1=password, bit2=distribution(배포용/DRM).
+    이런 HWP 는 본문 스트림이 암호화돼 변환기가 정상 처리 못 함. (근거: HWP 5.0 스펙)"""
+    try:
+        import olefile
+        import struct
+
+        if not olefile.isOleFile(file_path):
+            return False
+        ole = olefile.OleFileIO(file_path)
+        try:
+            if not ole.exists("FileHeader"):
+                return False
+            data = ole.openstream("FileHeader").read()
+            if len(data) < 40 or data[:17] != b"HWP Document File":
+                return False
+            flags = struct.unpack("<I", data[36:40])[0]
+            return bool(flags & 0x02) or bool(flags & 0x04)  # password or distribution(DRM)
+        finally:
+            ole.close()
+    except Exception:
+        return False
+
+
+def _detect_unsupported_file(file_path: str) -> str | None:
+    """입력 파일이 정상 처리 가능한지 판정(이슈 #278). 차단 사유 문자열 또는 정상이면 None.
+
+    근거(공식):
+    - 포맷 인식: 매직헤더 allowlist (file/file libmagic 정본 DB + 각 포맷 공식 스펙).
+      _KNOWN_MAGIC_PREFIXES 위 주석에 출처 명시. 확장자와 무관하게 실제 바이트로 본다.
+    - 암호화 자체는 바이트 패턴으로 못 본다(암호문=고엔트로피 랜덤). 포맷별 구조로 판정:
+      PDF=/Encrypt(pypdf is_encrypted, ISO 32000), Office=OLE2의 EncryptedPackage(MS-OFFCRYPTO),
+      HWP=FileHeader flags(HWP 5.0 스펙).
+    - Fasoo 등 독점 DRM은 표준 감지법이 없다 → 알려진 매직헤더에 안 맞고 텍스트도 아닌
+      바이너리(=고엔트로피 garbage)로 걸러낸다.
+    """
+    try:
+        with open(file_path, "rb") as f:
+            head = f.read(512)
+    except Exception:
+        return None  # 읽기 실패는 여기서 판단 안 함(후속 단계에서 처리)
+    if not head:
+        return "빈 파일"
+
+    is_pdf = head.startswith(b"%PDF-")
+    is_ole2 = head.startswith(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1")
+    # ── Layer 1: 알려진 포맷 매직헤더인가 ──
+    known = (
+        is_pdf
+        or is_ole2
+        or head[4:8] == b"ftyp"  # mp4/mov/m4a (ISO-BMFF, offset 4)
+        or (len(head) >= 2 and head[0] == 0xFF and (head[1] & 0xE0) == 0xE0)  # mp3 frame sync
+        or any(head.startswith(sig) for sig in _KNOWN_MAGIC_PREFIXES)
+    )
+    if not known:
+        if _looks_like_text(head):
+            return None  # csv/txt/json/md/html 등 텍스트 파일
+        return "지원하지 않거나 손상된 파일(DRM 암호화 등)"
+
+    # ── Layer 2: 알려진 포맷이지만 비밀번호/암호화된 경우 ──
+    if is_pdf and _is_encrypted_pdf(file_path):
+        return "암호화된 PDF 문서"
+    if is_ole2 and _is_encrypted_office(file_path):
+        return "암호화된 Office 문서"
+    if is_ole2 and _is_protected_hwp(file_path):
+        return "암호화/배포용(DRM) HWP 문서"
+    return None
+
+
 # fontTools 로그 억제
 for _n in ("fontTools", "fontTools.ttLib", "fontTools.ttLib.ttFont"):
     _lg = logging.getLogger(_n)
@@ -2467,6 +2610,16 @@ class DocumentProcessor:
 
         ext = os.path.splitext(file_path)[-1].lower()
         _log.info(f"[DocumentProcessor] file_path={file_path}, ext={ext}")
+
+        # 비정상/암호화 파일 사전 감지(이슈 #278/#307): 지원 포맷 매직헤더에 하나도 안 맞고
+        # 텍스트도 아니면(=DRM 암호화/손상 바이너리) 파싱/변환 단계의 garbage 처리를 유발하므로
+        # 진입부에서 컷한다. 확장자와 무관하게 실제 헤더로 판정.
+        bad_reason = _detect_unsupported_file(file_path)
+        if bad_reason:
+            _log.warning(f"[parser] 비정상 파일 감지({bad_reason}) — 처리 중단: {file_path}")
+            raise GenosServiceException(
+                "1", f"{bad_reason} 입니다. 정상 문서로 다시 업로드하세요: {os.path.basename(file_path)}"
+            )
 
         if ext in (".wav", ".mp3", ".m4a"):
             text = self._parse_audio(file_path, **kwargs)

--- a/genon/preprocessor/facade/parser_processor.py
+++ b/genon/preprocessor/facade/parser_processor.py
@@ -163,6 +163,9 @@ def _looks_like_text(head: bytes) -> bool:
     NUL 이 있거나 제어문자 비율이 높으면 바이너리(=텍스트 아님)."""
     if not head:
         return False
+    # UTF-16/32 텍스트는 NUL 바이트가 흔하므로 BOM 이면 먼저 텍스트로 인정.
+    if head.startswith((b"\xff\xfe", b"\xfe\xff")):  # UTF-16 LE/BE (UTF-32 BOM 도 이 prefix로 시작)
+        return True
     if b"\x00" in head:
         return False
     ctrl = sum(
@@ -1326,7 +1329,7 @@ class IntelligentDocumentProcessor:
             genos_layout_cfg.get("timeout"), "layout.genos_layout.timeout"
         )
         if layout_timeout is None or layout_timeout <= 0:
-            layout_timeout = 3600
+            layout_timeout = 1200  # 이슈 #278: per-page hang 방지(GenosLayoutOptions 기본과 통일)
         layout_retry_count = _parse_optional_int(
             genos_layout_cfg.get("retry_count"), "layout.genos_layout.retry_count"
         )


### PR DESCRIPTION
## 배경

- #278(PR #293)에서 지능형 전처리기에 **비정상/암호화 파일 사전 감지**(`_detect_unsupported_file`)를 추가함:
  - Layer 1: 매직헤더 allowlist — 지원 포맷 매직에 안 맞고 텍스트도 아니면(DRM 블롭 등) 컷
  - Layer 2: 암호화 구조 감지 — PDF `/Encrypt`(pypdf) · Office `EncryptedPackage`(olefile) · HWP `FileHeader` flags
- 원본 문서를 직접 받는 전처리기는 intelligent 만이 아니므로, **parser / convert / attachment** 에도 동일 감지를 적용함 (리뷰 지적 반영).
- **chunking_processor 는 제외** — 원본 문서가 아니라 parser 결과 JSON 을 입력받음.
- 추가로 **PR #293 의 봇 리뷰(CodeRabbit/Gemini) 중 유효 판정 6건**을 이 PR 에 함께 반영함 (2번째 커밋).

## 변경 1 — 사전 감지 확대 (커밋 1)

| 파일 | 내용 |
|---|---|
| `parser_processor.py` | 감지 블록 복제 + `DocumentProcessor.__call__` 진입부 컷 |
| `convert_processor.py` | 〃 (HWP 폴백 분기 이전에 컷 — 변환 재진입 경로 중복검사 방지) |
| `attachment_processor.py` | 〃 (내부 Docx/Hwp 프로세서는 DocumentProcessor 가 라우팅하므로 진입부 1곳으로 커버) |
| `intelligent_processor.py` | 4파일 동기화 필요 주석 추가 |

- facade 는 **단일 파일 배포** 구조(각 파일에 `GenosServiceException` 중복 정의된 것과 동일 패턴)라 import 공유 대신 블록을 복제함. 블록 상단에 "수정 시 4파일 동기화" 주석 명시.

## 변경 2 — PR #293 리뷰 후속 수정 (커밋 2)

| # | 수정 | 이유 |
|---|---|---|
| 1 | `finish_reason=="length"` 를 **JSON 파싱보다 먼저** 체크 | length 응답은 JSON 이 잘려 있어 파싱 시도 자체가 불필요/위험 |
| 2 | TableFormer lazy-init **thread-safe**(lock+더블체크) | 동시 페이지 처리 시 `None` 중간상태를 본 워커가 빈표 보강을 영구 스킵 |
| 3 | `_looks_like_text` **UTF-16/32 BOM 통과** | UTF-16 텍스트는 NUL 이 흔해 바이너리로 오탐 차단될 수 있음 — 감지 블록 4파일 동기 반영 |
| 4 | intelligent 게이트 `GenosServiceException(1→"1")` | 생성자 타입힌트(str)·타 호출부와 일치 |
| 5 | `check_empty_text` unused `level` → `_level` | Ruff |
| 6 | `parser_processor` layout timeout 폴백 3600→1200 | #278 의 per-page hang 방지 계약과 통일 |

## 검증 (docker)

| 시나리오 | 결과 |
|---|---|
| DRM 블롭 2종(.pdf/.png 위장)·암호화 PDF 차단 — **4개 모듈 각각** | OK |
| **UTF-16(BOM) csv 통과** + 정상 12종 통과 — 4개 모듈 각각 | OK |
| `length` → layout_only 폴백 **e2e**(mock VLM, 11페이지) → 청크 생성 | OK |
| 4파일 감지 블록 동일성 diff / 게이트 위치 ast 검사 | IDENTICAL / OK |

- attachment 는 재현 이미지에 libpango 가 없어(기존 weasyprint 모듈 import 이슈, 본 변경과 무관) 파일의 감지 블록을 추출·실행해 검증함.
- TableFormer lock 은 mock 환경에서 동시성 재현이 어려워 로직 검증까지(표준 double-checked locking).

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)