### PR TITLE
fix(attachment): docx 헤더 이미지 중복 업로드로 인한 FileNotFoundError 수정

### DIFF
--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -1461,6 +1461,7 @@ class DocxProcessor:
         chunk_index_on_page = 0
         vectors = []
         upload_tasks = []
+        scheduled_upload_paths = set()  # 청크 간 동일 이미지(헤더 그림 등) 중복 업로드 방지
         for chunk_idx, chunk in enumerate(chunks):
             if chunker_type == "recursive":
                 chunk_page = chunk["page_no"]
@@ -1491,10 +1492,18 @@ class DocxProcessor:
 
             chunk_index_on_page += 1
             if upload_files:
-                file_list = self.get_media_files(doc_items)
-                upload_tasks.append(asyncio.create_task(
-                    upload_files(file_list, request=request)
-                ))
+                # 동일 이미지(#56 docx 헤더 그림 등)가 여러 청크에 반복 참조되면 upload_files 가
+                # 같은 파일을 중복 업로드·삭제해 FileNotFoundError 로 전체 요청이 실패한다.
+                # 경로 기준으로 최초 1회만 업로드하도록 dedupe.
+                file_list = []
+                for f in self.get_media_files(doc_items):
+                    if f['path'] not in scheduled_upload_paths:
+                        scheduled_upload_paths.add(f['path'])
+                        file_list.append(f)
+                if file_list:
+                    upload_tasks.append(asyncio.create_task(
+                        upload_files(file_list, request=request)
+                    ))
 
         if upload_tasks:
             await asyncio.gather(*upload_tasks)


### PR DESCRIPTION
Closes #327

## 문제

- 첨부용 전처리기(표준) v2.2.3에서 헤더 이미지가 포함된 docx 처리 시 "오류 발생"으로 실패함
- 재현 문서: HD현대미포.docx, 비상장기업.docx (2026-07-16 운영 테스트)
- 에러 지점: `genos_utils._upload_single`의 `os.remove(org_path)`에서 `FileNotFoundError`

```
File "/app/src/genos_utils.py", line 110, in _upload_single
  await asyncio.to_thread(os.remove, org_path)
FileNotFoundError: [Errno 2] No such file or directory: '.../Document-120073/image_000000_e9b83ce1....png'
```

## 원인

- #56에서 docx 헤더 그림 추출이 추가되면서, 동일 헤더 이미지가 여러 청크의 `doc_items`에 반복 참조됨
- `DocxProcessor.compose_vectors`가 청크마다 `upload_files` 태스크를 생성 → 같은 파일 경로가 여러 태스크에 중복 스케줄됨
- `genos_utils._upload_single`은 업로드 후 finally에서 `os.remove` 수행 → 첫 태스크가 파일을 삭제한 뒤 나머지 태스크가 `FileNotFoundError` → `asyncio.gather`로 전파되어 요청 전체가 실패함
- 실측: HD현대미포.docx에서 unique 이미지 2개가 104회 스케줄됨(중복 102회). 로그의 "Session is closed" 다발도 동일 레이스의 부수 증상임

## 수정

- `compose_vectors`에서 업로드 스케줄된 경로를 set으로 추적, 경로당 최초 1회만 업로드하도록 dedupe
- 중복 스케줄 자체를 제거하므로 크래시 해소와 함께 동일 이미지 반복 업로드(위 실측 기준 102회)도 사라짐
- 변경 파일: `genon/preprocessor/facade/attachment_processor.py` (DocxProcessor.compose_vectors)

## 검증

- 로컬 하네스로 `genos_utils.upload_files` 실동작(업로드 후 `os.remove`)을 모사해 실측함
- 픽스 전: HD현대미포.docx → `FileNotFoundError` 재현 (scheduled=104, unique=2). 운영 로그와 동일한 이미지 해시(`e9b83ce1…`, `70f8947b…`)로 재현 확인
- 픽스 후:
  - HD현대미포.docx → 성공 (vectors=52, 업로드 2회/중복 0)
  - 비상장기업.docx → 성공 (vectors=149, 업로드 4회/중복 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate uploads when the same image is referenced across multiple document sections.
  * Improved media processing efficiency while preserving generated document vectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->