### PR TITLE
fix(attachment): TextLoader 긴 한 줄 txt/json/md 청킹 잘림 수정 (#333)

### DIFF
--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 import asyncio
 import fitz
+import html
 import json
 import math
 import os
@@ -617,10 +618,19 @@ class TextLoader:
                 content = raw.decode('utf-8', errors='replace')
 
             # 4) PDF 변환 유지
-            html = f"<html><meta charset='utf-8'><body><pre>{content}</pre></body></html>"
+            # <pre> 기본값(white-space: pre)은 자동 줄바꿈을 하지 않아, A4 폭을 넘는 긴 줄이
+            # weasyprint 렌더 단계에서 잘려(discard) PDF·청킹에서 누락됨(이슈 #333).
+            #  - white-space: pre-wrap  → 원문 줄바꿈/공백 유지 + 폭 초과 시 자동 줄바꿈
+            #  - overflow-wrap: anywhere → 공백 없는 초장문(URL 등)도 강제 개행
+            #  - html.escape           → <, & 등이 태그로 해석돼 뒤 텍스트가 유실되는 것 방지
+            html_doc = (
+                "<html><meta charset='utf-8'><body>"
+                "<pre style='white-space: pre-wrap; overflow-wrap: anywhere;'>"
+                f"{html.escape(content)}</pre></body></html>"
+            )
             html_path = os.path.join(self.output_dir, 'temp.html')
             with open(html_path, 'w', encoding='utf-8') as f:
-                f.write(html)
+                f.write(html_doc)
             # pdf_path = (self.file_path
             #             .replace('.txt', '.pdf')
             #             .replace('.json', '.pdf'))

--- a/genon/preprocessor/tests/unit/test_attachment_textloader_long_line_333.py
+++ b/genon/preprocessor/tests/unit/test_attachment_textloader_long_line_333.py
@@ -1,0 +1,115 @@
+"""
+이슈 #333 회귀 테스트 — TextLoader 긴 한 줄 잘림 방지.
+
+배경:
+  txt/json/md 는 TextLoader.load() 가 원문을 <pre> 로 감싸 weasyprint 로 PDF 변환한 뒤
+  그 PDF 에서 텍스트를 추출해 청킹한다. <pre> 기본값(white-space: pre)은 자동 줄바꿈을
+  하지 않아, A4 폭을 넘는 긴 줄이 렌더 단계에서 잘려(discard) PDF·청킹에서 누락됐다.
+  수정: <pre> 에 white-space: pre-wrap; overflow-wrap: anywhere 적용 + content html.escape.
+
+검증 경로:
+  TextLoader.load() 는 weasyprint(HTML) 가 있어야 PDF 경로를 탄다. 없으면 원문을 그대로
+  Document 로 반환(잘림 없음)하므로 이 회귀를 재현하지 못한다 → weasyprint 없으면 skip.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import pytest
+
+
+def _import_processor():
+    try:
+        from facade.attachment_processor import _get_pdf_path, TextLoader
+        return _get_pdf_path, TextLoader
+    except ModuleNotFoundError:
+        # 실행 루트에 따라 sys.path 보정 (기존 테스트와 동일 패턴)
+        sys.path.append(str(Path(__file__).resolve().parents[3]))
+        from facade.attachment_processor import _get_pdf_path, TextLoader
+        return _get_pdf_path, TextLoader
+
+
+def _has_weasyprint() -> bool:
+    try:
+        import weasyprint  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _norm(s: str) -> str:
+    """추출 텍스트 비교용: 모든 공백/개행 제거.
+
+    weasyprint 가 wrap 하면서 삽입한 개행이나 PyMuPDF 추출 시 생기는 공백이
+    토큰 중간에 끼어도(overflow-wrap 로 토큰이 쪼개질 수 있음) 원문 대조가 되도록 정규화.
+    """
+    return "".join(s.split())
+
+
+def _extract_text(loader) -> str:
+    docs = loader.load()
+    return "".join(getattr(d, "page_content", "") or "" for d in docs)
+
+
+requires_weasyprint = pytest.mark.skipif(
+    not _has_weasyprint(), reason="weasyprint 미설치로 PDF 경로 회귀 검증 스킵"
+)
+
+
+@pytest.mark.unit
+@requires_weasyprint
+def test_long_single_line_txt_not_truncated(tmp_path: Path):
+    """줄바꿈 없는 긴 한 줄의 끝 텍스트가 청킹 결과에서 누락되지 않아야 한다(이슈 #333)."""
+    _get_pdf_path, TextLoader = _import_processor()
+
+    # A4 폭을 확실히 넘기는 긴 한 줄 + 문장 끝 고유 토큰.
+    # 수정 전에는 끝 토큰이 페이지 밖으로 밀려 렌더/추출에서 누락됨.
+    head = "교정시설 수용관리 업무 안내 " + ("가나다라마바사아자차카타파하 " * 40)
+    tail_token = "문장끝고유표식TAIL333"
+    content = head + tail_token  # 개행 없는 단일 라인
+
+    txt = tmp_path / "long_line.txt"
+    txt.write_text(content, encoding="utf-8")
+
+    extracted = _extract_text(TextLoader(str(txt)))
+
+    # PDF 가 실제로 생성됐는지도 확인(경로가 폴백으로 새지 않았음을 보증)
+    assert Path(_get_pdf_path(str(txt))).exists()
+    assert _norm(tail_token) in _norm(extracted), (
+        "긴 한 줄의 끝 토큰이 추출 텍스트에서 누락됨 — <pre> wrap 미적용 회귀"
+    )
+
+
+@pytest.mark.unit
+@requires_weasyprint
+def test_html_special_chars_preserved(tmp_path: Path):
+    """<, & 등 HTML 특수문자가 태그로 해석돼 뒤 텍스트가 유실되지 않아야 한다(html.escape)."""
+    _get_pdf_path, TextLoader = _import_processor()
+
+    # escape 없으면 '<b>' 이후 '중요' 는 태그로 먹히고, 'a<b 그리고 ... ' 도 유실됨.
+    content = "머리말 <b>중요구절</b> 그리고 조건 a<b 이고 기호 & 앰퍼샌드 끝토큰ESCAPE333"
+
+    txt = tmp_path / "special_chars.txt"
+    txt.write_text(content, encoding="utf-8")
+
+    norm = _norm(_extract_text(TextLoader(str(txt))))
+
+    for token in ("중요구절", "앰퍼샌드", "끝토큰ESCAPE333"):
+        assert _norm(token) in norm, f"escape 누락으로 '{token}' 이 유실됨"
+
+
+@pytest.mark.unit
+@requires_weasyprint
+def test_long_single_line_json_not_truncated(tmp_path: Path):
+    """json 도 TextLoader 경로를 타므로 동일하게 끝 텍스트가 보존돼야 한다."""
+    _get_pdf_path, TextLoader = _import_processor()
+
+    long_val = ("동일한긴문자열반복 " * 50).strip()
+    tail_token = "제이슨끝표식JSON333"
+    content = '{"field": "' + long_val + " " + tail_token + '"}'  # 한 줄 json
+
+    jf = tmp_path / "long_line.json"
+    jf.write_text(content, encoding="utf-8")
+
+    extracted = _extract_text(TextLoader(str(jf)))
+    assert _norm(tail_token) in _norm(extracted)

--- a/genon/preprocessor/tests/unit/test_attachment_textloader_long_line_333.py
+++ b/genon/preprocessor/tests/unit/test_attachment_textloader_long_line_333.py
@@ -7,9 +7,12 @@
   하지 않아, A4 폭을 넘는 긴 줄이 렌더 단계에서 잘려(discard) PDF·청킹에서 누락됐다.
   수정: <pre> 에 white-space: pre-wrap; overflow-wrap: anywhere 적용 + content html.escape.
 
-검증 경로:
-  TextLoader.load() 는 weasyprint(HTML) 가 있어야 PDF 경로를 탄다. 없으면 원문을 그대로
-  Document 로 반환(잘림 없음)하므로 이 회귀를 재현하지 못한다 → weasyprint 없으면 skip.
+주의:
+  - 콘텐츠는 ASCII 로 구성한다. weasyprint→PDF→PyMuPDF round-trip 은 CJK 글리프에
+    대응 폰트가 필요한데 CI 러너엔 한글 폰트가 없어(.notdef) 추출 텍스트가 깨진다.
+    잘림/escape 버그는 언어 무관이므로 ASCII 로도 동일하게 재현·검증된다.
+  - TextLoader.load() 는 weasyprint(HTML) 가 있어야 PDF 경로를 탄다. 없으면 원문을
+    그대로 Document 로 반환(잘림 없음)해 회귀를 재현 못하므로 → weasyprint 없으면 skip.
 """
 from __future__ import annotations
 
@@ -59,14 +62,12 @@ requires_weasyprint = pytest.mark.skipif(
 @pytest.mark.unit
 @requires_weasyprint
 def test_long_single_line_txt_not_truncated(tmp_path: Path):
-    """줄바꿈 없는 긴 한 줄의 끝 텍스트가 청킹 결과에서 누락되지 않아야 한다(이슈 #333)."""
+    """공백은 있지만 개행 없는 긴 한 줄의 끝 토큰이 누락되지 않아야 한다(white-space: pre-wrap)."""
     _get_pdf_path, TextLoader = _import_processor()
 
-    # A4 폭을 확실히 넘기는 긴 한 줄 + 문장 끝 고유 토큰.
-    # 수정 전에는 끝 토큰이 페이지 밖으로 밀려 렌더/추출에서 누락됨.
-    head = "교정시설 수용관리 업무 안내 " + ("가나다라마바사아자차카타파하 " * 40)
-    tail_token = "문장끝고유표식TAIL333"
-    content = head + tail_token  # 개행 없는 단일 라인
+    # A4 폭을 확실히 넘기는 긴 한 줄(개행 없음) + 문장 끝 고유 토큰.
+    # 수정 전(white-space: pre)에는 끝 토큰이 페이지 밖으로 밀려 렌더/추출에서 누락됨.
+    content = "HEADSTART " + ("longword " * 200) + "ENDSENTINEL333"
 
     txt = tmp_path / "long_line.txt"
     txt.write_text(content, encoding="utf-8")
@@ -75,8 +76,26 @@ def test_long_single_line_txt_not_truncated(tmp_path: Path):
 
     # PDF 가 실제로 생성됐는지도 확인(경로가 폴백으로 새지 않았음을 보증)
     assert Path(_get_pdf_path(str(txt))).exists()
-    assert _norm(tail_token) in _norm(extracted), (
-        "긴 한 줄의 끝 토큰이 추출 텍스트에서 누락됨 — <pre> wrap 미적용 회귀"
+    assert "ENDSENTINEL333" in _norm(extracted), (
+        "긴 한 줄의 끝 토큰이 추출 텍스트에서 누락됨 — white-space: pre-wrap 미적용 회귀"
+    )
+
+
+@pytest.mark.unit
+@requires_weasyprint
+def test_no_space_long_token_not_truncated(tmp_path: Path):
+    """공백 없는 초장문(URL·연속 문자열 등)의 끝 토큰이 누락되지 않아야 한다(overflow-wrap: anywhere)."""
+    _get_pdf_path, TextLoader = _import_processor()
+
+    # 공백이 전혀 없는 한 덩어리 → pre-wrap 만으로는 안 쪼개짐, overflow-wrap: anywhere 필요.
+    content = "P" + ("A" * 2000) + "NOSPACETAIL333"
+
+    txt = tmp_path / "no_space.txt"
+    txt.write_text(content, encoding="utf-8")
+
+    extracted = _extract_text(TextLoader(str(txt)))
+    assert "NOSPACETAIL333" in _norm(extracted), (
+        "공백 없는 초장문의 끝 토큰이 누락됨 — overflow-wrap: anywhere 미적용 회귀"
     )
 
 
@@ -86,16 +105,16 @@ def test_html_special_chars_preserved(tmp_path: Path):
     """<, & 등 HTML 특수문자가 태그로 해석돼 뒤 텍스트가 유실되지 않아야 한다(html.escape)."""
     _get_pdf_path, TextLoader = _import_processor()
 
-    # escape 없으면 '<b>' 이후 '중요' 는 태그로 먹히고, 'a<b 그리고 ... ' 도 유실됨.
-    content = "머리말 <b>중요구절</b> 그리고 조건 a<b 이고 기호 & 앰퍼샌드 끝토큰ESCAPE333"
+    # escape 없으면 'a<b' 이 열린 태그로 해석돼 그 뒤 토큰이 통째로 유실됨.
+    content = "PREFIXTOKEN a<b MIDDLEWORD AMPERSANDWORD & END TAILESCAPE333"
 
     txt = tmp_path / "special_chars.txt"
     txt.write_text(content, encoding="utf-8")
 
     norm = _norm(_extract_text(TextLoader(str(txt))))
 
-    for token in ("중요구절", "앰퍼샌드", "끝토큰ESCAPE333"):
-        assert _norm(token) in norm, f"escape 누락으로 '{token}' 이 유실됨"
+    for token in ("AMPERSANDWORD", "TAILESCAPE333"):
+        assert token in norm, f"escape 누락으로 '{token}' 이 유실됨"
 
 
 @pytest.mark.unit
@@ -104,12 +123,10 @@ def test_long_single_line_json_not_truncated(tmp_path: Path):
     """json 도 TextLoader 경로를 타므로 동일하게 끝 텍스트가 보존돼야 한다."""
     _get_pdf_path, TextLoader = _import_processor()
 
-    long_val = ("동일한긴문자열반복 " * 50).strip()
-    tail_token = "제이슨끝표식JSON333"
-    content = '{"field": "' + long_val + " " + tail_token + '"}'  # 한 줄 json
+    content = '{"field": "' + ("wordval " * 200) + 'JSONTAIL333"}'  # 한 줄 json
 
     jf = tmp_path / "long_line.json"
     jf.write_text(content, encoding="utf-8")
 
     extracted = _extract_text(TextLoader(str(jf)))
-    assert _norm(tail_token) in _norm(extracted)
+    assert "JSONTAIL333" in _norm(extracted)

--- a/genon/preprocessor/tests/unit/test_attachment_textloader_long_line_333.py
+++ b/genon/preprocessor/tests/unit/test_attachment_textloader_long_line_333.py
@@ -33,10 +33,13 @@ def _import_processor():
 
 
 def _has_weasyprint() -> bool:
+    # ImportError = 패키지 미설치, OSError = 네이티브 라이브러리(pango/gobject 등) 로드 실패.
+    # 프로덕션(attachment_processor)도 두 경우 모두 HTML=None 폴백을 타므로 skip 이 맞다.
+    # 그 외 예기치 않은 예외는 표면화되도록 좁게 잡는다(Ruff BLE001).
     try:
         import weasyprint  # noqa: F401
         return True
-    except Exception:
+    except (ImportError, OSError):
         return False
 
 


### PR DESCRIPTION
# fix(attachment): TextLoader 긴 한 줄 txt/json/md 청킹 잘림 수정 (#333)

## 개요

줄바꿈 없이 한 줄이 긴 **txt/json/md** 파일을 기본 첨부 전처리기(attachment 모드)로 적재하면, PDF 변환 시 A4 페이지 좌우 폭을 넘어가는 부분이 렌더링되지 않고(잘림), 청킹에서도 넘친 텍스트가 통째로 누락되던 문제를 수정함.

- txt/json: PDF 뷰어·청킹 **둘 다** 잘림
- md: PDF 뷰어는 정상(줄바꿈됨)인데 청킹만 잘림

Closes #333

## 원인

txt/json/md 는 `TextLoader.load()` 가 원문을 `<pre>{content}</pre>` HTML 로 감싸 weasyprint 로 PDF 변환 → 그 PDF 를 PyMuPDF 로 파싱해 청킹함.

그런데 `<pre>` 의 기본값이 `white-space: pre` 라 **자동 줄바꿈을 하지 않음**. 그래서:

- 긴 줄이 페이지 박스를 넘어감
- weasyprint 가 넘친 부분을 PDF 에 아예 그리지 않음(discard)
- PyMuPDF 추출·청킹 단계에서 그대로 소실

md 만 "뷰어는 멀쩡, 청킹만 잘림" 인 이유는 경로가 갈리기 때문:

| 용도 | 경로 | 결과 |
|------|------|------|
| 청킹용 텍스트 추출 | `get_loader` → `TextLoader` (`<pre>`) | 잘림 |
| 표시용(뷰어) PDF | `compose_vectors` → `convert_md_to_pdf` (markdown → `<p>`, 자동 wrap) | 정상 |

두 PDF 모두 weasyprint 로 생성되며(LibreOffice 아님), 차이는 HTML 구조(`<pre>` no-wrap vs `<p>` auto-wrap)뿐. 즉 두 증상(txt/json/md)의 근본 원인은 하나 — `TextLoader` 가 `<pre>` 로 감싸 긴 줄을 wrap 하지 않는 것. (버전 무관 — v2.2.2 / v2.2.3 / develop 동일)

## 변경 사항

`genon/preprocessor/facade/attachment_processor.py`

- 상단에 `import html` 추가
- `TextLoader.load()` 의 `<pre>` HTML 생성부 수정:
  - `white-space: pre-wrap` → 원문 줄바꿈/공백 유지 + 폭 초과 시 자동 줄바꿈
  - `overflow-wrap: anywhere` → 공백 없는 초장문(URL 등)도 강제 개행
  - `html.escape(content)` → `<`, `&` 등이 태그로 해석돼 뒤 텍스트가 유실되는 것 방지
  - 로컬 변수 `html` → `html_doc` 개명 (신규 `html` 모듈과 충돌 회피)

```python
html_doc = (
    "<html><meta charset='utf-8'><body>"
    "<pre style='white-space: pre-wrap; overflow-wrap: anywhere;'>"
    f"{html.escape(content)}</pre></body></html>"
)
```

이 한 곳 수정으로 txt/json/md 청킹 누락이 함께 해결됨. md 표시용 `convert_md_to_pdf` 경로는 이미 정상이라 수정 불필요.

## 테스트

`genon/preprocessor/tests/unit/test_attachment_textloader_long_line_333.py` 신규 추가 (기존 `test_attachment_processor_samples.py` 컨벤션 준수: `@pytest.mark.unit`, `_import_processor` sys.path 폴백, weasyprint 미설치 시 skip)

- `test_long_single_line_txt_not_truncated` — 줄바꿈 없는 긴 txt 의 끝 토큰이 청킹 결과에 보존되는지
- `test_html_special_chars_preserved` — `<`, `&`, 태그 유사 문자열 뒤 텍스트 보존(escape) 검증
- `test_long_single_line_json_not_truncated` — json 도 동일 경로라 끝 토큰 보존

### 검증 결과

`TextLoader.load()` 의 PDF 경로(escape + pre-wrap → weasyprint → PyMuPDF)를 동일 입력으로 재현해 확인:

- 세 테스트 모두 **수정본에서 통과**
- 대조로 **수정 전 `<pre>` 경로에선 실패**(긴 줄 끝 토큰·escape 뒤 토큰 유실) → 진짜 회귀 가드로 작동함을 확인

> 참고: 저장소 전체 `pytest` 는 프로젝트 의존성(pandas·langchain·docling 등) 환경에서 실행 필요.

## 영향 범위

- tabular / docling 모드 무관, 기본 첨부(attachment) 모드의 txt/json/md 경로에만 영향
- 기존 정상 문서(짧은 줄)의 렌더 결과는 동일 — `pre-wrap` 은 원문 줄바꿈/공백을 그대로 유지함
- 수정 후 대상 문서 재적재 필요


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-PDF rendering for long single-line TXT and JSON files, preventing content from being truncated.
  * Preserved special characters and markup-like text correctly during conversion.
  * Improved line wrapping for long text in generated PDFs.

* **Tests**
  * Added regression coverage for long lines and special-character handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->