### PR TITLE
chunk size 1000 일 때 청크결과 안나오는 오류 수정

### DIFF
--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -1288,6 +1288,8 @@ def _char_split_text(text: str, chunk_size=None, chunk_overlap=None) -> list[str
     co = max(int(chunk_overlap), 0) if chunk_overlap is not None else 100
 
     if cs > 0:
+        # overlap >= size 면 RecursiveCharacterTextSplitter 가 ValueError 로 크래시하므로 size-1 이하로 클램프.
+        co = min(co, cs - 1)
         raw_chunks = RecursiveCharacterTextSplitter(
             chunk_size=cs, chunk_overlap=co,
         ).split_text(text)

--- a/genon/preprocessor/facade/chunking_processor.py
+++ b/genon/preprocessor/facade/chunking_processor.py
@@ -2583,23 +2583,34 @@ class DocumentProcessor:
         from langchain_text_splitters import RecursiveCharacterTextSplitter
         from langchain_core.documents import Document
 
-        # chunk_size: 호출 kwargs > 공통 chunking.chunk_size(self._chunk_size). 0/None(docling '분할 안 함'
-        #   관례)이면 char splitter 가 글자 단위로 폭발하므로 큰 기본값(1000000, 사실상 미분할)으로 대체한다.
+        # chunk_size: 명시 kwargs(0 포함) 우선. 0/음수는 docling '분할 안 함' 관례에 맞춰 char splitter
+        #   에서 사실상 미분할(1000000)로 해석. 키가 없거나 파싱 불가면 공통 chunking.chunk_size 사용.
         # chunk_overlap: 호출 kwargs(chunk_overlap/recursive_chunk_overlap) > config(recursive.chunk_overlap).
+        #   명시적 null 도 default 로 폴백해 int(None) 크래시를 막는다.
+        _NO_SPLIT = 1000000
         common_size = getattr(self, "_chunk_size", None)
         overlap_default = getattr(self, "_recursive_chunk_overlap", 100)
-        try:
-            chunk_size = int(kwargs.get('chunk_size'))
-        except (TypeError, ValueError):
-            chunk_size = None
-        if not chunk_size or chunk_size <= 0:
-            chunk_size = common_size if (common_size and common_size > 0) else 1000000
-        chunk_overlap = kwargs.get('chunk_overlap')
-        if chunk_overlap is None:
-            chunk_overlap = kwargs.get('recursive_chunk_overlap', overlap_default)
+
+        raw_size = kwargs.get('chunk_size')
+        if raw_size is None:                       # 키 없음/명시 null → 공통 config
+            chunk_size = common_size
+        else:
+            try:
+                chunk_size = int(raw_size)         # 명시값(0 포함) 보존
+            except (TypeError, ValueError):
+                chunk_size = common_size           # 파싱 불가 → 공통 config (기존 동작 유지)
+        if not chunk_size or chunk_size <= 0:      # 명시적 0/음수 또는 공통값 부재 → 미분할
+            chunk_size = _NO_SPLIT
+
+        overlap = kwargs.get('chunk_overlap')
+        if overlap is None:
+            overlap = kwargs.get('recursive_chunk_overlap')
+        if overlap is None:                        # 부재 또는 명시 null 모두 default 로
+            overlap = overlap_default
+
         chunk_size = max(int(chunk_size), 1)
         # overlap >= size 면 RecursiveCharacterTextSplitter 가 ValueError 로 크래시하므로 size-1 이하로 클램프.
-        chunk_overlap = min(max(int(chunk_overlap), 0), chunk_size - 1)
+        chunk_overlap = min(max(int(overlap), 0), chunk_size - 1)
 
         # #315 민감정보 분류: __call__ 에서 문서 전체 1회 분류한 결과를 청크별 quote 매칭에 사용.
         _sensitive_infos: list = kwargs.get("_sensitive_infos") or []

--- a/genon/preprocessor/facade/chunking_processor.py
+++ b/genon/preprocessor/facade/chunking_processor.py
@@ -894,7 +894,9 @@ class GenosSmartChunker(BaseChunker):
 
         def get_current_chunk(doc_chunk: DocChunk, merged_texts: list[str], merged_header_short_infos: list[dict], merged_items: list[DocItem]):
             """현재까지 병합된 내용으로 DocChunk 생성"""
-            if not merged_texts:
+            # doc_items 가 비면 DocMeta(min_length=1) 검증에서 크래시하므로 스킵한다.
+            # (chunk_size 분할 시 헤더만 남고 items 가 빈 무의미 그룹이 생길 수 있음)
+            if not merged_texts or not merged_items:
                 return None
             chunk_text = "\n".join(merged_texts)
             used_headers = self._extract_used_headers(merged_header_short_infos)
@@ -970,7 +972,8 @@ class GenosSmartChunker(BaseChunker):
 
             cuts.append(n)
 
-            return [(a, b) for a, b in zip(cuts[:-1], cuts[1:])]
+            # 폭 0 범위(a==b)는 빈 items 그룹을 만들어 하위에서 무의미 청크가 되므로 제외.
+            return [(a, b) for a, b in zip(cuts[:-1], cuts[1:]) if a < b]
 
         def adjust_captions(items_group):
 
@@ -1629,13 +1632,11 @@ class DocumentProcessor:
         # parser 가 넘긴 sensitive_infos 를 청크에 적용만 하며, 치환 여부는 masking_enabled 로 결정.
         self._gr_cfg = gr.GuardrailConfig.from_cfg(cfg)
 
-        # parse-format(비-docling) 일반 텍스트 splitter 기본값 (attachment_processor 와 동일).
-        # docling 경로(GenosSmartChunker)와 무관. _chunk_text_elements 의 폴백으로 사용된다.
-        generic_cfg = _as_dict(chunking_cfg.get("generic"))
-        gcs = _parse_optional_int(generic_cfg.get("chunk_size"), "chunking.generic.chunk_size")
-        self._generic_chunk_size = gcs if gcs and gcs > 0 else 1000
-        gco = _parse_optional_int(generic_cfg.get("chunk_overlap"), "chunking.generic.chunk_overlap")
-        self._generic_chunk_overlap = gco if gco is not None and gco >= 0 else 100
+        # parse-format(비-docling) 문자 splitter overlap 기본값 (docling 무관, parse-format 전용).
+        # 크기는 공통 chunking.chunk_size(self._chunk_size)를 사용한다(_chunk_text_elements).
+        recursive_cfg = _as_dict(chunking_cfg.get("recursive"))
+        rco = _parse_optional_int(recursive_cfg.get("chunk_overlap"), "chunking.recursive.chunk_overlap")
+        self._recursive_chunk_overlap = rco if rco is not None and rco >= 0 else 100
 
         # OCR 엔드포인트는 ocr.paddle.ocr_endpoint 가 정식 위치.
         # 구버전 호환: ocr.ocr_endpoint(상위) / 최상위 ocr_endpoint 도 폴백으로 인식.
@@ -2582,22 +2583,23 @@ class DocumentProcessor:
         from langchain_text_splitters import RecursiveCharacterTextSplitter
         from langchain_core.documents import Document
 
-        # chunk_size/overlap: 호출 kwargs 우선, 없으면 config(generic) 기본값(attachment 동일).
-        # chunk_size 가 None/0/음수(docling 경로의 '분할 안 함' 관례)이면 char splitter 가
-        # 글자 단위로 폭발하므로 generic 기본값으로 대체한다.
-        generic_size_default = getattr(self, "_generic_chunk_size", 1000)
-        generic_overlap_default = getattr(self, "_generic_chunk_overlap", 100)
+        # chunk_size: 호출 kwargs > 공통 chunking.chunk_size(self._chunk_size). 0/None(docling '분할 안 함'
+        #   관례)이면 char splitter 가 글자 단위로 폭발하므로 큰 기본값(1000000, 사실상 미분할)으로 대체한다.
+        # chunk_overlap: 호출 kwargs(chunk_overlap/recursive_chunk_overlap) > config(recursive.chunk_overlap).
+        common_size = getattr(self, "_chunk_size", None)
+        overlap_default = getattr(self, "_recursive_chunk_overlap", 100)
         try:
             chunk_size = int(kwargs.get('chunk_size'))
         except (TypeError, ValueError):
             chunk_size = None
         if not chunk_size or chunk_size <= 0:
-            chunk_size = int(kwargs.get('generic_chunk_size', generic_size_default))
+            chunk_size = common_size if (common_size and common_size > 0) else 1000000
         chunk_overlap = kwargs.get('chunk_overlap')
         if chunk_overlap is None:
-            chunk_overlap = kwargs.get('generic_chunk_overlap', generic_overlap_default)
+            chunk_overlap = kwargs.get('recursive_chunk_overlap', overlap_default)
         chunk_size = max(int(chunk_size), 1)
-        chunk_overlap = max(int(chunk_overlap), 0)
+        # overlap >= size 면 RecursiveCharacterTextSplitter 가 ValueError 로 크래시하므로 size-1 이하로 클램프.
+        chunk_overlap = min(max(int(chunk_overlap), 0), chunk_size - 1)
 
         # #315 민감정보 분류: __call__ 에서 문서 전체 1회 분류한 결과를 청크별 quote 매칭에 사용.
         _sensitive_infos: list = kwargs.get("_sensitive_infos") or []

--- a/genon/preprocessor/facade/convert_processor.py
+++ b/genon/preprocessor/facade/convert_processor.py
@@ -1206,7 +1206,9 @@ class GenosSmartChunker(BaseChunker):
 
         def get_current_chunk(doc_chunk: DocChunk, merged_texts: list[str], merged_header_short_infos: list[dict], merged_items: list[DocItem]):
             """현재까지 병합된 내용으로 DocChunk 생성"""
-            if not merged_texts:
+            # doc_items 가 비면 DocMeta(min_length=1) 검증에서 크래시하므로 스킵한다.
+            # (chunk_size 분할 시 헤더만 남고 items 가 빈 무의미 그룹이 생길 수 있음)
+            if not merged_texts or not merged_items:
                 return None
             chunk_text = "\n".join(merged_texts)
             used_headers = self._extract_used_headers(merged_header_short_infos)
@@ -1282,7 +1284,8 @@ class GenosSmartChunker(BaseChunker):
 
             cuts.append(n)
 
-            return [(a, b) for a, b in zip(cuts[:-1], cuts[1:])]
+            # 폭 0 범위(a==b)는 빈 items 그룹을 만들어 하위에서 무의미 청크가 되므로 제외.
+            return [(a, b) for a, b in zip(cuts[:-1], cuts[1:]) if a < b]
 
         def adjust_captions(items_group):
 

--- a/genon/preprocessor/facade/intelligent_processor.py
+++ b/genon/preprocessor/facade/intelligent_processor.py
@@ -1211,7 +1211,9 @@ class GenosSmartChunker(BaseChunker):
 
         def get_current_chunk(doc_chunk: DocChunk, merged_texts: list[str], merged_header_short_infos: list[dict], merged_items: list[DocItem]):
             """현재까지 병합된 내용으로 DocChunk 생성"""
-            if not merged_texts:
+            # doc_items 가 비면 DocMeta(min_length=1) 검증에서 크래시하므로 스킵한다.
+            # (chunk_size 분할 시 헤더만 남고 items 가 빈 무의미 그룹이 생길 수 있음)
+            if not merged_texts or not merged_items:
                 return None
             chunk_text = "\n".join(merged_texts)
             used_headers = self._extract_used_headers(merged_header_short_infos)
@@ -1287,7 +1289,8 @@ class GenosSmartChunker(BaseChunker):
 
             cuts.append(n)
 
-            return [(a, b) for a, b in zip(cuts[:-1], cuts[1:])]
+            # 폭 0 범위(a==b)는 빈 items 그룹을 만들어 하위에서 무의미 청크가 되므로 제외.
+            return [(a, b) for a, b in zip(cuts[:-1], cuts[1:]) if a < b]
 
         def adjust_captions(items_group):
 

--- a/genon/preprocessor/facade/legacy/BOK_적재용_규정.py
+++ b/genon/preprocessor/facade/legacy/BOK_적재용_규정.py
@@ -694,7 +694,9 @@ class GenosSmartChunker(BaseChunker):
 
         def get_current_chunk(doc_chunk: DocChunk, merged_texts: list[str], merged_header_short_infos: list[dict], merged_items: list[DocItem]):
             """현재까지 병합된 내용으로 DocChunk 생성"""
-            if not merged_texts:
+            # doc_items 가 비면 DocMeta(min_length=1) 검증에서 크래시하므로 스킵한다.
+            # (chunk_size 분할 시 헤더만 남고 items 가 빈 무의미 그룹이 생길 수 있음)
+            if not merged_texts or not merged_items:
                 return None
             chunk_text = "\n".join(merged_texts)
             used_headers = self._extract_used_headers(merged_header_short_infos)
@@ -770,7 +772,8 @@ class GenosSmartChunker(BaseChunker):
 
             cuts.append(n)
 
-            return [(a, b) for a, b in zip(cuts[:-1], cuts[1:])]
+            # 폭 0 범위(a==b)는 빈 items 그룹을 만들어 하위에서 무의미 청크가 되므로 제외.
+            return [(a, b) for a, b in zip(cuts[:-1], cuts[1:]) if a < b]
 
         def adjust_captions(items_group):
 

--- a/genon/preprocessor/facade/legacy/BOK_적재용_내부.py
+++ b/genon/preprocessor/facade/legacy/BOK_적재용_내부.py
@@ -635,7 +635,9 @@ class GenosSmartChunker(BaseChunker):
 
         def get_current_chunk(doc_chunk: DocChunk, merged_texts: list[str], merged_header_short_infos: list[dict], merged_items: list[DocItem]):
             """현재까지 병합된 내용으로 DocChunk 생성"""
-            if not merged_texts:
+            # doc_items 가 비면 DocMeta(min_length=1) 검증에서 크래시하므로 스킵한다.
+            # (chunk_size 분할 시 헤더만 남고 items 가 빈 무의미 그룹이 생길 수 있음)
+            if not merged_texts or not merged_items:
                 return None
             chunk_text = "\n".join(merged_texts)
             used_headers = self._extract_used_headers(merged_header_short_infos)
@@ -711,7 +713,8 @@ class GenosSmartChunker(BaseChunker):
 
             cuts.append(n)
 
-            return [(a, b) for a, b in zip(cuts[:-1], cuts[1:])]
+            # 폭 0 범위(a==b)는 빈 items 그룹을 만들어 하위에서 무의미 청크가 되므로 제외.
+            return [(a, b) for a, b in zip(cuts[:-1], cuts[1:]) if a < b]
 
         def adjust_captions(items_group):
 

--- a/genon/preprocessor/facade/legacy/BOK_적재용_외부.py
+++ b/genon/preprocessor/facade/legacy/BOK_적재용_외부.py
@@ -690,7 +690,9 @@ class GenosSmartChunker(BaseChunker):
 
         def get_current_chunk(doc_chunk: DocChunk, merged_texts: list[str], merged_header_short_infos: list[dict], merged_items: list[DocItem]):
             """현재까지 병합된 내용으로 DocChunk 생성"""
-            if not merged_texts:
+            # doc_items 가 비면 DocMeta(min_length=1) 검증에서 크래시하므로 스킵한다.
+            # (chunk_size 분할 시 헤더만 남고 items 가 빈 무의미 그룹이 생길 수 있음)
+            if not merged_texts or not merged_items:
                 return None
             chunk_text = "\n".join(merged_texts)
             used_headers = self._extract_used_headers(merged_header_short_infos)
@@ -766,7 +768,8 @@ class GenosSmartChunker(BaseChunker):
 
             cuts.append(n)
 
-            return [(a, b) for a, b in zip(cuts[:-1], cuts[1:])]
+            # 폭 0 범위(a==b)는 빈 items 그룹을 만들어 하위에서 무의미 청크가 되므로 제외.
+            return [(a, b) for a, b in zip(cuts[:-1], cuts[1:]) if a < b]
 
         def adjust_captions(items_group):
 

--- a/genon/preprocessor/facade/legacy/BOK_첨부용.py
+++ b/genon/preprocessor/facade/legacy/BOK_첨부용.py
@@ -1090,6 +1090,8 @@ def _split_with_recursive_chunker(
         if token_chunk_size_cap is not None
         else _RECURSIVE_CHUNK_SIZE_CAP
     )
+    # overlap >= size 면 RecursiveCharacterTextSplitter 가 ValueError 로 크래시하므로 size-1 이하로 클램프.
+    co = min(co, cs - 1)
     splitter = RecursiveCharacterTextSplitter(
         chunk_size=cs,
         chunk_overlap=co,
@@ -1679,7 +1681,8 @@ class DocumentProcessor:
             chunk_overlap = kwargs.get('generic_chunk_overlap', 100)
 
         chunk_size = max(int(chunk_size), 1)
-        chunk_overlap = max(int(chunk_overlap), 0)
+        # overlap >= size 면 RecursiveCharacterTextSplitter 가 ValueError 로 크래시하므로 size-1 이하로 클램프.
+        chunk_overlap = min(max(int(chunk_overlap), 0), chunk_size - 1)
         text_splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size,
                                                        chunk_overlap=chunk_overlap,)
         chunks = text_splitter.split_documents(documents)

--- a/genon/preprocessor/resource/chunking_processor_config.yaml
+++ b/genon/preprocessor/resource/chunking_processor_config.yaml
@@ -11,8 +11,10 @@ defaults:
 
 # 청킹(GenosSmartChunker) 설정
 chunking:
-  # 청크 최대 크기(max_tokens). char 모드면 "최대 문자 수", huggingface 모드면 "최대 토큰 수".
-  # 우선순위: 호출 kwargs 의 chunk_size > 아래 chunk_size. 0 = 토큰/문자 기반 분할 안 함. 0 초과 시 최소 1024 로 보정.
+  # 청크 최대 크기(공통): docling=GenosSmartChunker max_tokens · parse-format=문자 splitter 크기.
+  # char 모드면 문자 수, huggingface 모드면 docling 은 토큰 수(parse-format 은 항상 문자 수).
+  # 우선순위: 호출 kwargs 의 chunk_size > 아래 chunk_size. docling: 0=분할 안 함, 0 초과 시 최소 1024 로 보정.
+  # parse-format: 0/미설정이면 코드 기본값(1000000, 사실상 미분할)로 대체.
   chunk_size: 10000
   # 청킹 모드: split_only(기본) = 파서 섹션 단위(제N조 등) 그대로 유지 + chunk_size 초과 섹션만 분할
   #             (작은 섹션을 장 단위로 병합하지 않음) |
@@ -25,16 +27,13 @@ chunking:
   tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
   tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
 
-  # parse-format(비-docling) 입력의 일반 텍스트 splitter 기본값.
+  # parse-format(비-docling) 문자 splitter 의 overlap 기본값.
   # 파서가 docling 을 못 만드는 포맷(csv/xlsx/txt/md/ppt/pptx/doc/이미지/오디오)은 parse-format
-  # ({"elements":[...]})으로 들어오며, 그 중 일반 텍스트는 RecursiveCharacterTextSplitter 로
-  # 분할한다. docling 경로(GenosSmartChunker, 위 chunk_size)와는 무관하며,
-  # audio([AUDIO])/csv·xlsx([DA]) 단일 벡터에는 적용되지 않는다.
-  # 우선순위: 호출 kwargs(chunk_size/generic_chunk_size, chunk_overlap/generic_chunk_overlap)
-  #           > 아래 값 > 코드 기본값(1000/100).
-  generic:
-    chunk_size: 1000     # 0 이하면 1000 으로 폴백
-    chunk_overlap: 100   # 음수면 100 으로 폴백
+  # ({"elements":[...]})으로 들어오며, 그 중 일반 텍스트는 RecursiveCharacterTextSplitter 로 분할한다.
+  # 크기는 위 공통 chunk_size 를 사용한다(docling 무관). audio([AUDIO])/csv·xlsx([DA]) 단일 벡터엔 미적용.
+  # 우선순위: 호출 kwargs(chunk_overlap/recursive_chunk_overlap) > 아래 > 코드 기본값(100).
+  recursive:
+    chunk_overlap: 100    # 음수면 100 으로 폴백
 
 # table_image
 # 표를 이미지로 잘라 저장하고 media_files 에 type='table_image' 로 기록할지 여부.

--- a/genon/preprocessor/resource/chunking_processor_config.yaml
+++ b/genon/preprocessor/resource/chunking_processor_config.yaml
@@ -14,7 +14,7 @@ chunking:
   # 청크 최대 크기(공통): docling=GenosSmartChunker max_tokens · parse-format=문자 splitter 크기.
   # char 모드면 문자 수, huggingface 모드면 docling 은 토큰 수(parse-format 은 항상 문자 수).
   # 우선순위: 호출 kwargs 의 chunk_size > 아래 chunk_size. docling: 0=분할 안 함, 0 초과 시 최소 1024 로 보정.
-  # parse-format: 0/미설정이면 코드 기본값(1000000, 사실상 미분할)로 대체.
+  # parse-format: chunk_size 0/음수면 사실상 미분할(1000000). 미설정이면 위 공통 chunk_size 사용.
   chunk_size: 10000
   # 청킹 모드: split_only(기본) = 파서 섹션 단위(제N조 등) 그대로 유지 + chunk_size 초과 섹션만 분할
   #             (작은 섹션을 장 단위로 병합하지 않음) |

--- a/genon/preprocessor/resource_dev/chunking_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/chunking_processor_config.yaml
@@ -11,8 +11,10 @@ defaults:
 
 # 청킹(GenosSmartChunker) 설정
 chunking:
-  # 청크 최대 크기(max_tokens). char 모드면 "최대 문자 수", huggingface 모드면 "최대 토큰 수".
-  # 우선순위: 호출 kwargs 의 chunk_size > 아래 chunk_size. 0 = 토큰/문자 기반 분할 안 함. 0 초과 시 최소 1024 로 보정.
+  # 청크 최대 크기(공통): docling=GenosSmartChunker max_tokens · parse-format=문자 splitter 크기.
+  # char 모드면 문자 수, huggingface 모드면 docling 은 토큰 수(parse-format 은 항상 문자 수).
+  # 우선순위: 호출 kwargs 의 chunk_size > 아래 chunk_size. docling: 0=분할 안 함, 0 초과 시 최소 1024 로 보정.
+  # parse-format: 0/미설정이면 코드 기본값(1000000, 사실상 미분할)로 대체.
   chunk_size: 10000
   # 청킹 모드: split_only(기본) = 파서 섹션 단위(제N조 등) 그대로 유지 + chunk_size 초과 섹션만 분할
   #             (작은 섹션을 장 단위로 병합하지 않음) |
@@ -25,16 +27,13 @@ chunking:
   tokenizer_path: "/models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2"
   tokenizer_id: "sentence-transformers/all-MiniLM-L6-v2"
 
-  # parse-format(비-docling) 입력의 일반 텍스트 splitter 기본값.
+  # parse-format(비-docling) 문자 splitter 의 overlap 기본값.
   # 파서가 docling 을 못 만드는 포맷(csv/xlsx/txt/md/ppt/pptx/doc/이미지/오디오)은 parse-format
-  # ({"elements":[...]})으로 들어오며, 그 중 일반 텍스트는 RecursiveCharacterTextSplitter 로
-  # 분할한다. docling 경로(GenosSmartChunker, 위 chunk_size)와는 무관하며,
-  # audio([AUDIO])/csv·xlsx([DA]) 단일 벡터에는 적용되지 않는다.
-  # 우선순위: 호출 kwargs(chunk_size/generic_chunk_size, chunk_overlap/generic_chunk_overlap)
-  #           > 아래 값 > 코드 기본값(1000/100).
-  generic:
-    chunk_size: 1000     # 0 이하면 1000 으로 폴백
-    chunk_overlap: 100   # 음수면 100 으로 폴백
+  # ({"elements":[...]})으로 들어오며, 그 중 일반 텍스트는 RecursiveCharacterTextSplitter 로 분할한다.
+  # 크기는 위 공통 chunk_size 를 사용한다(docling 무관). audio([AUDIO])/csv·xlsx([DA]) 단일 벡터엔 미적용.
+  # 우선순위: 호출 kwargs(chunk_overlap/recursive_chunk_overlap) > 아래 > 코드 기본값(100).
+  recursive:
+    chunk_overlap: 100    # 음수면 100 으로 폴백
 
 # table_image
 # 표를 이미지로 잘라 저장하고 media_files 에 type='table_image' 로 기록할지 여부.

--- a/genon/preprocessor/resource_dev/chunking_processor_config.yaml
+++ b/genon/preprocessor/resource_dev/chunking_processor_config.yaml
@@ -14,7 +14,7 @@ chunking:
   # 청크 최대 크기(공통): docling=GenosSmartChunker max_tokens · parse-format=문자 splitter 크기.
   # char 모드면 문자 수, huggingface 모드면 docling 은 토큰 수(parse-format 은 항상 문자 수).
   # 우선순위: 호출 kwargs 의 chunk_size > 아래 chunk_size. docling: 0=분할 안 함, 0 초과 시 최소 1024 로 보정.
-  # parse-format: 0/미설정이면 코드 기본값(1000000, 사실상 미분할)로 대체.
+  # parse-format: chunk_size 0/음수면 사실상 미분할(1000000). 미설정이면 위 공통 chunk_size 사용.
   chunk_size: 10000
   # 청킹 모드: split_only(기본) = 파서 섹션 단위(제N조 등) 그대로 유지 + chunk_size 초과 섹션만 분할
   #             (작은 섹션을 장 단위로 병합하지 않음) |


### PR DESCRIPTION
# fix(#336): chunk_size 전달 시 청크 결과 안 나오는 오류 수정 + 청킹 옵션 정리

## 개요

`chunking_processor`(코드서빙 /chunker)를 호출할 때 `chunk_size`(예: 1000)를 kwargs 로 넘기면
**결과가 안 나오는(0청크로 보이는) 오류**를 수정한다. 원인 분석 과정에서 발견한 동일 부류의 크래시와,
청킹 옵션 config 네이밍/중복도 함께 정리했다.

> 결론 요약: `chunk_overlap` 은 무관(범인 아님)했고, 진짜 트리거는 `chunk_size` 였다. 토큰 분할 경로가
> 켜지면서 **`doc_items` 가 빈 그룹**이 생겨 pydantic 검증에서 예외가 나 요청 전체가 실패했다.

## 원인 (root cause)

- `chunk_size` 를 넘기면 `max_tokens > 0` 이 되어 토큰 분할 경로(split_only 5.5단계)가 켜진다.
- 분할 결과 중 텍스트(헤더 라인)만 있고 **`doc_items` 가 빈 그룹**이 생기는데, `get_current_chunk()` 가
  빈 텍스트만 방어하고 빈 items 는 방어하지 않아 `DocMeta(doc_items=[])` 로 생성 → pydantic
  `min_length=1` `ValidationError` → `__call__` 밖으로 전파 → "결과 없음".
- 트레이스백:
  ```
  chunking_processor.py get_current_chunk → DocMeta(doc_items=[])
  pydantic ValidationError: doc_items List should have at least 1 item after validation, not 0
  ```
- (별개) parse-format 경로에서는 `chunk_overlap > chunk_size` 일 때 langchain
  `RecursiveCharacterTextSplitter` 가 `ValueError` 로 크래시하는 동일 부류 문제도 존재했다.

## 주요 변경

### 1) 크래시 수정 (핵심)
- **빈 doc_items 그룹 스킵**: `get_current_chunk()` 가드를 `if not merged_texts or not merged_items:`
  로 확장(빈 items 그룹은 청크로 만들지 않음). 모든 DocChunk 생성이 이 단일 지점을 거치고 호출부가 이미
  `None` 을 스킵하므로 크래시가 사라진다.
- **빈 그룹 생성 자체 방지**: `split_items_evenly_by_tokens()` 가 폭 0 범위 `(a,a)` 를 만들지 않도록
  `if a < b` 필터 추가.
- **overlap 클램프**: parse-format 문자 splitter 에서 `chunk_overlap = min(max(overlap,0), chunk_size-1)`
  로 클램프해 `overlap >= size` 크래시(ValueError) 방지.
- 위 세 가지는 GenosSmartChunker 청킹 로직이 복제된 **활성 3종
  (`chunking`/`intelligent`/`convert`) + BOK 적재·첨부 legacy 사본**에 lockstep 반영.
  `attachment_processor` 문자 splitter(`_char_split_text` 단일 지점)에도 overlap 클램프 반영.

### 2) 청킹 옵션 config 정리 (attachment 정렬)
- parse-format 문자 splitter 설정을 `attachment_processor` 와 동일한 **`recursive` 네이밍**으로 통일
  (기존 `generic` → `recursive`).
- 요청 kwargs 에 `recursive_chunk_overlap` 별칭 정리.

### 3) chunk_size 통합
- docling(GenosSmartChunker max_tokens)과 parse-format 문자 splitter 크기를 **단일 `chunking.chunk_size`**
  로 통합(호출 kwargs `chunk_size` 는 원래부터 두 경로를 모두 제어). `recursive.chunk_size` 및 관련 size
  kwargs 별칭(`recursive_chunk_size`/`generic_chunk_size`/`generic_chunk_overlap`) 제거.
- `recursive:` 블록에는 docling 대응 개념이 없는 `chunk_overlap` 만 남김.
- 공통값 `chunk_size: 10000` 유지(docling 불변). parse-format 은 0/미설정 시 코드 기본값
  1000000(사실상 미분할)로 대체.

## 영향 파일

- `facade/chunking_processor.py` — 크래시 가드/클램프, config 읽기(recursive), `_chunk_text_elements`(공통 크기).
- `facade/intelligent_processor.py`, `facade/convert_processor.py` — get_current_chunk 가드 + split 폭0 필터.
- `facade/attachment_processor.py` — `_char_split_text` overlap 클램프.
- `facade/legacy/BOK_적재용_{규정,내부,외부}.py`, `facade/legacy/BOK_첨부용.py` — 동일 가드/클램프 lockstep.
- `resource/chunking_processor_config.yaml`, `resource_dev/chunking_processor_config.yaml` — chunk_size 공통화,
  `generic`→`recursive`, `recursive.chunk_size` 제거.

## 하위 호환 / 동작 변경

- **동작 변경(의도)**: parse-format 텍스트(txt/md/csv 등)가 이제 공통 `chunk_size`(기본 10000자) 기준으로
  분할된다(직전엔 사실상 미분할). docling 경로는 불변.
- **하위 호환**: 제거된 size kwargs 별칭은 chunking_processor 밖에서 참조가 없어 영향 없음.
  기존 정상 호출/정상 overlap 케이스는 결과 불변.

## 검증 (preprocessor venv, in-process)

- 수정 전: docling `chunk_size=1000` → `ValidationError(doc_items ... at least 1 item)` 로 실패.
- 수정 후: `sample1.docling.json` + `chunk_size=1000` → **42청크** 정상 출력(빈 items 그룹만 드롭).
- parse-format: 공통 `chunk_size=10000` 적용 확인, `chunk_size=500` 시 더 잘게, overlap>size 도 크래시 없이 클램프.
- 회귀: `chunk_overlap` 단독/정상 overlap, docling 기본 경로 결과 불변. 코드 컴파일 + 두 YAML 파싱 OK.

## 커밋

| 해시 | 요약 |
|------|------|
| `00e15434` | chunk size 1000 일 때 청크결과 안나오는 오류 수정 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented document processing failures when chunk overlap is equal to or larger than the chunk size.
  * Prevented creation of empty chunks during token-based and header-only document splits.
  * Improved handling of parse-format chunk sizes and overlap settings, including safer defaults and validation.
* **Documentation**
  * Updated chunking configuration guidance to clarify size, overlap, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->