### PR TITLE
fix: nltk punkt_tab

### DIFF
--- a/build-script/code-serving-doc-parser/build.config
+++ b/build-script/code-serving-doc-parser/build.config
@@ -34,7 +34,7 @@ PUSH_IMAGE=true
 TORCH_CPU_INDEX_URL=https://download.pytorch.org/whl/cpu
 
 # NLTK 패키지 (쉼표 구분, "all" 도 가능). Dockerfile.standard 기본은 all.
-NLTK_PACKAGES=punkt,stopwords,averaged_perceptron_tagger,averaged_perceptron_tagger_eng,wordnet,omw-1.4
+NLTK_PACKAGES=punkt,punkt_tab,stopwords,averaged_perceptron_tagger,averaged_perceptron_tagger_eng,wordnet,omw-1.4
 
 # rhwp(genos-rhwp) 빌드 git ref
 RHWP_GIT_REF=genos/main

--- a/build-script/doc-parser-build.config
+++ b/build-script/doc-parser-build.config
@@ -71,7 +71,7 @@ APP_UNAME=genos
 APP_GNAME=genos
 
 # NLTK packages (comma-separated). Use "all" to download everything.
-APP_NLTK_PACKAGES=punkt,stopwords,averaged_perceptron_tagger,averaged_perceptron_tagger_eng,wordnet,omw-1.4
+APP_NLTK_PACKAGES=punkt,punkt_tab,stopwords,averaged_perceptron_tagger,averaged_perceptron_tagger_eng,wordnet,omw-1.4
 
 # HuggingFace Access Tokens (Private Repo 접근용, 이슈 #199 — SDK 별 fine-grained 분리)
 # ⚠️  두 값 모두 여기에 직접 입력하지 말 것 — 반드시 hf_private_token.env 파일에만


### PR DESCRIPTION
배경 (Background)

첨부용 전처리기에서 PPT 파싱 시 unstructured 라이브러리가 NLTK punkt_tab 리소스를 필요로 하는데, 해당 리소스가 없어 파싱 오류 발생
확인 결과 현재 도커 빌드 스크립트에는 punkt_tab 설치 과정이 누락되어 있었음
운영망(본사) 전처리기에는 punkt_tab이 존재했으나, 이는 빌드 시점(7/2)이 아닌 이후(7/6) 별도로 설치된 것으로 확인됨. 온라인 환경에서는 필요 시점에 자동 설치되는 것으로 보이나, 오프라인/폐쇄망 환경에서는 이 자동 설치가 불가능해 빌드 시 명시적으로 포함해야 함
최신 버전 NLTK부터 punkt_tab이 필수 리소스로 요구됨

변경 사항 (Changes)

도커 빌드 스크립트에 punkt_tab 다운로드/설치 단계 추가
로컬에서 재빌드 후 PPT 파싱 정상 동작 확인 완료

테스트 (Test)

 punkt_tab 추가 반영한 이미지로 PPT 파싱 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app’s language-processing resources to include an additional tokenizer dataset, helping improve text parsing reliability during build and runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->