### PR TITLE
fix: correct YAML indentation in issue_slack.yml

### DIFF
--- a/.github/workflows/issue_slack.yml
+++ b/.github/workflows/issue_slack.yml
@@ -14,14 +14,14 @@ jobs:
         with:
           created_time: ${{ github.event.issue.created_at }}
           script: |
-        from datetime import datetime, timedelta, timezone
-        kst = timezone(timedelta(hours=9))
-        created_time = get_input("created_time")
-        # GitHub timestamps end with 'Z' (UTC); fromisoformat in 3.11+ accepts it,
-        # but normalize for older runtimes too.
-        iso = created_time.replace("Z", "+00:00")
-        dt_kst = datetime.fromisoformat(iso).astimezone(kst)
-        set_output("time", dt_kst.strftime("%Y-%m-%d %H:%M:%S"))
+            from datetime import datetime, timedelta, timezone
+            kst = timezone(timedelta(hours=9))
+            created_time = get_input("created_time")
+            # GitHub timestamps end with 'Z' (UTC); fromisoformat in 3.11+ accepts it,
+            # but normalize for older runtimes too.
+            iso = created_time.replace("Z", "+00:00")
+            dt_kst = datetime.fromisoformat(iso).astimezone(kst)
+            set_output("time", dt_kst.strftime("%Y-%m-%d %H:%M:%S"))
       - name: Create Slack payload
         id: create_payload
         run: |


### PR DESCRIPTION
## Summary
- `issue_slack.yml`'s `script: |` block content was indented *less* than the `script:` key itself, which is invalid YAML for a literal block scalar. This silently broke the Issue-created Slack notification workflow (the equivalent `pr_slack.yml` was correctly indented and kept working).
- Re-indented the Python script block to sit properly under `script:`.

## Test plan
- [ ] `yamllint`/`python -c "import yaml; yaml.safe_load(open('.github/workflows/issue_slack.yml'))"` parses cleanly (verified locally)
- [ ] Open a test issue after merge and confirm the Slack notification fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated issue timestamp preprocessing in the Slack notification workflow.
  * No user-visible behavior changes; timestamps continue to be displayed in KST.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->