### PR TITLE
첨부용 config yaml 옵션 정리

### DIFF
--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -1253,27 +1253,38 @@ class HybridChunker(BaseChunker):
 # 페이지 정보는 export_to_markdown(page_break_placeholder=...)로 삽입한 마커를
 # 청크별로 카운트해 복원한다. 한 청크가 여러 페이지에 걸칠 수 있다.
 _RECURSIVE_PAGE_BREAK = "<!-- PB -->"
-_RECURSIVE_CHUNK_SIZE_CAP = 60000  # 임베딩 입력 한도(~128K 토큰)의 절반 안전 마진
 
 
-def _resolve_recursive_tokenizer(tokenizer_id=None):
-    if tokenizer_id is None:
-        local = Path(_DEFAULT_TOKENIZER_LOCAL_PATH)
-        tokenizer_id = local if local.exists() else _DEFAULT_TOKENIZER_ID
-    return AutoTokenizer.from_pretrained(tokenizer_id)
+def _char_split_text(text: str, chunk_size=None, chunk_overlap=None) -> list[str]:
+    """문자수 기반 청킹 공용 헬퍼 (generic/recursive 경로 공유).
+
+    chunk_size 가 0 이하/None 이면 분할하지 않고 전체를 1청크로 둔다.
+    chunk_size > 0 이면 RecursiveCharacterTextSplitter 로 문자 단위 분할한다.
+    """
+    if not text:
+        return []
+
+    cs = int(chunk_size) if chunk_size is not None else 0
+    co = max(int(chunk_overlap), 0) if chunk_overlap is not None else 100
+
+    if cs > 0:
+        raw_chunks = RecursiveCharacterTextSplitter(
+            chunk_size=cs, chunk_overlap=co,
+        ).split_text(text)
+    else:
+        raw_chunks = [text]
+
+    return [c for c in raw_chunks if c]
 
 
 def _split_with_recursive_chunker(
     document: DoclingDocument,
     chunk_size=None,
     chunk_overlap=None,
-    tokenizer_id=None,
-    token_chunk_size_cap=None,
 ) -> List[dict]:
-    """Markdown export + RecursiveCharacterTextSplitter로 docling 문서를 분할.
+    """Markdown export + 문자수 기반 청킹(_char_split_text)으로 docling 문서를 분할.
 
-    1) char 단위로 1차 분할 (chunk_size 기본 8192).
-    2) 한 청크가 60,000 토큰을 초과하면 토큰 단위로 강제 재분할 — 임베딩 한도 절대 상한 (이슈 #183).
+    chunk_size 로 문자 분할 (0 이하이면 분할 안 함 = 전체 1청크).
 
     Returns: list of dict {text, page_no, pages, doc_items}
     """
@@ -1281,33 +1292,12 @@ def _split_with_recursive_chunker(
     if not md_full:
         return []
 
-    cs = max(int(chunk_size), 1) if chunk_size is not None else 8192
     co = max(int(chunk_overlap), 0) if chunk_overlap is not None else 100
-    token_chunk_size_cap = (
-        max(int(token_chunk_size_cap), 1)
-        if token_chunk_size_cap is not None
-        else _RECURSIVE_CHUNK_SIZE_CAP
+    raw_chunks = _char_split_text(
+        md_full,
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
     )
-    splitter = RecursiveCharacterTextSplitter(
-        chunk_size=cs,
-        chunk_overlap=co,
-    )
-    raw_chunks = splitter.split_text(md_full)
-
-    # 60K 토큰 절대 상한 — 어떤 chunk_size 설정에서도 초과 청크는 토큰 단위로 강제 재분할
-    tokenizer = _resolve_recursive_tokenizer(tokenizer_id)
-    token_splitter = RecursiveCharacterTextSplitter.from_huggingface_tokenizer(
-        tokenizer,
-        chunk_size=token_chunk_size_cap,
-        chunk_overlap=0,
-    )
-    safe_chunks: list[str] = []
-    for raw in raw_chunks:
-        if len(tokenizer.tokenize(raw)) <= token_chunk_size_cap:
-            safe_chunks.append(raw)
-        else:
-            safe_chunks.extend(token_splitter.split_text(raw))
-    raw_chunks = safe_chunks
 
     # 페이지별 doc_items 캐시 (반복 조회 방지)
     page_items_cache: dict[int, list] = {}
@@ -1414,8 +1404,6 @@ class DocxProcessor:
                 document,
                 chunk_size=recursive_chunk_size,
                 chunk_overlap=recursive_chunk_overlap,
-                tokenizer_id=kwargs.get("recursive_tokenizer_id"),
-                token_chunk_size_cap=kwargs.get("recursive_token_chunk_size_cap"),
             )
             for ch in chunks:
                 self.page_chunk_counts[ch["page_no"]] += 1
@@ -1434,9 +1422,6 @@ class DocxProcessor:
             "tokenizer": self._tokenizer,
             "tokenizer_type": kwargs.get("hybrid_tokenizer_type", "char"),
         }
-        hybrid_tokenizer = kwargs.get("hybrid_tokenizer_id")
-        if hybrid_tokenizer:
-            chunker_kwargs["tokenizer"] = hybrid_tokenizer
         chunker = HybridChunker(**chunker_kwargs)
         chunks: List[DocChunk] = list(chunker.chunk(dl_doc=document, **kwargs))
         for chunk in chunks:
@@ -1593,8 +1578,6 @@ class HwpProcessor:
                 document,
                 chunk_size=recursive_chunk_size,
                 chunk_overlap=recursive_chunk_overlap,
-                tokenizer_id=kwargs.get("recursive_tokenizer_id"),
-                token_chunk_size_cap=kwargs.get("recursive_token_chunk_size_cap"),
             )
             for ch in chunks:
                 page_chunk_counts[ch["page_no"]] += 1
@@ -1613,9 +1596,6 @@ class HwpProcessor:
             "tokenizer": self._tokenizer,
             "tokenizer_type": kwargs.get("hybrid_tokenizer_type", "char"),
         }
-        hybrid_tokenizer = kwargs.get("hybrid_tokenizer_id")
-        if hybrid_tokenizer:
-            chunker_kwargs["tokenizer"] = hybrid_tokenizer
         chunker = HybridChunker(**chunker_kwargs)
         chunks: List[DocChunk] = list(chunker.chunk(dl_doc=document, **kwargs))
         for chunk in chunks:
@@ -1765,13 +1745,17 @@ class DocumentProcessor:
         # config 위치: formats.ppt.page_description. 공통 모듈(enrichment/page_description)로 파싱.
         formats_cfg = _as_dict(cfg.get("formats"))
         ppt_fmt_cfg = _as_dict(formats_cfg.get("ppt"))
+        hwp_fmt_cfg = _as_dict(formats_cfg.get("hwp"))
         ppt_pd_cfg = _as_dict(ppt_fmt_cfg.get("page_description"))
         self._page_desc_options = PageDescriptionOptions.from_config(ppt_pd_cfg, self._config_dir)
 
         # 청킹용 토크나이저 (chunking config 기반; 미지정 시 현행 기본값)
         self._tokenizer = _resolve_tokenizer(chunking_cfg)
 
-        chunker_type = str(defaults_cfg.get("chunker_type", "recursive")).strip().lower()
+        # 청킹 모드는 chunking.chunker_type 에서 읽는다(구버전 호환: 없으면 defaults.chunker_type).
+        chunker_type = str(
+            chunking_cfg.get("chunker_type", defaults_cfg.get("chunker_type", "recursive"))
+        ).strip().lower()
         if chunker_type not in {"recursive", "hybrid"}:
             _log.warning(
                 f"[DocumentProcessor] Unknown defaults.chunker_type '{chunker_type}', fallback to 'recursive'."
@@ -1779,48 +1763,56 @@ class DocumentProcessor:
             chunker_type = "recursive"
 
         use_pdf_sdk = _parse_optional_bool(defaults_cfg.get("use_pdf_sdk"), "defaults.use_pdf_sdk")
-        use_hwp_sdk = _parse_optional_bool(defaults_cfg.get("use_hwp_sdk"), "defaults.use_hwp_sdk")
+
+        # HWP/HWPX 전용 옵션은 formats.hwp 에서 읽는다(구버전 호환: 없으면 defaults 폴백).
+        use_hwp_sdk = _parse_optional_bool(hwp_fmt_cfg.get("use_hwp_sdk"), "formats.hwp.use_hwp_sdk")
+        if use_hwp_sdk is None:
+            use_hwp_sdk = _parse_optional_bool(defaults_cfg.get("use_hwp_sdk"), "defaults.use_hwp_sdk")
         dump_sdk_output = _parse_optional_bool(
-            defaults_cfg.get("dump_sdk_output"), "defaults.dump_sdk_output"
+            hwp_fmt_cfg.get("dump_sdk_output"), "formats.hwp.dump_sdk_output"
         )
-        save_images = _parse_optional_bool(defaults_cfg.get("save_images"), "defaults.save_images")
+        if dump_sdk_output is None:
+            dump_sdk_output = _parse_optional_bool(
+                defaults_cfg.get("dump_sdk_output"), "defaults.dump_sdk_output"
+            )
+        save_images = _parse_optional_bool(hwp_fmt_cfg.get("save_images"), "formats.hwp.save_images")
+        if save_images is None:
+            save_images = _parse_optional_bool(defaults_cfg.get("save_images"), "defaults.save_images")
 
         log_level = _parse_optional_int(defaults_cfg.get("log_level"), "defaults.log_level")
         if log_level is None:
             log_level = 4
 
-        generic_chunk_size = _parse_optional_int(
-            generic_chunk_cfg.get("chunk_size"), "chunking.generic.chunk_size"
-        )
-        if generic_chunk_size is None or generic_chunk_size <= 0:
-            generic_chunk_size = 1000
-        generic_chunk_overlap = _parse_optional_int(
-            generic_chunk_cfg.get("chunk_overlap"), "chunking.generic.chunk_overlap"
-        )
-        if generic_chunk_overlap is None or generic_chunk_overlap < 0:
-            generic_chunk_overlap = 100
+        # 청크 크기 공통 옵션(chunking.chunk_size). recursive/hybrid 는 chunker_type 으로
+        # 택일되므로 값 하나를 활성 모드가 자기 단위(recursive=문자 수 · hybrid=토큰 수)로 해석한다.
+        common_chunk_size = _parse_optional_int(chunking_cfg.get("chunk_size"), "chunking.chunk_size")
 
+        # 문자수 기반 통합 청킹 설정. 우선순위: recursive.chunk_size > chunking.chunk_size(공통)
+        # > (레거시)chunking.generic.chunk_size > 0.
         recursive_chunk_size = _parse_optional_int(
             recursive_chunk_cfg.get("chunk_size"), "chunking.recursive.chunk_size"
         )
-        if recursive_chunk_size is None or recursive_chunk_size <= 0:
-            recursive_chunk_size = 8192
+        if recursive_chunk_size is None:
+            recursive_chunk_size = common_chunk_size
+        if recursive_chunk_size is None:
+            recursive_chunk_size = _parse_optional_int(
+                generic_chunk_cfg.get("chunk_size"), "chunking.generic.chunk_size"
+            )
+        if recursive_chunk_size is None or recursive_chunk_size < 0:
+            recursive_chunk_size = 0  # 0 = 전체 문서를 1청크로 (문자수 분할 안 함)
         recursive_chunk_overlap = _parse_optional_int(
-            recursive_chunk_cfg.get("chunk_overlap"), "chunking.recursive.chunk_overlap"
+            recursive_chunk_cfg.get("chunk_overlap", generic_chunk_cfg.get("chunk_overlap")),
+            "chunking.recursive.chunk_overlap",
         )
         if recursive_chunk_overlap is None or recursive_chunk_overlap < 0:
             recursive_chunk_overlap = 100
-        recursive_token_cap = _parse_optional_int(
-            recursive_chunk_cfg.get("token_chunk_size_cap"),
-            "chunking.recursive.token_chunk_size_cap",
-        )
-        if recursive_token_cap is None or recursive_token_cap <= 0:
-            recursive_token_cap = _RECURSIVE_CHUNK_SIZE_CAP
-        recursive_tokenizer_id = str(recursive_chunk_cfg.get("tokenizer_id") or "").strip() or None
 
+        # hybrid(토큰 수). 우선순위: hybrid.chunk_size > chunking.chunk_size(공통) > 무제한 기본값.
         hybrid_chunk_size = _parse_optional_int(
             hybrid_chunk_cfg.get("chunk_size"), "chunking.hybrid.chunk_size"
         )
+        if hybrid_chunk_size is None:
+            hybrid_chunk_size = common_chunk_size
         if hybrid_chunk_size is None or hybrid_chunk_size <= 0:
             hybrid_chunk_size = _DEFAULT_HYBRID_MAX_TOKENS
         hybrid_merge_peers = _parse_optional_bool(
@@ -1828,7 +1820,6 @@ class DocumentProcessor:
         )
         if hybrid_merge_peers is None:
             hybrid_merge_peers = True
-        hybrid_tokenizer_id = str(hybrid_chunk_cfg.get("tokenizer_id") or "").strip() or None
         hybrid_tokenizer_type = str(hybrid_chunk_cfg.get("tokenizer_type", "char")).strip().lower()
         if hybrid_tokenizer_type not in {"char", "huggingface"}:
             _log.warning(
@@ -1870,15 +1861,10 @@ class DocumentProcessor:
             "use_hwp_sdk": True if use_hwp_sdk is None else use_hwp_sdk,
             "dump_sdk_output": False if dump_sdk_output is None else dump_sdk_output,
             "save_images": True if save_images is None else save_images,
-            "generic_chunk_size": generic_chunk_size,
-            "generic_chunk_overlap": generic_chunk_overlap,
             "recursive_chunk_size": recursive_chunk_size,
             "recursive_chunk_overlap": recursive_chunk_overlap,
-            "recursive_token_chunk_size_cap": recursive_token_cap,
-            "recursive_tokenizer_id": recursive_tokenizer_id,
             "hybrid_chunk_size": hybrid_chunk_size,
             "hybrid_merge_peers": hybrid_merge_peers,
-            "hybrid_tokenizer_id": hybrid_tokenizer_id,
             "hybrid_tokenizer_type": hybrid_tokenizer_type,
             "image_ocr_languages": image_ocr_languages,
             "tabular_encoding_detect_sample_bytes": tabular_sample_bytes,
@@ -2027,11 +2013,11 @@ class DocumentProcessor:
                 },
             )]
 
-        # chunk_size 우선순위: kwargs['chunk_size'] > chunking.generic.chunk_size(generic_chunk_size).
+        # chunk_size 우선순위: kwargs['chunk_size'] > chunking.recursive.chunk_size(recursive_chunk_size).
         # 값이 없거나 <=0 이면 1 page = 1 chunk, 있으면 연속 페이지를 그 길이까지 결합.
         chunk_size = _parse_optional_int(kwargs.get('chunk_size'), 'chunk_size')
         if chunk_size is None:
-            chunk_size = _parse_optional_int(kwargs.get('generic_chunk_size'), 'generic_chunk_size')
+            chunk_size = _parse_optional_int(kwargs.get('recursive_chunk_size'), 'recursive_chunk_size')
 
         chunks: list[Document] = []
         if chunk_size is None or chunk_size <= 0:
@@ -2186,18 +2172,23 @@ class DocumentProcessor:
         return documents
 
     def split_documents(self, documents, **kwargs: dict) -> list[Document]:
+        # 문자수 기반 통합 청킹 (chunking.recursive 설정 공유). chunk_size<=0 이면 문서당 1청크.
         chunk_size = kwargs.get('chunk_size')
         if chunk_size is None:
-            chunk_size = kwargs.get('generic_chunk_size', 1000)
+            chunk_size = kwargs.get('recursive_chunk_size', 0)
         chunk_overlap = kwargs.get('chunk_overlap')
         if chunk_overlap is None:
-            chunk_overlap = kwargs.get('generic_chunk_overlap', 100)
+            chunk_overlap = kwargs.get('recursive_chunk_overlap', 100)
 
-        chunk_size = max(int(chunk_size), 1)
-        chunk_overlap = max(int(chunk_overlap), 0)
-        text_splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size,
-                                                       chunk_overlap=chunk_overlap,)
-        chunks = text_splitter.split_documents(documents)
+        chunks = [
+            Document(page_content=part, metadata=dict(doc.metadata))
+            for doc in documents
+            for part in _char_split_text(
+                doc.page_content,
+                chunk_size=chunk_size,
+                chunk_overlap=chunk_overlap,
+            )
+        ]
         chunks = [chunk for chunk in chunks if chunk.page_content]
         if not chunks:
             raise Exception('Empty document')

--- a/genon/preprocessor/facade/gitbook_doc/attachment_processor.md
+++ b/genon/preprocessor/facade/gitbook_doc/attachment_processor.md
@@ -93,48 +93,48 @@ defaults:
   # 5=DEBUG, 4=INFO, 3=WARNING, 2=ERROR, 1=CRITICAL, 0=NOLOG
   log_level: 4
 
-  # hwp/docx 분기 기본 청커: "recursive" | "hybrid"
-  chunker_type: "recursive"
-
-  # 입력 포맷 자동 PDF 변환 엔진 선택
+  # 입력 포맷 자동 PDF 변환 엔진 선택 (ppt/txt/md/img→pdf, hwp 폴백 등 전 변환 경로 공용)
   use_pdf_sdk: true
 
-  # hwp/hwpx 처리 시 기본 SDK 백엔드 사용 여부
-  use_hwp_sdk: true
+# 포맷별 옵션 컨테이너
+formats:
+  # HWP/HWPX: SDK 백엔드 파싱 옵션
+  hwp:
+    # SDK 백엔드 사용 여부 (false=레거시 backend 로 폴백)
+    use_hwp_sdk: true
+    # use_hwp_sdk=true 일 때만 유효한 SDK 출력 덤프(디버그)
+    dump_sdk_output: false
+    # 이미지 저장 여부
+    save_images: true
 
-  # use_hwp_sdk=true 일 때만 유효한 SDK 출력 덤프
-  dump_sdk_output: false
-
-  # hwp/hwpx 처리 시 이미지 저장 여부
-  save_images: true
+  # PPT(ppt/pptx) 페이지 설명(VLM). 상세는 3.2 formats.ppt.page_description 참고
+  ppt:
+    page_description:
+      enable: false
+      # ... (아래 formats.ppt 소절 참고)
 
 chunking:
-  # 청킹용 토크나이저 기본값(hybrid 경로 등). tokenizer_path 가 실제 존재하면 그 경로,
-  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
-  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
-  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
+  # 청킹 모드: "recursive"(문자수 기반, 기본) | "hybrid"(layout 구조 기반; hwp/hwpx/docx 에만 적용)
+  chunker_type: "recursive"
 
-  # pdf/txt/md/ppt 등 일반 텍스트 splitter 기본값
-  generic:
-    chunk_size: 1000
-    chunk_overlap: 100
+  # 청크 크기(공통): recursive 모드=문자 수 · hybrid 모드=토큰 수. 0=크기 기반 분할 안 함(전체 1청크)
+  chunk_size: 1000000
 
-  # hwp/hwpx/docx + recursive 분기 기본값
+  # 문자수 기반 청킹 (전 포맷 공용: pdf/txt/md/img/ppt/hwp/hwpx/docx). chunker_type: recursive 일 때.
   recursive:
-    chunk_size: 8192
     chunk_overlap: 100
-    # 임베딩 입력 안정성을 위한 토큰 절대 상한
-    token_chunk_size_cap: 60000
-    # 비우면 로컬 경로(/models/...) 우선, 없으면 HF ID fallback
-    tokenizer_id: ""
 
-  # hwp/hwpx/docx + hybrid 분기 기본값
+  # layout 구조 기반 청킹 (선택 모드). chunker_type: hybrid 일 때 hwp/hwpx/docx 에만 적용.
+  # (토크나이저는 아래 chunking.tokenizer_path/tokenizer_id 를 공용으로 사용)
   hybrid:
     # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
     tokenizer_type: "char"
-    tokenizer_id: ""
-    chunk_size: 10000000
     merge_peers: true
+
+  # 청킹용 토크나이저 기본값(hybrid huggingface 모드 등). tokenizer_path 가 실제 존재하면 그 경로,
+  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
+  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
+  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
 
 loaders:
   image:
@@ -165,48 +165,50 @@ whisper:
 
 모든 기본값과 동작은 코드(`DocumentProcessor.__init__`)에서 검증되었습니다. 값이 누락되거나 무효하면 표의 기본값으로 폴백합니다.
 
-#### defaults
+#### defaults (전역)
 
 | 키 | 기본값 | 설명 |
 |----|--------|------|
 | `log_level` | `4` (INFO) | 로깅 레벨. 5=DEBUG, 4=INFO, 3=WARNING, 2=ERROR, 1=CRITICAL, 0=NOLOG |
-| `chunker_type` | `"recursive"` | hwp/hwpx/docx 분기의 기본 청커. `recursive` 또는 `hybrid`. 그 외 값은 `recursive`로 폴백 |
-| `use_pdf_sdk` | `true` | 입력 포맷 자동 PDF 변환 시 SDK 엔진 사용 여부 (PPT/DOC/이미지/HWP 폴백 변환에 영향) |
-| `use_hwp_sdk` | `true` | hwp/hwpx 처리 시 기본 SDK 백엔드(`GenosHwpDocumentBackend`) 사용 여부 |
-| `dump_sdk_output` | `false` | SDK 원본 출력 덤프 여부. `use_hwp_sdk=true` 일 때만 유효 |
+| `use_pdf_sdk` | `true` | 입력 포맷 자동 PDF 변환 시 SDK 엔진 사용 여부 (PPT/DOC/이미지/HWP 폴백 변환에 영향, 전 변환 경로 공용) |
+
+#### formats.hwp (HWP/HWPX 전용)
+
+| 키 | 기본값 | 설명 |
+|----|--------|------|
+| `use_hwp_sdk` | `true` | hwp/hwpx 처리 시 기본 SDK 백엔드(`GenosHwpDocumentBackend`) 사용 여부. `false`면 레거시 backend로 폴백 |
+| `dump_sdk_output` | `false` | SDK 원본 출력 덤프 여부(디버그). `use_hwp_sdk=true` 일 때만 유효 |
 | `save_images` | `true` | hwp/hwpx 처리 시 추출 이미지 저장 여부 |
 
-#### chunking (청킹용 토크나이저 기본값)
+> 구버전 config 호환: `formats.hwp` 가 없으면 예전 위치(`defaults.use_hwp_sdk` 등)를 폴백으로 읽습니다.
+
+#### chunking
 
 | 키 | 기본값 | 설명 |
 |----|--------|------|
-| `tokenizer_path` | `/models/...all-MiniLM-L6-v2` | 청킹용 토크나이저 로컬 경로(hybrid `huggingface` 모드 및 recursive 60K 토큰 cap 계산에 사용). 경로가 실제 존재하면 그 경로 사용 |
+| `chunker_type` | `"recursive"` | 청킹 모드. `recursive`(문자수 기반, 전 포맷 공용) 또는 `hybrid`(layout 기반, hwp/hwpx/docx 에만 적용). 그 외 값은 `recursive`로 폴백. 구버전 호환: 없으면 `defaults.chunker_type` 폴백 |
+| `chunk_size` | `1000000` | **공통 청크 크기.** recursive 모드=문자 수, hybrid 모드=토큰 수로 해석. `0`(또는 음수)=크기 기반 분할 안 함 → 전체 문서를 1청크로 둠. recursive/hybrid 는 `chunker_type`으로 택일되므로 값 하나를 활성 모드가 자기 단위로 사용 |
+| `tokenizer_path` | `/models/...all-MiniLM-L6-v2` | 청킹용 토크나이저 로컬 경로(hybrid `huggingface` 모드에서 사용). 경로가 실제 존재하면 그 경로 사용 |
 | `tokenizer_id` | `sentence-transformers/all-MiniLM-L6-v2` | `tokenizer_path` 가 없을 때 폴백할 HF ID (외부 네트워크 차단 환경 대비) |
 
-#### chunking.generic (pdf/txt/md/ppt 등 일반 splitter)
+> `chunk_size`/`chunker_type`/`tokenizer_*` 는 하위 블록이 아닌 `chunking` 공통 레벨에 둡니다. per-block 로 `chunking.recursive.chunk_size` / `chunking.hybrid.chunk_size` 를 지정하면 해당 모드에 한해 공통값을 덮어씁니다(선택).
+
+#### chunking.recursive (문자수 기반, 전 포맷 공용 — 기본 모드)
 
 | 키 | 기본값 | 설명 |
 |----|--------|------|
-| `chunk_size` | `1000` | 일반 텍스트 분할 청크 크기(문자 단위). 0 이하면 1000으로 폴백 |
 | `chunk_overlap` | `100` | 청크 간 오버랩(문자 단위). 음수면 100으로 폴백 |
 
-#### chunking.recursive (hwp/hwpx/docx + recursive 분기, 기본 청커)
+> 청크 크기는 공통 `chunking.chunk_size`(문자 수)로 지정합니다. `0`이면 문자 분할 없이 전체를 1청크로 둡니다.
 
-| 키 | 기본값 | 설명 |
-|----|--------|------|
-| `chunk_size` | `8192` | 청크 크기(문자 단위). 한국어 기준 약 12K~16K 토큰. 0 이하면 8192로 폴백 |
-| `chunk_overlap` | `100` | 청크 간 오버랩(문자 단위). 음수면 100으로 폴백 |
-| `token_chunk_size_cap` | `60000` | 토큰 절대 상한. 어떤 chunk_size에서도 한 청크가 이 값을 초과하면 토큰 단위로 강제 재분할 (임베딩 입력 한도 ~128K 토큰의 절반 안전 마진) |
-| `tokenizer_id` | `""` | 비우면 로컬 경로(`/models/...sentence-transformers-all-MiniLM-L6-v2`) 우선, 없으면 HF ID로 fallback |
-
-#### chunking.hybrid (hwp/hwpx/docx + hybrid 분기)
+#### chunking.hybrid (layout 기반 — hwp/hwpx/docx 전용 선택 모드)
 
 | 키 | 기본값 | 설명 |
 |----|--------|------|
 | `tokenizer_type` | `"char"` | 토큰 수 계산 방식. `char`(기본)=문자 수 기준(HF 토크나이저 미로드, 외부 모델 의존 없음) / `huggingface`=HF 토크나이저 기준. 그 외 값은 `char`로 폴백 |
-| `tokenizer_id` | `""` | `huggingface` 모드에서만 사용. 비우면 chunking 상위 토크나이저(로컬 경로 우선, 없으면 HF ID)로 fallback |
-| `chunk_size` | `10000000` | 청크당 최대 크기. `char` 모드면 문자 수, `huggingface` 모드면 토큰 수. 기본값은 사실상 제한 없음 → hybrid를 레이아웃 기반 병합 도구로만 사용. 0 이하/누락 시 코드 fallback(`1e30`) |
 | `merge_peers` | `true` | 같은 제목/캡션을 가진 작은 청크를 크기 제한 내에서 병합 |
+
+> hybrid 의 청크 크기(토큰 수)도 공통 `chunking.chunk_size` 로 지정합니다. 기본 `1000000`은 사실상 제한이 없어 hybrid를 레이아웃 기반 병합 도구로만 쓰게 됩니다. `huggingface` 모드 토크나이저는 위 `chunking.tokenizer_path/tokenizer_id` 를 공용으로 사용합니다.
 
 #### loaders.image
 
@@ -237,15 +239,17 @@ whisper:
 
 #### chunker_type: recursive vs hybrid
 
-- **recursive (기본)**: `DoclingDocument`를 markdown으로 export한 뒤 `RecursiveCharacterTextSplitter`로 **문자 단위** 분할합니다. 단락/헤딩/표 경계의 줄바꿈이 보존되어 문장 중간에서 잘리는 현상이 적고, 페이지 단위 정확도를 가집니다. 대부분의 경우 권장됩니다.
-- **hybrid**: 레이아웃 계층 구조를 유지하며 청크 크기 기반으로 청크를 조절합니다. 크기 계산 방식은 `chunking.hybrid.tokenizer_type`(기본 `char`=문자 수 / `huggingface`=HF 토큰 수)으로 선택합니다. 기본 `chunk_size=10000000`은 사실상 제한이 없는 수준이라, 이 전처리기에서는 주로 레이아웃 기반 병합 도구로 동작합니다. 청크 단위 bbox 정확도가 필요할 때 사용합니다.
-- **60K 토큰 cap**: recursive 분기에서는 chunk_size와 무관하게 한 청크가 `token_chunk_size_cap`(기본 60000) 토큰을 넘으면 토큰 단위로 강제 재분할됩니다. 기본 8192자 청크에서는 보통 트리거되지 않으며, 큰 chunk_size를 지정했을 때의 안전망입니다.
+- **recursive (기본, 전 포맷 공용)**: 문자 수 기반 청킹입니다. hwp/hwpx/docx 는 `DoclingDocument`를 markdown으로 export한 뒤, pdf/txt/md/img 는 로드된 텍스트를 대상으로 `RecursiveCharacterTextSplitter`로 **문자 단위** 분할합니다(공통 `chunk_size` 문자 수). 단락/헤딩/표 경계의 줄바꿈이 보존되어 문장 중간에서 잘리는 현상이 적고, 페이지 단위 정확도를 가집니다. 대부분의 경우 권장됩니다.
+- **`chunk_size=0` → 전체 1청크**: 공통 `chunk_size` 가 `0`(또는 음수)이면 문자 분할을 하지 않고 문서 전체를 한 청크로 둡니다(PPT 는 예외적으로 "1 page = 1 chunk" 유지). 검색 정밀도를 위해 문서를 잘게 나누려면 `chunk_size` 를 적정 문자 수(예: 2000)로 지정하세요.
+- **hybrid (hwp/hwpx/docx 전용)**: 레이아웃 계층 구조를 유지하며 청크 크기 기반으로 청크를 조절합니다. layout 파싱이 되는 hwp/hwpx/docx 에만 적용되고, pdf/txt/md/img/ppt 는 `chunker_type: hybrid` 로 두어도 각자 문자수/페이지 기반으로 동작합니다. 크기 계산 방식은 `chunking.hybrid.tokenizer_type`(기본 `char`=문자 수 / `huggingface`=HF 토큰 수)으로 선택하며, 크기는 공통 `chunk_size`(토큰 수)로 지정합니다. 기본값(`1000000`)은 사실상 제한이 없어 주로 레이아웃 기반 병합 도구로 동작합니다. 청크 단위 bbox 정확도가 필요할 때 사용합니다.
+
+> **임베딩 토큰 상한 주의**: 이전 버전의 60K 토큰 강제 재분할(안전망)은 제거되었습니다. `chunk_size` 가 매우 크거나 `0`(전체 1청크)이면 한 청크가 임베딩 모델 입력 한도를 초과할 수 있습니다. 대용량/토큰과다 문서는 `chunk_size` 를 적정 값으로 지정해 방지하세요.
 
 #### formats.ppt.page_description (PPT 페이지 설명 — 속도 최적화)
 
 PPT(`.ppt`/`.pptx`)를 **PDF→경량 docling 파싱** 후 각 페이지를 **이미지로 렌더링해 VLM 으로 설명**하고, 페이지의 native text 와 **동일 청크**로 구성합니다. 첨부용은 즉시 응답이 목적이라 **속도 우선**으로 튜닝합니다(이미지·출력 축소, 병렬↑, 간결 프롬프트).
 
-- **청킹**: **1 page = 1 chunk**. `chunking.generic.chunk_size` 가 `>0` 이면 연속 페이지를 그 크기(문자 수)까지 결합합니다(`0`=페이지별 1청크 고정). bbox 는 첨부용 원칙대로 미추출.
+- **청킹**: **1 page = 1 chunk**. 공통 `chunking.chunk_size` 가 `>0` 이면 연속 페이지를 그 크기(문자 수)까지 결합합니다(`0`=페이지별 1청크 고정). bbox 는 첨부용 원칙대로 미추출.
 - **enable=false** 여도 PPT 는 docling 경량 파싱으로 처리되며, 설명 생성만 생략됩니다(텍스트/설명이 모두 없는 페이지는 `.` 로 채워 Empty 예외 방지).
 - native text 는 프롬프트의 **`{{page_text}}`** 변수로 전달됩니다.
 
@@ -289,34 +293,33 @@ config yaml의 기본값은 `DocumentProcessor.__init__`에서 `self._default_kw
 | kwargs | 대응 config | 비고 |
 |--------|-------------|------|
 | `log_level` | `defaults.log_level` | |
-| `chunker_type` | `defaults.chunker_type` | |
+| `chunker_type` | `chunking.chunker_type` | |
 | `use_pdf_sdk` | `defaults.use_pdf_sdk` | |
-| `use_hwp_sdk` | `defaults.use_hwp_sdk` | |
-| `chunk_size` | generic/recursive 분기의 chunk_size를 직접 지정 | 미지정 시 분기별 config 기본값 사용 |
-| `chunk_overlap` | generic/recursive 분기의 chunk_overlap | 미지정 시 분기별 config 기본값 사용 |
+| `use_hwp_sdk` | `formats.hwp.use_hwp_sdk` | |
+| `chunk_size` | `chunking.chunk_size` (공통) | 활성 모드 단위(recursive=문자 수 / hybrid=토큰 수). 미지정 시 config 기본값 사용 |
+| `chunk_overlap` | `chunking.recursive.chunk_overlap` | 미지정 시 config 기본값 사용 |
 
-> `chunk_size`/`chunk_overlap`은 일반 분기(PDF/TXT 등)와 recursive 분기 모두에서 우선 적용되고, 미지정 시 각각 `chunking.generic.*` 또는 `chunking.recursive.*` 기본값으로 폴백합니다.
+> `chunk_size`/`chunk_overlap`은 모든 문자수 청킹 경로(pdf/txt/md/img/ppt + hwp/hwpx/docx recursive)에 공통 적용되고, 미지정 시 `chunking.chunk_size` / `chunking.recursive.chunk_overlap` 기본값으로 폴백합니다.
 
 ### 3.4 자주 쓰는 튜닝 시나리오
 
-**① 청크 크기 조정** — 더 작은 청크로 검색 정밀도를 높이고 싶을 때:
+**① 청크 크기 조정** — 더 작은 청크로 검색 정밀도를 높이고 싶을 때 (공통 `chunk_size`):
 
 ```yaml
 chunking:
+  chunk_size: 2000        # 문자 수 (recursive 모드). 0=전체 문서를 1청크
   recursive:
-    chunk_size: 2000
     chunk_overlap: 200
 ```
 
-**② hybrid 청커 사용** — 청크 단위 bbox 정확도가 필요할 때:
+**② hybrid 청커 사용** — hwp/hwpx/docx 에서 청크 단위 bbox 정확도가 필요할 때:
 
 ```yaml
-defaults:
-  chunker_type: "hybrid"
 chunking:
+  chunker_type: "hybrid"
+  chunk_size: 1000        # hybrid 모드에서는 토큰 수. 실제 분할 제한을 두려면 작은 값 지정
   hybrid:
     tokenizer_type: "char"  # char=문자 수 기준 | huggingface=HF 토큰 수 기준
-    chunk_size: 1000        # 실제 분할 제한을 두려면 작은 값 지정(char 모드면 문자 수)
     merge_peers: true
 ```
 
@@ -331,8 +334,9 @@ whisper:
 **④ HWP SDK 비활성화** — 엔터프라이즈 SDK 없이 레거시 백엔드로 처리할 때:
 
 ```yaml
-defaults:
-  use_hwp_sdk: false
+formats:
+  hwp:
+    use_hwp_sdk: false
 ```
 
 ---
@@ -366,7 +370,8 @@ defaults:
         └── 기타 (.pdf, .ppt,    ► get_loader() ──► LangChain Loader
             .doc, .jpg, .txt,                          │
             .json, .md, .html 등)                      ▼
-                                       RecursiveCharacterTextSplitter (generic)
+                                    문자수 청킹(recursive, 공통 chunk_size)
+                                    (PPT 는 페이지 기반: 1 page=1 chunk)
                                                        │
                                                        ▼
                                               ┌─────────────────────────────┐
@@ -413,13 +418,13 @@ HWP/HWPX 파일은 변환 실패 시 단계적으로 폴백합니다.
 | 클래스/함수 | 역할 | config 연관 |
 |-------------|------|-------------|
 | `DocumentProcessor` | 메인 엔트리포인트. config 로딩 + 확장자 라우팅 + generic 분기 처리 | 전체 |
-| `HwpProcessor` | hwp/hwpx 통합 처리 (SDK 백엔드 + 폴백) | `defaults.use_hwp_sdk/dump_sdk_output/save_images`, `chunking.recursive/hybrid` |
-| `DocxProcessor` | docx Docling 파싱 + 청킹 | `chunking.recursive/hybrid` |
+| `HwpProcessor` | hwp/hwpx 통합 처리 (SDK 백엔드 + 폴백) | `formats.hwp.{use_hwp_sdk,dump_sdk_output,save_images}`, `chunking.*` |
+| `DocxProcessor` | docx Docling 파싱 + 청킹 | `chunking.*` |
 | `AudioLoader` | 오디오 분할 + Whisper STT 병렬 호출 | `whisper.*` |
 | `TabularLoader` | CSV/XLSX → DataFrame 파싱, `[DA]` 마커 부착 | `loaders.tabular.encoding_detect_sample_bytes` |
 | `TextLoader` | txt/json/md 인코딩 자동 감지 로드 | — |
-| `HierarchicalChunker` / `HybridChunker` | 레이아웃 기반/토큰 기반 청킹 | `chunking.hybrid.*` |
-| `_split_with_recursive_chunker` | recursive 분기 헬퍼 (markdown export + 문자 분할) | `chunking.recursive.*` |
+| `HierarchicalChunker` / `HybridChunker` | 레이아웃 기반/토큰 기반 청킹 | `chunking.chunk_size`, `chunking.hybrid.*` |
+| `_char_split_text` / `_split_with_recursive_chunker` | 문자수 청킹 공용 헬퍼(전 포맷) / recursive 분기(markdown export + 문자 분할) | `chunking.chunk_size`, `chunking.recursive.chunk_overlap` |
 
 ---
 
@@ -454,8 +459,8 @@ HWP/HWPX 파일은 변환 실패 시 단계적으로 폴백합니다.
 |------|------|------|
 | `chunk length is 0` (`GenosServiceException`) | HWP/DOCX에서 추출된 청크가 0개 | 원본 파일이 비었거나 파싱 실패. 다른 백엔드(`use_hwp_sdk` 변경)나 PDF 폴백 확인 |
 | 오디오 전사 결과 비어있음 | `whisper.url`이 placeholder(`<WHISPER_ENDPOINT>`) | config에서 실제 STT 서버 주소로 변경 |
-| HWP 변환 실패 후 에러 | SDK/레거시 백엔드/PDF 변환 모두 실패 | `use_hwp_sdk`, `use_pdf_sdk` 조정. LibreOffice(`soffice`) 설치 확인 |
-| 청크가 비정상적으로 큼 | chunk_size를 매우 크게 지정 | `token_chunk_size_cap`(기본 60000) 안전망 동작 확인. chunk_size 축소 |
+| HWP 변환 실패 후 에러 | SDK/레거시 백엔드/PDF 변환 모두 실패 | `formats.hwp.use_hwp_sdk`, `defaults.use_pdf_sdk` 조정. LibreOffice(`soffice`) 설치 확인 |
+| 청크가 비정상적으로 큼 / 임베딩 입력 초과 | 기본 `chunk_size` 가 크거나 `0`(전체 1청크)이라 한 청크가 임베딩 토큰 한도 초과 (60K 토큰 안전망 제거됨) | `chunking.chunk_size` 를 적정 문자 수(예: 2000~8000)로 지정 |
 | 한글 텍스트 깨짐 (CSV/TXT) | 인코딩 감지 실패 | TXT는 다단 인코딩 폴백 사용. CSV는 `encoding_detect_sample_bytes` 증대 |
 | 로그가 너무 많음/적음 | `log_level` 설정 | config `defaults.log_level` 조정 (4=INFO 기본) |
 | config가 적용 안 됨 | `resource_dev` 파일이 우선 로드됨 | 로딩 우선순위([2장](#2-빠른-시작)) 확인. 의도치 않은 `resource_dev` 파일 제거 |
@@ -468,7 +473,7 @@ HWP/HWPX 파일은 변환 실패 시 단계적으로 폴백합니다.
 
 ### A. 설정 로딩 (`DocumentProcessor.__init__`)
 
-생성 시 `_resolve_default_attachment_config_path()`로 config 경로를 결정(`resource_dev` → `resource`)한 뒤 `_load_config()`로 읽습니다. 각 섹션(`defaults`/`chunking`/`loaders`/`whisper`)은 `_parse_optional_bool/_parse_optional_int` 등으로 검증되어 `self._default_kwargs`에 평탄화됩니다. `chunk_size`/`overlap`은 분기별로 `generic_*`/`recursive_*` prefix로 저장됩니다. 무효 값은 표의 기본값으로 폴백하고 경고 로그를 남깁니다.
+생성 시 `_resolve_default_attachment_config_path()`로 config 경로를 결정(`resource_dev` → `resource`)한 뒤 `_load_config()`로 읽습니다. 각 섹션(`defaults`/`formats`/`chunking`/`loaders`/`whisper`)은 `_parse_optional_bool/_parse_optional_int` 등으로 검증되어 `self._default_kwargs`에 평탄화됩니다. `chunker_type`·공통 `chunk_size` 는 `chunking` 에서, HWP 옵션은 `formats.hwp` 에서 읽습니다(각각 구버전 위치 `defaults.*` 폴백 지원). 공통 `chunk_size` 는 `recursive_chunk_size`/`hybrid_chunk_size` 양쪽 소스로 쓰이고, 문자 오버랩은 `recursive_chunk_overlap` 로 저장됩니다. 무효 값은 표의 기본값으로 폴백하고 경고 로그를 남깁니다.
 
 ### B. 라우팅 (`DocumentProcessor.__call__`)
 
@@ -496,7 +501,8 @@ HWP/HWPX 파일은 변환 실패 시 단계적으로 폴백합니다.
 
 ### D. 청킹 내부
 
-- **recursive (`_split_with_recursive_chunker`)**: `export_to_markdown(page_break_placeholder="<!-- PB -->")`로 단일 markdown 생성 → `RecursiveCharacterTextSplitter`(문자 단위) → 60K 토큰 cap 후처리 → placeholder 카운트로 페이지 매핑 복원. 반환은 `list[dict]{text, page_no, pages, doc_items}`. 한 청크가 여러 페이지에 걸칠 수 있어 페이지 단위 정확도를 가집니다.
+- **문자수 청킹(`_char_split_text`)**: 공용 헬퍼. `chunk_size>0` 이면 `RecursiveCharacterTextSplitter`로 문자 단위 분할, `<=0` 이면 분할 없이 전체를 1청크로 둡니다. pdf/txt/md/img 는 로드된 텍스트에, hwp/hwpx/docx(recursive)는 markdown export 에 적용됩니다. (별도 토큰 상한 후처리는 없음 — 60K cap 제거됨)
+- **recursive (`_split_with_recursive_chunker`)**: `export_to_markdown(page_break_placeholder="<!-- PB -->")`로 단일 markdown 생성 → `_char_split_text`(문자 단위) → placeholder 카운트로 페이지 매핑 복원. 반환은 `list[dict]{text, page_no, pages, doc_items}`. 한 청크가 여러 페이지에 걸칠 수 있어 페이지 단위 정확도를 가집니다.
 - **hybrid (`HybridChunker`)**: `HierarchicalChunker`로 레이아웃 청크 생성 → `_split_by_doc_items`(슬라이딩 윈도우) → `_split_using_plain_text`(semchunk) → `merge_peers=true`면 동일 메타데이터 청크 병합. 청크 단위 bbox 정확도.
 - 두 분기는 `compose_vectors`에서 `chunker_type`으로 다시 분기해 처리됩니다 (recursive=dict, hybrid=DocChunk).
 

--- a/genon/preprocessor/resource/attachment_processor_config.yaml
+++ b/genon/preprocessor/resource/attachment_processor_config.yaml
@@ -5,51 +5,20 @@ defaults:
   # 5=DEBUG, 4=INFO, 3=WARNING, 2=ERROR, 1=CRITICAL, 0=NOLOG
   log_level: 4
 
-  # hwp/docx 분기 기본 청커: "recursive" | "hybrid"
-  chunker_type: "recursive"
-
-  # 입력 포맷 자동 PDF 변환 엔진 선택
+  # 입력 포맷 자동 PDF 변환 엔진 선택 (ppt/txt/md/img→pdf, hwp 폴백 등 전 변환 경로 공용)
   use_pdf_sdk: true
-
-  # hwp/hwpx 처리 시 기본 SDK 백엔드 사용 여부
-  use_hwp_sdk: true
-
-  # use_hwp_sdk=true 일 때만 유효한 SDK 출력 덤프
-  dump_sdk_output: false
-
-  # hwp/hwpx 처리 시 이미지 저장 여부
-  save_images: true
-
-chunking:
-  # 청킹용 토크나이저 기본값(hybrid 경로 등). tokenizer_path 가 실제 존재하면 그 경로,
-  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
-  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
-  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
-
-  # pdf/txt/md/ppt 등 일반 텍스트 splitter 기본값
-  generic:
-    chunk_size: 10000000
-    chunk_overlap: 100
-
-  # hwp/hwpx/docx + recursive 분기 기본값
-  recursive:
-    chunk_size: 8192
-    chunk_overlap: 100
-    # 임베딩 입력 안정성을 위한 토큰 절대 상한
-    token_chunk_size_cap: 60000
-    # 비우면 로컬 경로(/models/...) 우선, 없으면 HF ID fallback
-    tokenizer_id: ""
-
-  # hwp/hwpx/docx + hybrid 분기 기본값
-  hybrid:
-    # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
-    tokenizer_type: "char"
-    tokenizer_id: ""
-    chunk_size: 10000000
-    merge_peers: true
 
 # 포맷별 옵션 컨테이너
 formats:
+  # HWP/HWPX: SDK 백엔드 파싱 옵션
+  hwp:
+    # SDK 백엔드 사용 여부 (false=레거시 backend 로 폴백)
+    use_hwp_sdk: true
+    # use_hwp_sdk=true 일 때만 유효한 SDK 출력 덤프(디버그)
+    dump_sdk_output: false
+    # 이미지 저장 여부
+    save_images: true
+
   # PPT(ppt/pptx): PDF 변환 → 경량 docling 파싱 → 페이지 기반 청킹(기본 1 page 1 chunk,
   # chunk_size 지정 시 연속 페이지 결합). page_description 으로 "페이지 자체"를 VLM 설명.
   # (첨부용은 dotsocr 미수행 + do_ocr=false 최소 파싱, bbox 미추출)
@@ -71,6 +40,29 @@ formats:
       # params: { max_completion_tokens: 512 }
       # 프롬프트: 첨부용은 간결(2~3문장) 버전 사용
       prompt_template_file: prompt_page_image_description_fast.md
+
+chunking:
+  # 청킹 모드: "recursive"(문자수 기반, 기본) | "hybrid"(layout 구조 기반; hwp/hwpx/docx 에만 적용)
+  chunker_type: "recursive"
+
+  # 청크 크기(공통): recursive 모드=문자 수 · hybrid 모드=토큰 수. 0=크기 기반 분할 안 함(전체 1청크)
+  chunk_size: 1000000
+
+  # 문자수 기반 청킹 (전 포맷 공용: pdf/txt/md/img/ppt/hwp/hwpx/docx). chunker_type: recursive 일 때.
+  recursive:
+    chunk_overlap: 100
+
+  # layout 구조 기반 청킹 (선택 모드). chunker_type: hybrid 일 때 hwp/hwpx/docx 에만 적용.
+  # (토크나이저는 위 chunking.tokenizer_path/tokenizer_id 를 공용으로 사용)
+  hybrid:
+    # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
+    tokenizer_type: "char"
+    merge_peers: true
+
+  # 청킹용 토크나이저 기본값(hybrid 경로 등). tokenizer_path 가 실제 존재하면 그 경로,
+  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
+  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
+  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
 
 loaders:
   image:

--- a/genon/preprocessor/resource_dev/attachment_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/attachment_processor_config.yaml
@@ -5,51 +5,20 @@ defaults:
   # 5=DEBUG, 4=INFO, 3=WARNING, 2=ERROR, 1=CRITICAL, 0=NOLOG
   log_level: 4
 
-  # hwp/docx 분기 기본 청커: "recursive" | "hybrid"
-  chunker_type: "recursive"
-
-  # 입력 포맷 자동 PDF 변환 엔진 선택
+  # 입력 포맷 자동 PDF 변환 엔진 선택 (ppt/txt/md/img→pdf, hwp 폴백 등 전 변환 경로 공용)
   use_pdf_sdk: true
-
-  # hwp/hwpx 처리 시 기본 SDK 백엔드 사용 여부
-  use_hwp_sdk: true
-
-  # use_hwp_sdk=true 일 때만 유효한 SDK 출력 덤프
-  dump_sdk_output: false
-
-  # hwp/hwpx 처리 시 이미지 저장 여부
-  save_images: true
-
-chunking:
-  # 청킹용 토크나이저 기본값(hybrid 경로 등). tokenizer_path 가 실제 존재하면 그 경로,
-  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
-  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
-  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
-
-  # pdf/txt/md/ppt 등 일반 텍스트 splitter 기본값
-  generic:
-    chunk_size: 10000000
-    chunk_overlap: 100
-
-  # hwp/hwpx/docx + recursive 분기 기본값
-  recursive:
-    chunk_size: 8192
-    chunk_overlap: 100
-    # 임베딩 입력 안정성을 위한 토큰 절대 상한
-    token_chunk_size_cap: 60000
-    # 비우면 로컬 경로(/models/...) 우선, 없으면 HF ID fallback
-    tokenizer_id: ""
-
-  # hwp/hwpx/docx + hybrid 분기 기본값
-  hybrid:
-    # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
-    tokenizer_type: "char"
-    tokenizer_id: ""
-    chunk_size: 10000000
-    merge_peers: true
 
 # 포맷별 옵션 컨테이너
 formats:
+  # HWP/HWPX: SDK 백엔드 파싱 옵션
+  hwp:
+    # SDK 백엔드 사용 여부 (false=레거시 backend 로 폴백)
+    use_hwp_sdk: true
+    # use_hwp_sdk=true 일 때만 유효한 SDK 출력 덤프(디버그)
+    dump_sdk_output: false
+    # 이미지 저장 여부
+    save_images: true
+
   # PPT(ppt/pptx): PDF 변환 → 경량 docling 파싱 → 페이지 기반 청킹(기본 1 page 1 chunk,
   # chunk_size 지정 시 연속 페이지 결합). page_description 으로 "페이지 자체"를 VLM 설명.
   # (첨부용은 dotsocr 미수행 + do_ocr=false 최소 파싱, bbox 미추출)
@@ -71,6 +40,29 @@ formats:
       # params: { max_completion_tokens: 512 }
       # 프롬프트: 첨부용은 간결(2~3문장) 버전 사용
       prompt_template_file: prompt_page_image_description_fast.md
+
+chunking:
+  # 청킹 모드: "recursive"(문자수 기반, 기본) | "hybrid"(layout 구조 기반; hwp/hwpx/docx 에만 적용)
+  chunker_type: "recursive"
+
+  # 청크 크기(공통): recursive 모드=문자 수 · hybrid 모드=토큰 수. 0=크기 기반 분할 안 함(전체 1청크)
+  chunk_size: 1000000
+
+  # 문자수 기반 청킹 (전 포맷 공용: pdf/txt/md/img/ppt/hwp/hwpx/docx). chunker_type: recursive 일 때.
+  recursive:
+    chunk_overlap: 100
+
+  # layout 구조 기반 청킹 (선택 모드). chunker_type: hybrid 일 때 hwp/hwpx/docx 에만 적용.
+  # (토크나이저는 위 chunking.tokenizer_path/tokenizer_id 를 공용으로 사용)
+  hybrid:
+    # 토큰 수 계산 방식. "char"(default)=문자 수 기준 | "huggingface"=HF 토크나이저 기준
+    tokenizer_type: "char"
+    merge_peers: true
+
+  # 청킹용 토크나이저 기본값(hybrid 경로 등). tokenizer_path 가 실제 존재하면 그 경로,
+  # 없으면 tokenizer_id(HF) 로 폴백 (외부 네트워크 차단 환경 대비)
+  tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
+  tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
 
 loaders:
   image:

--- a/genon/preprocessor/tests/unit/test_attachment_chunk_config_unit.py
+++ b/genon/preprocessor/tests/unit/test_attachment_chunk_config_unit.py
@@ -1,0 +1,146 @@
+"""
+attachment_processor 의 청킹/포맷 설정 → _default_kwargs 매핑 단위 테스트.
+
+이번 리팩터로 바뀐 동작을 검증한다:
+  - chunk_size 공통화(chunking.chunk_size → recursive/hybrid 동시 반영, per-block override)
+  - chunker_type 위치 이동(chunking.chunker_type, 없으면 defaults.chunker_type 폴백)
+  - HWP 옵션 이동(formats.hwp.*, 없으면 defaults.* 폴백)
+  - token_chunk_size_cap 완전 제거
+
+의존성(docling 등) 미가용 환경에서는 importorskip 으로 자동 skip 된다(CI gate).
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_CONFIG_NAME = "attachment_processor_config.yaml"
+
+
+def _load_processor():
+    mod = pytest.importorskip("facade.attachment_processor")
+    return mod.DocumentProcessor
+
+
+def _write_config(tmp_path: Path, mutate) -> str:
+    """출고 attachment config 를 복사하고 mutate(cfg) 로 수정한 임시 config 경로 반환."""
+    repo_resource = Path(__file__).resolve().parents[2] / "resource" / _CONFIG_NAME
+    cfg = yaml.safe_load(repo_resource.read_text(encoding="utf-8"))
+    cfg.setdefault("chunking", {})
+    cfg.setdefault("defaults", {})
+    cfg.setdefault("formats", {})
+    mutate(cfg)
+    out = tmp_path / _CONFIG_NAME
+    out.write_text(yaml.safe_dump(cfg, allow_unicode=True), encoding="utf-8")
+    return str(out)
+
+
+def _init(tmp_path: Path, mutate):
+    DocumentProcessor = _load_processor()
+    try:
+        return DocumentProcessor(config_path=_write_config(tmp_path, mutate))
+    except Exception as e:  # noqa: BLE001 - 모델/네트워크 등 환경 의존
+        pytest.skip(f"DocumentProcessor init unavailable: {e}")
+
+
+# ---------------------------------------------------------------------------
+# 공통 chunk_size
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_common_chunk_size_applies_to_recursive_and_hybrid(tmp_path):
+    """chunking.chunk_size(공통)가 recursive/hybrid 양쪽 기본값으로 반영된다."""
+    def m(cfg):
+        cfg["chunking"]["chunk_size"] = 2000
+        cfg["chunking"].get("recursive", {}).pop("chunk_size", None)
+        cfg["chunking"].get("hybrid", {}).pop("chunk_size", None)
+    proc = _init(tmp_path, m)
+    assert proc._default_kwargs["recursive_chunk_size"] == 2000
+    assert proc._default_kwargs["hybrid_chunk_size"] == 2000
+
+
+@pytest.mark.unit
+def test_recursive_chunk_size_overrides_common(tmp_path):
+    """per-block recursive.chunk_size 가 공통 chunk_size 를 덮어쓴다(hybrid 는 공통 유지)."""
+    def m(cfg):
+        cfg["chunking"]["chunk_size"] = 2000
+        cfg["chunking"].setdefault("recursive", {})["chunk_size"] = 500
+    proc = _init(tmp_path, m)
+    assert proc._default_kwargs["recursive_chunk_size"] == 500
+    assert proc._default_kwargs["hybrid_chunk_size"] == 2000
+
+
+@pytest.mark.unit
+def test_chunk_size_zero_kept(tmp_path):
+    """chunk_size=0(전체 1청크) 이 그대로 로드된다(강제 기본값으로 치환되지 않음)."""
+    def m(cfg):
+        cfg["chunking"]["chunk_size"] = 0
+        cfg["chunking"].get("recursive", {}).pop("chunk_size", None)
+    proc = _init(tmp_path, m)
+    assert proc._default_kwargs["recursive_chunk_size"] == 0
+
+
+# ---------------------------------------------------------------------------
+# chunker_type 위치 이동 + 폴백
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_chunker_type_from_chunking(tmp_path):
+    def m(cfg):
+        cfg["chunking"]["chunker_type"] = "hybrid"
+        cfg["defaults"].pop("chunker_type", None)
+    proc = _init(tmp_path, m)
+    assert proc._default_kwargs["chunker_type"] == "hybrid"
+
+
+@pytest.mark.unit
+def test_chunker_type_fallback_to_defaults(tmp_path):
+    """chunking.chunker_type 부재 시 구 위치 defaults.chunker_type 로 폴백."""
+    def m(cfg):
+        cfg["chunking"].pop("chunker_type", None)
+        cfg["defaults"]["chunker_type"] = "hybrid"
+    proc = _init(tmp_path, m)
+    assert proc._default_kwargs["chunker_type"] == "hybrid"
+
+
+# ---------------------------------------------------------------------------
+# HWP 옵션 formats.hwp 이동 + 폴백
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_hwp_options_from_formats(tmp_path):
+    def m(cfg):
+        cfg["formats"]["hwp"] = {
+            "use_hwp_sdk": False, "dump_sdk_output": True, "save_images": False,
+        }
+    proc = _init(tmp_path, m)
+    assert proc._default_kwargs["use_hwp_sdk"] is False
+    assert proc._default_kwargs["save_images"] is False
+    # dump_sdk_output 은 use_hwp_sdk=False 여도 _default_kwargs 자체엔 설정값이 반영됨
+    assert proc._default_kwargs["dump_sdk_output"] is True
+
+
+@pytest.mark.unit
+def test_hwp_options_fallback_to_defaults(tmp_path):
+    """formats.hwp 부재 시 구 위치 defaults.* 로 폴백."""
+    def m(cfg):
+        cfg["formats"].pop("hwp", None)
+        cfg["defaults"]["use_hwp_sdk"] = False
+        cfg["defaults"]["save_images"] = False
+    proc = _init(tmp_path, m)
+    assert proc._default_kwargs["use_hwp_sdk"] is False
+    assert proc._default_kwargs["save_images"] is False
+
+
+# ---------------------------------------------------------------------------
+# token_chunk_size_cap 완전 제거
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_token_chunk_size_cap_removed(tmp_path):
+    """token cap 관련 키가 _default_kwargs 에 더 이상 존재하지 않는다."""
+    proc = _init(tmp_path, lambda cfg: None)
+    assert "recursive_token_chunk_size_cap" not in proc._default_kwargs
+    assert "recursive_tokenizer_id" not in proc._default_kwargs
+    assert "hybrid_tokenizer_id" not in proc._default_kwargs

--- a/genon/preprocessor/tests/unit/test_attachment_chunking.py
+++ b/genon/preprocessor/tests/unit/test_attachment_chunking.py
@@ -1,0 +1,144 @@
+"""
+attachment_processor 청킹/설정 변경에 대한 단위 테스트 (로컬 실행 가능 부분).
+
+로컬 환경은 vendored docling 충돌로 `facade.attachment_processor` import 가 불가하므로,
+아래 두 검증은 **모듈 import 없이** 수행한다:
+  1) 통합 문자수 헬퍼 `_char_split_text` — 소스에서 함수만 AST 추출해 stub 의존성으로 실행.
+  2) shipped config(yaml) 구조 — chunk_size/chunker_type 공통화, generic·token cap 제거,
+     formats.hwp 이동 등 리팩터 결과를 yaml 로드만으로 검증.
+
+(DocumentProcessor.__init__ 파싱 → _default_kwargs 매핑 검증은 docling 가용 CI 에서 실행되는
+ test_attachment_chunk_config_unit.py 가 담당한다.)
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+import yaml
+
+_FACADE_DIR = Path(__file__).resolve().parents[2] / "facade"
+_ATTACH_SRC = _FACADE_DIR / "attachment_processor.py"
+_RESOURCE_DIR = Path(__file__).resolve().parents[2] / "resource"
+_RESOURCE_DEV_DIR = Path(__file__).resolve().parents[2] / "resource_dev"
+_CONFIG_NAME = "attachment_processor_config.yaml"
+
+
+# ---------------------------------------------------------------------------
+# _char_split_text: 실제 소스에서 함수만 추출 + stub 로 실행 (import 불필요)
+# ---------------------------------------------------------------------------
+
+class _FakeSplitter:
+    """RecursiveCharacterTextSplitter 대체: 문자수 기준 고정 크기 분할."""
+
+    def __init__(self, chunk_size, chunk_overlap):
+        self.cs = int(chunk_size)
+        self.co = int(chunk_overlap)
+
+    def split_text(self, text):
+        step = max(self.cs - self.co, 1)
+        return [text[i:i + self.cs] for i in range(0, len(text), step)]
+
+
+def _load_char_split_text():
+    src = _ATTACH_SRC.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    fn = next(
+        n for n in tree.body
+        if isinstance(n, ast.FunctionDef) and n.name == "_char_split_text"
+    )
+    ns = {"RecursiveCharacterTextSplitter": _FakeSplitter}
+    exec(ast.get_source_segment(src, fn), ns)  # noqa: S102 - 테스트 내 신뢰된 소스
+    return ns["_char_split_text"]
+
+
+_TXT = "abcdefghij" * 5  # 50자
+
+
+@pytest.mark.unit
+class TestCharSplitText:
+    def setup_method(self):
+        self.f = _load_char_split_text()
+
+    def test_empty_returns_empty(self):
+        assert self.f("", chunk_size=0, chunk_overlap=0) == []
+
+    def test_chunk_size_zero_single_chunk(self):
+        """chunk_size=0 → 문서 전체가 1청크(분할 안 함)."""
+        assert self.f(_TXT, chunk_size=0, chunk_overlap=100) == [_TXT]
+
+    def test_chunk_size_none_single_chunk(self):
+        """chunk_size 미지정(None) → 0 과 동일하게 1청크."""
+        assert self.f(_TXT, chunk_size=None, chunk_overlap=None) == [_TXT]
+
+    def test_positive_chunk_size_splits_by_chars(self):
+        """chunk_size>0 → 문자수 단위 분할, 각 청크는 chunk_size 이하, 원문 보존."""
+        out = self.f(_TXT, chunk_size=20, chunk_overlap=0)
+        assert len(out) > 1
+        assert all(len(c) <= 20 for c in out)
+        assert "".join(out) == _TXT
+
+    def test_signature_has_no_token_cap(self):
+        """token cap 제거 확인: 파라미터가 (text, chunk_size, chunk_overlap) 뿐."""
+        import inspect
+        params = list(inspect.signature(self.f).parameters)
+        assert params == ["text", "chunk_size", "chunk_overlap"]
+
+
+# ---------------------------------------------------------------------------
+# shipped config 구조 검증 (yaml 로드만; import 불필요)
+# ---------------------------------------------------------------------------
+
+def _config_paths():
+    paths = []
+    for d in (_RESOURCE_DIR, _RESOURCE_DEV_DIR):
+        p = d / _CONFIG_NAME
+        if p.exists():
+            paths.append(p)
+    return paths
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("cfg_path", _config_paths(), ids=lambda p: p.parent.name)
+class TestConfigStructure:
+    def _load(self, cfg_path):
+        return yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+
+    def test_chunking_common_keys(self, cfg_path):
+        """chunker_type·chunk_size 는 chunking 공통 레벨에 있다."""
+        ch = self._load(cfg_path)["chunking"]
+        assert ch.get("chunker_type") in ("recursive", "hybrid")
+        assert "chunk_size" in ch  # 공통 chunk_size
+
+    def test_generic_block_removed(self, cfg_path):
+        assert "generic" not in self._load(cfg_path)["chunking"]
+
+    def test_recursive_block_minimal(self, cfg_path):
+        """recursive 블록엔 chunk_overlap 만(=chunk_size·tokenizer_id·token cap 제거)."""
+        rec = self._load(cfg_path)["chunking"]["recursive"]
+        assert "chunk_size" not in rec
+        assert "tokenizer_id" not in rec
+        assert "token_chunk_size_cap" not in rec
+
+    def test_hybrid_block_no_moved_keys(self, cfg_path):
+        """hybrid 블록엔 chunk_size·tokenizer_id 없음(공통/최상위로 이동)."""
+        hyb = self._load(cfg_path)["chunking"]["hybrid"]
+        assert "chunk_size" not in hyb
+        assert "tokenizer_id" not in hyb
+        assert hyb.get("tokenizer_type") in ("char", "huggingface")
+
+    def test_tokenizer_single_source(self, cfg_path):
+        ch = self._load(cfg_path)["chunking"]
+        assert "tokenizer_path" in ch and "tokenizer_id" in ch
+
+    def test_defaults_minimal(self, cfg_path):
+        """defaults 엔 전역 옵션만(log_level, use_pdf_sdk). hwp 옵션은 formats 로 이동."""
+        df = self._load(cfg_path)["defaults"]
+        assert set(df.keys()) <= {"log_level", "use_pdf_sdk"}
+        for moved in ("use_hwp_sdk", "dump_sdk_output", "save_images"):
+            assert moved not in df
+
+    def test_formats_hwp_present(self, cfg_path):
+        """HWP 전용 옵션은 formats.hwp 로 이동."""
+        hwp = self._load(cfg_path)["formats"]["hwp"]
+        assert set(hwp.keys()) == {"use_hwp_sdk", "dump_sdk_output", "save_images"}


### PR DESCRIPTION
# refactor(#312): 첨부용 전처리기 청킹/설정(config yaml) 정리

## 개요

첨부용 전처리기(`attachment_processor.py`)의 청킹 방식이 `generic`/`recursive`/`hybrid` 3갈래로
config·코드에 중복·분산돼 있었다. 실제로 `generic`·`recursive`는 **둘 다 문자수 기반**
(`RecursiveCharacterTextSplitter`)이라, 이를 **문자수 기반 단일 모드로 통합**하고 설정 구조를
정리했다. 옵션의 위치·의미를 일관되게 재편하고, 매뉴얼과 단위테스트를 함께 갱신했다.

> 동작 요약: 기본 청킹은 **문자수 기반(`recursive`)**, `hybrid`는 layout 파싱되는
> **hwp/hwpx/docx 전용 선택 모드**. 기본 `chunk_size`는 문서를 크게(사실상 1청크에 가깝게) 유지.

## 주요 변경

### 1) generic + recursive → 문자수 단일 모드로 통합
- 공용 헬퍼 `_char_split_text(text, chunk_size, chunk_overlap)` 신설 — pdf/txt/md/img(평문)와
  hwp/hwpx/docx(markdown export)가 동일한 문자 분할 로직을 공유.
- `chunk_size <= 0` 이면 분할하지 않고 **문서 전체를 1청크**로 둔다(PPT는 예외로 `1 page = 1 chunk` 유지).
- `chunking.generic` 블록 및 관련 `generic_*` 파싱 제거.

### 2) 청킹 옵션을 `chunking` 공통 레벨로 승격
- **`chunker_type`**: `defaults` → `chunking.chunker_type` 로 이동(`recursive` 기본 | `hybrid`).
- **`chunk_size`**: 공통 `chunking.chunk_size` 로 승격. recursive=문자 수, hybrid=토큰 수로 해석
  (두 모드는 `chunker_type`으로 택일 → 값 하나를 활성 모드가 자기 단위로 사용).
- `chunking.recursive` = `{ chunk_overlap }`, `chunking.hybrid` = `{ tokenizer_type, merge_peers }` 로 축소.

### 3) 토크나이저 설정 단일화
- 중복이던 `chunking.recursive.tokenizer_id`·`chunking.hybrid.tokenizer_id` 제거.
- 토크나이저는 최상위 `chunking.tokenizer_path`/`tokenizer_id` 하나로 일원화(hybrid `huggingface` 모드용).

### 4) HWP 전용 옵션을 `formats.hwp` 로 이동
- `use_hwp_sdk`·`dump_sdk_output`·`save_images` 를 `defaults` → `formats.hwp` 로 이동
  (기존 `formats.ppt` 패턴과 일관). `use_pdf_sdk`는 전 변환 경로 공용이라 `defaults` 유지.
- 결과적으로 `defaults` 에는 전역 옵션(`log_level`, `use_pdf_sdk`)만 남음.

## 설정 변화 (before → after)

```yaml
# before
defaults: { chunker_type, use_hwp_sdk, dump_sdk_output, save_images, use_pdf_sdk, log_level }
chunking:
  tokenizer_path / tokenizer_id
  generic:   { chunk_size, chunk_overlap }
  recursive: { chunk_size, chunk_overlap, token_chunk_size_cap, tokenizer_id }
  hybrid:    { tokenizer_type, tokenizer_id, chunk_size, merge_peers }

# after
defaults: { log_level, use_pdf_sdk }
formats:
  hwp: { use_hwp_sdk, dump_sdk_output, save_images }
chunking:
  chunker_type              # recursive(기본) | hybrid
  chunk_size                # 공통(recursive=문자 수 · hybrid=토큰 수 · 0=전체 1청크)
  recursive: { chunk_overlap }
  hybrid:    { tokenizer_type, merge_peers }
  tokenizer_path / tokenizer_id
```

## 하위 호환
- 구버전 config 폴백 지원: `chunking.chunker_type` 없으면 `defaults.chunker_type`,
  `formats.hwp.*` 없으면 `defaults.*`, `chunking.chunk_size` 없으면 `chunking.recursive|generic.chunk_size`
  순으로 폴백해 읽는다.
- 런타임 kwargs override 및 `HwpProcessor`/`DocxProcessor` 내부 인터페이스는 변경 없음.
- `legacy/BOK_첨부용.py`는 자체 상수를 보유해 영향 없음.

## 테스트
- 로컬: `pytest tests/unit/test_attachment_chunking.py` → 19 passed
  (config 구조 검증 + `_char_split_text` 로직 검증).
- CI(docling 가용): `test_attachment_chunk_config_unit.py` 포함 — 공통 chunk_size 반영,
  chunker_type/HWP 옵션 이동·폴백, token cap 키 부재 검증.
- 로컬은 vendored docling 충돌로 import 기반 테스트가 skip됨(기존 관례, CI에서 실제 실행).

## 변경 파일
- `facade/attachment_processor.py`
- `resource/attachment_processor_config.yaml`, `resource_dev/attachment_processor_config.yaml`
- `facade/gitbook_doc/attachment_processor.md`
- `tests/unit/test_attachment_chunking.py`, `tests/unit/test_attachment_chunk_config_unit.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment and document chunking behavior for more consistent split sizes.
  * Removed forced token-cap handling, which helps avoid unexpected chunking behavior.
  * Updated HWP/PPT processing defaults so settings are applied more reliably.

* **New Features**
  * Added support for simplified character-based chunking across attachments.

* **Documentation**
  * Updated configuration guidance to reflect the new chunking and format-specific settings layout.

* **Tests**
  * Added coverage for chunk sizing, configuration fallback behavior, and chunking output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->