### PR TITLE
Feature/342 docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+# docker build context 에서 제외할 항목.
+#
+# ⚠️ 이 레포에는 Dockerfile 이 9개 있고(루트 ./Dockerfile, .actor/, genon/serving/paddle/,
+#    genon/preprocessor/docker/, build-script/code-serving-doc-parser/) 모두 **레포 루트를
+#    컨텍스트**로 쓴다. 그래서 whitelist(`*` 로 전부 막고 `!경로` 로 되살리는 방식) 대신
+#    blacklist 를 쓴다 — whitelist 는 경로 하나만 빠뜨려도 다른 빌드를 조용히 깨뜨린다.
+#
+# 아래 항목이 어떤 Dockerfile 에서도 참조되지 않는 것을 확인하고 작성했다.
+
+# ── 비밀 값 (가장 중요) ─────────────────────────────────────────────
+# .gitignore 로 git 에서는 빠지지만 docker build context 에는 그대로 들어간다.
+# 지금은 어떤 Dockerfile 도 `COPY . .` 를 하지 않아 이미지에 실리지 않지만,
+# 누군가 광범위한 COPY 를 추가하는 순간 토큰이 이미지에 들어간다.
+# (빌드는 --secret 으로 토큰을 주입하므로 이 파일이 컨텍스트에 없어도 정상 동작한다.)
+build-script/hf_private_token.env
+**/*.pem
+**/*.key
+
+# ── 로컬 개발 환경 / 버전 관리 ──────────────────────────────────────
+.git
+.gitignore
+.dockerignore
+.venv
+**/.venv
+**/__pycache__
+**/*.py[cod]
+**/.pytest_cache
+**/.mypy_cache
+**/.ruff_cache
+**/*.egg-info
+
+# ── 개인 작업 공간 (약 4.9GB) ───────────────────────────────────────
+shkim_labs
+
+# ── 참조용 사본 (gitignore 대상, 빌드에 불필요) ─────────────────────
+reference
+
+# ── 에디터 / OS ─────────────────────────────────────────────────────
+.idea
+.vscode
+**/.DS_Store
+
+# ── 빌드 산출물 ─────────────────────────────────────────────────────
+dist
+build
+**/node_modules

--- a/build-script/code-serving-doc-parser/Dockerfile
+++ b/build-script/code-serving-doc-parser/Dockerfile
@@ -33,6 +33,11 @@ ARG DOCLING_PKG_VER=2.41.0
 # 1) Base (APT + LibreOffice) — Dockerfile.standard 와 동일 세트
 ############################
 FROM python:${PY_VER}-slim-${DEBIAN_DIST} AS base
+# NOTE: libspatialindex 는 rtree 가 libspatialindex_c.so 를 dlopen 할 때만 필요하므로
+#   런타임 패키지(-c8)로 충분하다 (-dev 는 헤더뿐이라 런타임 이미지에 둘 이유가 없다).
+#   ⚠️ 패키지명이 배포판마다 다르다: Debian trixie = libspatialindex-c8,
+#      Ubuntu 22.04(jammy) = libspatialindex-c6 (Dockerfile.gpu 가 쓰는 이름).
+#      서로 바꿔 쓰면 apt 가 패키지를 못 찾아 빌드가 깨진다.
 ENV DEBIAN_FRONTEND=noninteractive \
     PIP_NO_CACHE_DIR=1 \
     HOME=/app \
@@ -43,6 +48,10 @@ ENV DEBIAN_FRONTEND=noninteractive \
     TMPDIR=/app/tmp \
     HF_HOME=/app/.cache/huggingface \
     NLTK_DATA=/app/nltk_data
+# NOTE: /var/cache/apt 와 /var/lib/apt/lists 는 cache mount 라 **이미지 레이어에 포함되지 않는다.**
+#   예전에는 이 RUN 끝에서 `rm -rf /var/lib/apt/lists/*` 를 했는데, 이미지 크기에는 아무 이득이 없고
+#   다음 빌드가 재사용할 apt 인덱스 캐시만 파괴했다. 그래서 제거했다.
+#   ⚠️ cache mount 가 없는 다른 apt RUN(rhwp 빌더 등)의 rm 은 실제로 레이어를 줄이므로 유지해야 한다.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     echo "deb http://deb.debian.org/debian sid main" > /etc/apt/sources.list.d/sid.list && \
@@ -59,10 +68,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       fonts-dejavu fonts-noto-cjk fonts-noto-cjk-extra fonts-nanum \
       imagemagick poppler-utils \
       tesseract-ocr tesseract-ocr-eng tesseract-ocr-kor \
-      libspatialindex-dev \
+      libspatialindex-c8 \
     && apt-get install -y --no-install-recommends --only-upgrade \
       imagemagick imagemagick-7.q16 libmagickcore-7.q16-10 libmagickwand-7.q16-10 \
-    && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /app/.cache/huggingface /app/.cache/fontconfig /app/.config /app/.local/share /app/.fontconfig /app/nltk_data /app/tmp /tmp/xdg
 RUN sed -i 's/# \(ko_KR.UTF-8\)/\1/' /etc/locale.gen \
     && locale-gen \
@@ -83,12 +91,13 @@ RUN --mount=type=cache,target=/opt/h2o_cache \
     cp /opt/h2o_cache/H2Orestart.oxt /opt/h2orestart/H2Orestart.oxt; \
     unzip -q -o /opt/h2orestart/H2Orestart.oxt -d /usr/lib/libreoffice/share/extensions/h2orestart; \
     soffice --headless --nologo --nodefault --nofirststartwizard --terminate_after_init
-# HCRBatang 폰트 (resources 의 특정 파일만 /tmp 로 가져와 설치 — /app 은 오염시키지 않는다)
-COPY ./genon/preprocessor/resources/HCRBatang.ttf.tar.gz /tmp/HCRBatang.ttf.tar.gz
-RUN set -eux; \
+# HCRBatang 폰트 — bind mount 로 필요한 파일만 읽는다.
+# COPY 로 가져오면 다음 레이어에서 rm 해도 COPY 레이어(11.6MB)가 회수되지 않는다.
+RUN --mount=type=bind,source=genon/preprocessor/resources/HCRBatang.ttf.tar.gz,target=/tmp/HCRBatang.ttf.tar.gz \
+    set -eux; \
     mkdir -p /usr/share/fonts && \
     tar zxf /tmp/HCRBatang.ttf.tar.gz -C /usr/share/fonts/ && \
-    fc-cache -f -v && rm /tmp/HCRBatang.ttf.tar.gz
+    fc-cache -f -v
 
 ############################
 # 3) Builder — venv 설치는 genon/code-serving 방식 (uv venv --seed + uv pip install .)
@@ -104,34 +113,93 @@ ENV VIRTUAL_ENV=${APP_VENV} \
     HF_HOME=/app/.cache/huggingface \
     NLTK_DATA=/app/nltk_data
 
-RUN pip install uv
+# uv 버전을 핀한다. 아래 `uv pip install . --torch-backend=cpu` 가 --torch-backend 에 의존하므로
+# uv 버전이 빌드 동작에 직접 영향을 준다(0.8.0 에 존재함을 확인).
+ARG UV_VERSION=0.8.0
+RUN pip install "uv==${UV_VERSION}"
 
 WORKDIR /app
 # 의존성 정의는 build-script/code-serving-doc-parser 의 pyproject/uv.lock (preprocessor uv 정보 기반).
 COPY build-script/code-serving-doc-parser/pyproject.toml build-script/code-serving-doc-parser/uv.lock /app/
 
 # genon/code-serving 와 동일: uv venv --seed 로 /app/.venv 생성 후 uv pip install . 로 venv 에 설치.
+#
+# --torch-backend=cpu: 처음부터 PyTorch CPU 인덱스에서 받는다.
+#   이게 없으면 PyPI 기본(CUDA) torch 가 잡혀 nvidia 휠 15종 + triton 약 4GB 가 함께 내려오고,
+#   아래 HW_VARIANT=cpu 단계에서 전부 버려진다. 콜드 빌드 시간의 대부분이 이 다운로드였다.
+#   (preprocessor 쪽은 uv sync 를 써서 --torch-backend 가 없어 --no-install-package 로 처리한다.)
+# ⚠️ /app/tmp 를 지운 뒤 반드시 다시 만들어야 한다. base 스테이지가 ENV TMPDIR=/app/tmp 를
+#    설정하므로, 디렉토리가 없으면 uv 가 임시 파일을 만들지 못해
+#    `error: No such file or directory (os error 2) at path "/app/tmp/.tmpXXXX"` 로 죽는다.
+#    (uv 버전을 0.8.0 으로 핀하면서 드러났다 — 이전 미핀 uv 는 TMPDIR 을 자동 생성했다.)
 RUN --mount=type=cache,target=/root/.cache/uv \
     rm -rf /app/tmp /app/nltk_data && \
+    mkdir -p /app/tmp && \
     uv venv --seed && \
-    uv pip install .
+    uv pip install . --torch-backend=cpu
 
-# HW_VARIANT=cpu — torch/torchvision 을 CPU wheel 로 재설치 + nvidia-*/triton 제거(경량화).
+# HW_VARIANT=cpu — nvidia-*/triton 잔존 제거 (안전망).
+#
+# 위 `uv pip install . --torch-backend=cpu` 가 이미 CPU torch 를 넣으므로 여기서 torch 를
+# 재설치하지 않는다(예전에는 --reinstall-package 로 같은 CPU 휠을 약 190MB 다시 받았다).
+# 이 블록은 --torch-backend 가 어떤 이유로 CUDA 휠을 들여보냈을 때를 대비한 **안전망**이다.
+#
+# ⚠️ 제거 목록을 하드코딩하지 말 것. 예전에는 `nvidia-cublas-cu12` 처럼 `-cu12` 접미사
+#    목록을 박아두었는데, 버전 핀이 없어 torch 2.13 이 잡히면서 CUDA 13 휠로 패키지명이
+#    바뀌었다(`nvidia_cublas` 접미사 없음, `nvidia_cudnn_cu13`, `nvidia_nccl_cu13` …).
+#    이름이 하나도 일치하지 않아 uninstall 이 전부 실패했고, 끝의 `|| true` 가 그 실패를
+#    삼켜서 CPU 이미지에 CUDA 라이브러리 2.7GB 가 조용히 실려 나갔다.
+#    → 설치된 목록에서 이름을 뽑아 지우고, `|| true` 로 실패를 감추지 않는다.
+#    (지울 게 없으면 xargs -r 이 uv 를 호출하지 않으므로 그대로 성공한다.)
 RUN --mount=type=cache,target=/root/.cache/uv \
+    set -eu; \
     if [ "${HW_VARIANT}" = "cpu" ]; then \
-      echo "[INFO] HW_VARIANT=cpu — reinstalling torch/torchvision as CPU wheels" && \
-      uv pip install --python ${APP_VENV}/bin/python \
-        --reinstall-package torch --reinstall-package torchvision \
-        --index-url "${TORCH_CPU_INDEX_URL}" \
-        torch torchvision && \
-      uv pip uninstall --python ${APP_VENV}/bin/python \
-        nvidia-cublas-cu12 nvidia-cuda-cupti-cu12 nvidia-cuda-nvrtc-cu12 \
-        nvidia-cuda-runtime-cu12 nvidia-cudnn-cu12 nvidia-cufft-cu12 nvidia-cufile-cu12 \
-        nvidia-curand-cu12 nvidia-cusolver-cu12 nvidia-cusparse-cu12 nvidia-cusparselt-cu12 \
-        nvidia-nccl-cu12 nvidia-nvjitlink-cu12 nvidia-nvshmem-cu12 nvidia-nvtx-cu12 triton \
-      || true; \
+      echo "[INFO] HW_VARIANT=cpu — nvidia/triton 잔존 확인 및 제거"; \
+      uv pip list --python ${APP_VENV}/bin/python --format=freeze \
+        | sed -n 's/^\(nvidia[A-Za-z0-9._-]*\|triton\)==.*/\1/p' \
+        | tee /tmp/cuda_pkgs.txt; \
+      xargs -r uv pip uninstall --python ${APP_VENV}/bin/python < /tmp/cuda_pkgs.txt; \
+      rm -f /tmp/cuda_pkgs.txt; \
+      echo "[INFO] 남은 nvidia/triton 패키지 확인:"; \
+      uv pip list --python ${APP_VENV}/bin/python --format=freeze \
+        | grep -iE '^(nvidia|triton)' && { echo "[ERROR] nvidia/triton 잔존"; exit 1; } || true; \
     else \
       echo "[INFO] HW_VARIANT=${HW_VARIANT} — keeping torch as-is"; \
+    fi
+
+# torch 의 런타임 미사용 자산 제거 (약 141MB: test 81M + include 60M).
+# C++ 헤더와 테스트 픽스처로, 추론 경로에서는 쓰이지 않는다.
+# ⚠️ torch/bin(50MB)은 지우면 안 된다. torch/__init__.py 가 import 시점에 _manager_path() 로
+#    torch/bin/torch_shm_manager 존재를 무조건 확인하고, 없으면 RuntimeError 로 죽는다
+#    (DataLoader 를 쓰지 않아도 발생).
+# ⚠️ 코드서빙 특유의 위험: 런타임에 git clone 되는 **외부 서비스 코드**가
+#    `torch.utils.cpp_extension`(JIT C++ 확장 컴파일)을 쓰면 torch/include 가 없어 실패한다.
+#    현재 이 레포에는 사용처가 없지만, 서비스 코드는 이 이미지 밖에서 오므로 보장할 수 없다.
+#    그런 서비스를 붙이려면 이 RUN 에서 include 제거를 빼야 한다.
+RUN rm -rf ${APP_VENV}/lib/python3*/site-packages/torch/test \
+           ${APP_VENV}/lib/python3*/site-packages/torch/include
+
+# opencv 를 headless 로 통일한다 (Dockerfile.standard 와 동일 조치).
+#   opencv-python(non-headless)과 opencv-python-headless 가 둘 다 들어와 `opencv_python.libs`
+#   (약 116MB)가 중복이고, non-headless 가 libGL.so.1 에 링크해 apt `libgl1` → Mesa 소프트웨어
+#   GL 스택(약 208MB)까지 끌어온다. 헤드리스 컨테이너에는 불필요해 apt 에서도 libgl1 을 뺐다.
+# ⚠️ 순서 중요: opencv-python 을 지우면 공유되는 cv2/ 파일까지 사라지므로 뒤에 --reinstall 필수.
+# ⚠️ 버전을 uv.lock 에 맞춰 핀한다. `uv pip install` 은 lock 을 참조하지 않으므로 버전을 안 주면
+#    최신(현재 5.0.x)을 가져온다. 이 파일은 설치 자체가 lock 기반이 아니지만(위 uv pip install .),
+#    최소한 opencv 만이라도 결정적으로 고정해 빌드마다 달라지지 않게 한다.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    set -eu; \
+    OCV=$(grep -A1 '^name = "opencv-python-headless"' uv.lock | awk -F'"' '/^version/{print $2}'); \
+    if [ -z "${OCV}" ]; then echo "[ERROR] uv.lock 에서 opencv-python-headless 버전을 못 찾음"; exit 1; fi; \
+    echo "[INFO] opencv-python-headless==${OCV} (uv.lock 기준)"; \
+    if uv pip list --python ${APP_VENV}/bin/python --format=freeze | grep -q '^opencv-python=='; then \
+      uv pip uninstall --python ${APP_VENV}/bin/python opencv-python; \
+    fi; \
+    uv pip install --python ${APP_VENV}/bin/python --reinstall "opencv-python-headless==${OCV}"; \
+    ${APP_VENV}/bin/python -c "import cv2; print('[INFO] cv2', cv2.__version__)"; \
+    ${APP_VENV}/bin/python -c "import unstructured_inference; print('[INFO] unstructured_inference ok')"; \
+    if ls -d ${APP_VENV}/lib/python3*/site-packages/opencv_python.libs >/dev/null 2>&1; then \
+      echo "[ERROR] opencv_python.libs 잔존"; exit 1; \
     fi
 
 ############################
@@ -161,9 +229,16 @@ RUN --mount=type=cache,target=${HF_HOME} \
 ############################
 # 4-2b) rhwp 바이너리 (rust 빌드 → 결과만 COPY)
 ############################
-FROM rust:latest AS rhwp_builder
+FROM rust:1-slim AS rhwp_builder
 ARG RHWP_GIT_URL
 ARG RHWP_GIT_REF
+# rust:latest(약 1.5GB)는 buildpack-deps 기반이라 git 이 들어 있지만 rust:slim 에는 없다.
+# 산출물이 바이너리 하나뿐이라 slim 으로 낮추고 git 만 따로 설치한다 — 최종 이미지 크기는 그대로이고
+# 빌드 중 다운로드/디스크만 줄어든다.
+# ⚠️ genos-rhwp 가 pkg-config / libssl-dev / cmake 같은 시스템 의존을 요구하면 cargo build 에서
+#    깨진다. 그때는 아래 목록에 추가하거나 rust:latest 로 되돌린다.
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
@@ -183,17 +258,44 @@ FROM builder AS models_artifacts
 ARG APP_VENV
 ARG NLTK_PACKAGES
 ARG DOCLING_PKG_VER
+# 받을 docling 모델 목록. 인자 없이 `docling-tools models download` 를 호출하면 기본 세트
+# (layout, tableformer, code_formula, picture_classifier, easyocr)를 전부 받는데, 그중
+# code_formula(ds4sd--CodeFormula, 506MB)는 이 레포에서 절대 로드되지 않는다:
+#   do_code_enrichment / do_formula_enrichment 기본값 False(pipeline_options.py)이고
+#   이를 켜는 config 키·코드가 없어 CodeFormulaModel 은 enabled=False 로만 생성된다.
+#   ⚠️ 이 판단은 "현재 제품 기능 기준"이다. docling CLI 자체에는 code/formula enrichment 를 켜는
+#      옵션이 있으므로, 향후 facade 가 이를 노출하거나(코드서빙이라면 런타임에 clone 되는 서비스
+#      코드가 켜면) **오프라인 환경에서 모델이 없어 실패**한다. 그때는 DOCLING_MODELS 에
+#      code_formula 를 다시 넣어야 한다.
+# 나머지는 유지한다 (docling/utils/model_downloader.py 의 with_* 플래그와 1:1 대응):
+#   layout            → ds4sd--docling-layout-old. 이름이 old 지만 layout_model_specs.py 의
+#                       "Default Docling Layout Model"(DOCLING_LAYOUT_V2)이다. PDF 는
+#                       genos_layout(dotsocr)을 쓰지만, PPT/PPTX 경량 파이프라인이 bare
+#                       PdfPipelineOptions() 로 LayoutModel 을 만들어 실제 로드하므로 필수.
+#   tableformer       → ds4sd--docling-models. layout_model_type: docling_layout 배포에서 필요.
+#   picture_classifier→ ds4sd--DocumentFigureClassifier. chart.enable opt-in (16MB).
+#   easyocr           → /models/EasyOcr 의 craft_mlt_25k(83MB)/english_g2/latin_g2.
+#                       ⚠️ with_easyocr 도 기본 True 라, 목록에서 빼면 아래 korean_g2.zip
+#                       단계만 남아 CRAFT 검출기가 사라진다(EasyOCR 사용 시 필수).
+ARG DOCLING_MODELS="layout tableformer picture_classifier easyocr"
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --python ${APP_VENV}/bin/python "docling==${DOCLING_PKG_VER}"
-RUN --mount=type=cache,target=/root/.cache/models \
-    if [ ! -d /models ] || [ -z "$(ls -A /models)" ]; then \
-        docling-tools models download -o /models; \
+# NOTE: 예전에는 `--mount=type=cache,target=/root/.cache/models` 가 붙어 있었지만 아무도 그 경로를
+#   쓰지 않았다. docling-tools 는 `-o /models`(이미지 레이어)와 HF_HOME 을 쓴다. 오해를 남기지
+#   않도록 제거했다. (preprocessor 쪽도 동일하게 정리돼 있다.)
+RUN if [ ! -d /models ] || [ -z "$(ls -A /models)" ]; then \
+        docling-tools models download -o /models ${DOCLING_MODELS}; \
     fi
+# mncai/doc_parser_models 에서 실제로 쓰는 것은 MiniLM 토크나이저 폴더 하나뿐이다.
+# repo 전체(846MB)를 받으면 docling-models(506MB)/docling-layout-old(164MB)가 함께 오는데
+# 둘 다 코드에서 로드되지 않는다(TableFormer 는 ds4sd--docling-models, layout 기본값은
+# ds4sd--docling-layout-old 를 쓴다). 또 두 번째 download 의 --local-dir 이 이미 받은 폴더를
+# 다시 가리켜 동명 하위 디렉토리가 중첩 생성됐다(88MB 중복) — 코드는 바깥쪽만 사용한다.
 RUN --mount=type=cache,target=${HF_HOME} \
     mkdir -p /models/doc_parser_models && \
-    huggingface-cli download mncai/doc_parser_models --local-dir /models/doc_parser_models && \
-    huggingface-cli download mncai/doc_parser_models --include "sentence-transformers-all-MiniLM-L6-v2/*" \
-      --local-dir /models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2
+    huggingface-cli download mncai/doc_parser_models \
+      --include "sentence-transformers-all-MiniLM-L6-v2/*" \
+      --local-dir /models/doc_parser_models
 RUN --mount=type=cache,target=/root/.cache/nltk \
     python - <<'PY'
 import os, nltk
@@ -251,13 +353,17 @@ RUN groupadd -g $GID $GNAME && \
       /app/.config/libreoffice /app/.cache/libreoffice /app/.local/share /app/tmp /tmp/xdg
 
 # venv (패치된 docling_parse 포함) + 아티팩트
-COPY --from=builder ${APP_VENV} ${APP_VENV}
-COPY --from=sdk_artifacts /app/hwp_sdk /app/hwp_sdk
+# 🔴 --chown 으로 처음부터 올바른 소유자로 복사한다. 예전에는 아래에서
+#    `chown -R $UID:$GID /app … /models /app/nltk_data` 를 한 번에 돌렸는데, 이미 복사된
+#    .venv + /models + nltk_data + hwp_sdk 의 소유권만 바꾸는 것도 overlayfs 에서는
+#    전 파일 copy-up 이라 같은 데이터를 담은 수 GB 레이어가 하나 더 생겼다.
+COPY --chown=${UID}:${GID} --from=builder ${APP_VENV} ${APP_VENV}
+COPY --chown=${UID}:${GID} --from=sdk_artifacts /app/hwp_sdk /app/hwp_sdk
 COPY --from=rhwp_builder /usr/local/bin/rhwp /usr/local/bin/rhwp
 COPY --from=font_artifacts /app/extra_fonts /usr/share/fonts/additional
 RUN fc-cache -f -v
-COPY --from=models_artifacts /models /models
-COPY --from=models_artifacts /app/nltk_data /app/nltk_data
+COPY --chown=${UID}:${GID} --from=models_artifacts /models /models
+COPY --chown=${UID}:${GID} --from=models_artifacts /app/nltk_data /app/nltk_data
 
 # hwp_sdk import 경로 (venv site-packages 심링크, 표준 빌드 파리티용). python3.12 고정(slim 3.12.x).
 # ⚠️ docling 은 런타임에 clone 된 복사본 packages/ 의 wheel(genon-docling, import name: docling)을
@@ -266,16 +372,25 @@ COPY --from=models_artifacts /app/nltk_data /app/nltk_data
 RUN ln -s /app/hwp_sdk ${APP_VENV}/lib/python3.12/site-packages/hwp_sdk
 
 # 코드서빙 harness (genon/code-serving 와 동일 구성)
-COPY build-script/code-serving-doc-parser/supervisor/non-root-base.conf /etc/supervisor/supervisord.conf
-COPY build-script/code-serving-doc-parser/supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-COPY build-script/code-serving-doc-parser/scripts /app/scripts
-COPY build-script/code-serving-doc-parser/src /app/src
-COPY build-script/code-serving-doc-parser/gunicorn /app/gunicorn
+COPY --chown=${UID}:${GID} build-script/code-serving-doc-parser/supervisor/non-root-base.conf /etc/supervisor/supervisord.conf
+COPY --chown=${UID}:${GID} build-script/code-serving-doc-parser/supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY --chown=${UID}:${GID} build-script/code-serving-doc-parser/scripts /app/scripts
+COPY --chown=${UID}:${GID} build-script/code-serving-doc-parser/src /app/src
+COPY --chown=${UID}:${GID} build-script/code-serving-doc-parser/gunicorn /app/gunicorn
 
 # 샘플 service 제거(런타임에 /app/src/service 로 clone) + 스크립트 실행권한
+# (root 가 3000 소유 파일을 chmod 하는 것은 문제없고 소유권도 유지된다)
 RUN rm -rf /app/src/service && chmod +x /app/scripts/*.sh
 
-RUN chown -R $UID:$GID /app /run /var/log /etc/supervisor /models /app/nltk_data
+# 위 COPY 들이 이미 ${UID}:${GID} 로 복사했으므로 여기서는 작은 경로만 정리한다.
+#   - /app, /app/nltk_data : base 단계에서 root 로 미리 만들어진 디렉토리라
+#     COPY --chown 이 디렉토리 자체의 소유권은 바꾸지 않는다 → 비재귀 chown 으로 보정.
+#   - site-packages/hwp_sdk : 위 RUN 이 만든 심볼릭 링크 자체의 소유권(-h).
+#   - /var/log/supervisor, /var/run/supervisor 는 /var/log, /run 에 포함된다.
+RUN chown "${UID}:${GID}" /app /app/nltk_data && \
+    chown -h "${UID}:${GID}" ${APP_VENV}/lib/python3.12/site-packages/hwp_sdk && \
+    find /app -maxdepth 1 -user 0 -exec chown "${UID}:${GID}" {} + && \
+    chown -R "${UID}:${GID}" /run /var/log /etc/supervisor /app/.cache /app/.config /app/.local /app/.fontconfig /app/tmp /tmp/xdg
 
 USER $UID
 CMD ["supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]

--- a/build-script/code-serving-doc-parser/Dockerfile.gpu
+++ b/build-script/code-serving-doc-parser/Dockerfile.gpu
@@ -28,6 +28,10 @@ ARG GNAME=genos
 ARG RHWP_GIT_URL=https://github.com/genonai/genos-rhwp.git
 ARG RHWP_GIT_REF=genos/main
 ARG DOCLING_PKG_VER=2.41.0
+# NOTE: 현재 미사용. torch 설치를 `uv pip install . --torch-backend=cu124` 한 번으로 합치면서
+#   이 인덱스 URL 을 직접 넘기지 않게 됐다(uv 가 cu124 인덱스를 내장으로 안다).
+#   ⚠️ 사내 미러를 써야 한다면 --torch-backend 로는 지정할 수 없다. 그때는 pyproject 에
+#   `[[tool.uv.index]]` 로 미러를 등록하고 --torch-backend 를 빼는 방식으로 바꿔야 한다.
 ARG TORCH_CU_INDEX_URL=https://download.pytorch.org/whl/cu124
 
 ############################
@@ -54,7 +58,11 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl git \
     && rm -rf /var/lib/apt/lists/*
-RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+# uv 버전을 핀한다. 아래 `uv pip install . --torch-backend=cu124` 가 --torch-backend 에 의존하므로
+# uv 버전이 빌드 동작에 직접 영향을 준다(0.8.0 에 존재함을 확인).
+# astral 설치 스크립트는 URL 에 버전을 넣는 방식으로 특정 버전을 설치한다.
+ARG UV_VERSION=0.8.0
+RUN curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 RUN uv python install 3.12
 
@@ -64,17 +72,26 @@ COPY build-script/code-serving-doc-parser/pyproject.toml build-script/code-servi
 # genon/code-serving 와 동일: uv venv --seed + uv pip install . → /app/.venv
 # (uv 관리형 python3.12 를 명시. venv 의 bin/python 은 /opt/uv/python/... 를 가리키며,
 #  runtime 에 동일 경로로 COPY 되므로 심링크가 해소된다.)
+# --torch-backend=cu124: 처음부터 cu124 인덱스에서 받는다.
+#   예전에는 `uv pip install .` 로 PyPI 기본 CUDA torch + nvidia 휠(약 4GB)을 받은 뒤,
+#   곧바로 --index-url cu124 로 **다시 약 4GB** 를 받아 덮어썼다(총 약 8GB, 절반은 폐기).
+#   한 번에 받도록 바꿔 재설치 단계를 없앴다.
 RUN --mount=type=cache,target=/root/.cache/uv \
     rm -rf /app/tmp /app/nltk_data && \
     uv venv --python 3.12 --seed && \
-    uv pip install .
+    uv pip install . --torch-backend=cu124
 
-# GPU torch(cu124) 재고정 (pyproject deps 가 끌어온 기본 torch 를 cu124 wheel 로 override)
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --python ${APP_VENV}/bin/python \
-      --reinstall-package torch --reinstall-package torchvision \
-      --index-url "${TORCH_CU_INDEX_URL}" \
-      torch torchvision
+# torch 의 런타임 미사용 자산 제거 (약 141MB: test 81M + include 60M).
+# C++ 헤더와 테스트 픽스처로, 추론 경로에서는 쓰이지 않는다.
+# ⚠️ torch/bin(50MB)은 지우면 안 된다. torch/__init__.py 가 import 시점에 _manager_path() 로
+#    torch/bin/torch_shm_manager 존재를 무조건 확인하고, 없으면 RuntimeError 로 죽는다
+#    (DataLoader 를 쓰지 않아도 발생).
+# ⚠️ 코드서빙 특유의 위험: 런타임에 git clone 되는 **외부 서비스 코드**가
+#    `torch.utils.cpp_extension`(JIT C++ 확장 컴파일)을 쓰면 torch/include 가 없어 실패한다.
+#    현재 이 레포에는 사용처가 없지만, 서비스 코드는 이 이미지 밖에서 오므로 보장할 수 없다.
+#    그런 서비스를 붙이려면 이 RUN 에서 include 제거를 빼야 한다.
+RUN rm -rf ${APP_VENV}/lib/python3*/site-packages/torch/test \
+           ${APP_VENV}/lib/python3*/site-packages/torch/include
 
 # models_artifacts(FROM builder) 에서 필요한 시스템 라이브러리 설치.
 # curl/unzip: EasyOCR 한국어 모델 다운로드/압축해제용.
@@ -85,6 +102,32 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       curl unzip \
       libgl1 libglib2.0-0 libxcb1 libsm6 libxext6 libxrender1 \
     && rm -rf /var/lib/apt/lists/*
+
+# opencv 를 headless 로 통일한다 (Dockerfile.standard 와 동일 조치).
+#   opencv-python(non-headless)과 opencv-python-headless 가 둘 다 들어와 `opencv_python.libs`
+#   (약 116MB)가 중복이고, non-headless 가 libGL.so.1 에 링크해 runtime apt 의 `libgl1`
+#   → Mesa 소프트웨어 GL 스택(약 208MB)까지 끌어온다. 헤드리스라 불필요해 runtime apt 에서
+#   libgl1 을 뺐다(위 builder apt 의 libgl1 은 models_artifacts 용이라 유지).
+# ⚠️ 순서 두 가지가 모두 중요하다.
+#   1) 이 블록은 반드시 **위 apt RUN 뒤**에 와야 한다. builder 베이스가 ubuntu:22.04 최소
+#      구성이라 그 전에는 libglib2.0-0 이 없어 아래 `import cv2` 가 ImportError 로 죽는다.
+#   2) opencv-python 을 지우면 공유되는 cv2/ 파일까지 사라지므로 뒤에 --reinstall 필수.
+# ⚠️ 버전을 uv.lock 에 맞춰 핀한다. `uv pip install` 은 lock 을 참조하지 않으므로 버전을 안 주면
+#    최신(현재 5.0.x)을 가져온다. 최소한 opencv 만이라도 결정적으로 고정한다.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    set -eu; \
+    OCV=$(grep -A1 '^name = "opencv-python-headless"' uv.lock | awk -F'"' '/^version/{print $2}'); \
+    if [ -z "${OCV}" ]; then echo "[ERROR] uv.lock 에서 opencv-python-headless 버전을 못 찾음"; exit 1; fi; \
+    echo "[INFO] opencv-python-headless==${OCV} (uv.lock 기준)"; \
+    if uv pip list --python ${APP_VENV}/bin/python --format=freeze | grep -q '^opencv-python=='; then \
+      uv pip uninstall --python ${APP_VENV}/bin/python opencv-python; \
+    fi; \
+    uv pip install --python ${APP_VENV}/bin/python --reinstall "opencv-python-headless==${OCV}"; \
+    ${APP_VENV}/bin/python -c "import cv2; print('[INFO] cv2', cv2.__version__)"; \
+    ${APP_VENV}/bin/python -c "import unstructured_inference; print('[INFO] unstructured_inference ok')"; \
+    if ls -d ${APP_VENV}/lib/python3*/site-packages/opencv_python.libs >/dev/null 2>&1; then \
+      echo "[ERROR] opencv_python.libs 잔존"; exit 1; \
+    fi
 
 ############################
 # 2-1) HWP SDK / 2-2) 폰트 / 2-3) 모델 (CPU Dockerfile 과 동일)
@@ -105,9 +148,16 @@ RUN --mount=type=cache,target=${HF_HOME} \
     huggingface-cli download genon-search/additional_fonts \
       --repo-type dataset --local-dir /app/extra_fonts --local-dir-use-symlinks False
 
-FROM rust:latest AS rhwp_builder
+FROM rust:1-slim AS rhwp_builder
 ARG RHWP_GIT_URL
 ARG RHWP_GIT_REF
+# rust:latest(약 1.5GB)는 buildpack-deps 기반이라 git 이 들어 있지만 rust:slim 에는 없다.
+# 산출물이 바이너리 하나뿐이라 slim 으로 낮추고 git 만 따로 설치한다 — 최종 이미지 크기는 그대로이고
+# 빌드 중 다운로드/디스크만 줄어든다.
+# ⚠️ genos-rhwp 가 pkg-config / libssl-dev / cmake 같은 시스템 의존을 요구하면 cargo build 에서
+#    깨진다. 그때는 아래 목록에 추가하거나 rust:latest 로 되돌린다.
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
@@ -122,6 +172,26 @@ FROM builder AS models_artifacts
 ARG APP_VENV
 ARG NLTK_PACKAGES
 ARG DOCLING_PKG_VER
+# 받을 docling 모델 목록. 인자 없이 `docling-tools models download` 를 호출하면 기본 세트
+# (layout, tableformer, code_formula, picture_classifier, easyocr)를 전부 받는데, 그중
+# code_formula(ds4sd--CodeFormula, 506MB)는 이 레포에서 절대 로드되지 않는다:
+#   do_code_enrichment / do_formula_enrichment 기본값 False(pipeline_options.py)이고
+#   이를 켜는 config 키·코드가 없어 CodeFormulaModel 은 enabled=False 로만 생성된다.
+#   ⚠️ 이 판단은 "현재 제품 기능 기준"이다. docling CLI 자체에는 code/formula enrichment 를 켜는
+#      옵션이 있으므로, 향후 facade 가 이를 노출하거나(코드서빙이라면 런타임에 clone 되는 서비스
+#      코드가 켜면) **오프라인 환경에서 모델이 없어 실패**한다. 그때는 DOCLING_MODELS 에
+#      code_formula 를 다시 넣어야 한다.
+# 나머지는 유지한다 (docling/utils/model_downloader.py 의 with_* 플래그와 1:1 대응):
+#   layout            → ds4sd--docling-layout-old. 이름이 old 지만 layout_model_specs.py 의
+#                       "Default Docling Layout Model"(DOCLING_LAYOUT_V2)이다. PDF 는
+#                       genos_layout(dotsocr)을 쓰지만, PPT/PPTX 경량 파이프라인이 bare
+#                       PdfPipelineOptions() 로 LayoutModel 을 만들어 실제 로드하므로 필수.
+#   tableformer       → ds4sd--docling-models. layout_model_type: docling_layout 배포에서 필요.
+#   picture_classifier→ ds4sd--DocumentFigureClassifier. chart.enable opt-in (16MB).
+#   easyocr           → /models/EasyOcr 의 craft_mlt_25k(83MB)/english_g2/latin_g2.
+#                       ⚠️ with_easyocr 도 기본 True 라, 목록에서 빼면 아래 korean_g2.zip
+#                       단계만 남아 CRAFT 검출기가 사라진다(EasyOCR 사용 시 필수).
+ARG DOCLING_MODELS="layout tableformer picture_classifier easyocr"
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --python ${APP_VENV}/bin/python "docling==${DOCLING_PKG_VER}" \
  && (uv pip uninstall --python ${APP_VENV}/bin/python opencv-python || true) \
@@ -130,13 +200,20 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 #   헤드리스 ubuntu 빌더에는 Qt/xcb 런타임 라이브러리가 없어 easyocr→cv2 import 시
 #   ImportError(libQt5Core...so) 가 발생하기 때문. 이 stage venv 는 runtime 에 COPY 되지 않으므로
 #   영향 범위는 모델 다운로드 단계에 한정된다(런타임 OCR venv 는 builder 의 것 그대로).
-RUN --mount=type=cache,target=/root/.cache/models \
-    if [ ! -d /models ] || [ -z "$(ls -A /models)" ]; then docling-tools models download -o /models; fi
+# NOTE: 예전에는 `--mount=type=cache,target=/root/.cache/models` 가 붙어 있었지만 아무도 그 경로를
+#   쓰지 않았다. docling-tools 는 `-o /models`(이미지 레이어)와 HF_HOME 을 쓴다. 오해를 남기지
+#   않도록 제거했다.
+RUN if [ ! -d /models ] || [ -z "$(ls -A /models)" ]; then docling-tools models download -o /models ${DOCLING_MODELS}; fi
+# mncai/doc_parser_models 에서 실제로 쓰는 것은 MiniLM 토크나이저 폴더 하나뿐이다.
+# repo 전체(846MB)를 받으면 docling-models(506MB)/docling-layout-old(164MB)가 함께 오는데
+# 둘 다 코드에서 로드되지 않는다(TableFormer 는 ds4sd--docling-models, layout 기본값은
+# ds4sd--docling-layout-old 를 쓴다). 또 두 번째 download 의 --local-dir 이 이미 받은 폴더를
+# 다시 가리켜 동명 하위 디렉토리가 중첩 생성됐다(88MB 중복) — 코드는 바깥쪽만 사용한다.
 RUN --mount=type=cache,target=${HF_HOME} \
     mkdir -p /models/doc_parser_models && \
-    huggingface-cli download mncai/doc_parser_models --local-dir /models/doc_parser_models && \
-    huggingface-cli download mncai/doc_parser_models --include "sentence-transformers-all-MiniLM-L6-v2/*" \
-      --local-dir /models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2
+    huggingface-cli download mncai/doc_parser_models \
+      --include "sentence-transformers-all-MiniLM-L6-v2/*" \
+      --local-dir /models/doc_parser_models
 RUN --mount=type=cache,target=/root/.cache/nltk \
     python - <<'PY'
 import os, nltk
@@ -160,7 +237,15 @@ RUN --mount=type=cache,target=/root/.cache/easyocr_korean \
 ############################
 # 3) Runtime — nvidia/cuda + 문서 apt + H2Orestart + 아티팩트 + harness
 ############################
-FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 AS runtime
+# 베이스는 -cudnn-runtime 이 아니라 -base 를 쓴다.
+#   torch 는 pip nvidia 휠(uv.lock 에 15개, nvidia-cudnn-cu13 포함)에 링크되므로 베이스가 주는
+#   시스템 CUDA/cuDNN 은 쓰이지 않는다. -cudnn-runtime 에는 /usr/local/cuda-12.4 만 1.9GB 가 들어
+#   있어 CUDA 를 사실상 두 번 싣는 셈이었다(실측: /usr 4.7GB).
+#   CUDA 를 쓰는 다른 패키지도 없다 — onnxruntime 은 CPU 빌드다.
+#   같은 스택인 genon/preprocessor 의 GPU 빌드는 python:slim(시스템 CUDA 없음) 위에서 정상 동작한다.
+# ⚠️ ubuntu:22.04 까지 낮추지 말 것. -base 가 포함하는 cuda-compat 이 호스트 드라이버가 CUDA 12.4
+#    보다 구버전일 때 호환성을 메워 준다. 추가 절감(약 250MB)에 비해 위험이 크다.
+FROM nvidia/cuda:12.4.1-base-ubuntu22.04 AS runtime
 ARG APP_VENV
 ARG H2ORESTART_URL
 ARG UID
@@ -211,16 +296,20 @@ RUN mkdir -p /app/tmp /tmp/xdg \
     && mkdir -p /app/.cache/huggingface /app/nltk_data /app/tmp /tmp/xdg
 
 # LibreOffice H2Orestart 확장 + HCRBatang 폰트
-COPY ./genon/preprocessor/resources /tmp/resources
-RUN set -eux; \
+# NOTE: 예전에는 `COPY ./genon/preprocessor/resources /tmp/resources` 로 디렉토리를 통째 복사했다.
+#   (1) 필요한 건 HCRBatang 폰트뿐인데 참조가 전혀 없는 tessedata.tar.gz(35MB)까지 들어왔고
+#       (한국어 tessdata 는 apt tesseract-ocr-kor 로 이미 들어온다),
+#   (2) 마지막 `rm -rf /tmp/resources` 는 상위 레이어라 COPY 레이어(48MB)를 회수하지 못했다.
+#   → bind mount 로 필요한 파일만 읽어 레이어에 아무것도 남기지 않는다.
+RUN --mount=type=bind,source=genon/preprocessor/resources/HCRBatang.ttf.tar.gz,target=/tmp/HCRBatang.ttf.tar.gz \
+    set -eux; \
     mkdir -p /opt/h2orestart /usr/lib/libreoffice/share/extensions/h2orestart; \
     wget -O /opt/h2orestart/H2Orestart.oxt "${H2ORESTART_URL}"; \
     unzip -q -o /opt/h2orestart/H2Orestart.oxt -d /usr/lib/libreoffice/share/extensions/h2orestart; \
     soffice --headless --nologo --nodefault --nofirststartwizard --terminate_after_init || true; \
     mkdir -p /usr/share/fonts; \
-    tar zxf /tmp/resources/HCRBatang.ttf.tar.gz -C /usr/share/fonts/; \
-    fc-cache -f -v; \
-    rm -rf /tmp/resources
+    tar zxf /tmp/HCRBatang.ttf.tar.gz -C /usr/share/fonts/; \
+    fc-cache -f -v
 
 # 사용자 생성 + 디렉토리
 RUN groupadd -g $GID $GNAME && \
@@ -231,15 +320,21 @@ RUN groupadd -g $GID $GNAME && \
 WORKDIR /app
 
 # uv 관리형 python3.12 (venv 의 bin/python 심링크 대상) — venv 보다 먼저 COPY.
+# (/app 밖이라 root 소유로 둔다)
 COPY --from=builder /opt/uv/python /opt/uv/python
 # venv (패치된 docling_parse + cu124 torch 포함) + 아티팩트
-COPY --from=builder ${APP_VENV} ${APP_VENV}
-COPY --from=sdk_artifacts /app/hwp_sdk /app/hwp_sdk
+# 🔴 --chown 으로 처음부터 올바른 소유자로 복사한다. 예전에는 아래에서
+#    `chown -R $UID:$GID /app … /models /app/nltk_data` 를 한 번에 돌렸는데, 이미 복사된
+#    .venv + /models + nltk_data + hwp_sdk 의 소유권만 바꾸는 것도 overlayfs 에서는
+#    전 파일 copy-up 이라 같은 데이터를 담은 수 GB 레이어가 하나 더 생겼다
+#    (GPU 는 cu124 torch + nvidia-* 로 venv 가 커서 CPU 보다 손해가 크다).
+COPY --chown=${UID}:${GID} --from=builder ${APP_VENV} ${APP_VENV}
+COPY --chown=${UID}:${GID} --from=sdk_artifacts /app/hwp_sdk /app/hwp_sdk
 COPY --from=rhwp_builder /usr/local/bin/rhwp /usr/local/bin/rhwp
 COPY --from=font_artifacts /app/extra_fonts /usr/share/fonts/additional
 RUN fc-cache -f -v
-COPY --from=models_artifacts /models /models
-COPY --from=models_artifacts /app/nltk_data /app/nltk_data
+COPY --chown=${UID}:${GID} --from=models_artifacts /models /models
+COPY --chown=${UID}:${GID} --from=models_artifacts /app/nltk_data /app/nltk_data
 
 # hwp_sdk import 경로 (venv site-packages 심링크, 표준 빌드 파리티용). python3.12 고정.
 # ⚠️ docling 은 런타임에 clone 된 복사본 packages/ 의 wheel(genon-docling, import name: docling)을
@@ -248,14 +343,24 @@ COPY --from=models_artifacts /app/nltk_data /app/nltk_data
 RUN ln -s /app/hwp_sdk ${APP_VENV}/lib/python3.12/site-packages/hwp_sdk
 
 # 코드서빙 harness
-COPY build-script/code-serving-doc-parser/supervisor/non-root-base.conf /etc/supervisor/supervisord.conf
-COPY build-script/code-serving-doc-parser/supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-COPY build-script/code-serving-doc-parser/scripts /app/scripts
-COPY build-script/code-serving-doc-parser/src /app/src
-COPY build-script/code-serving-doc-parser/gunicorn /app/gunicorn
+COPY --chown=${UID}:${GID} build-script/code-serving-doc-parser/supervisor/non-root-base.conf /etc/supervisor/supervisord.conf
+COPY --chown=${UID}:${GID} build-script/code-serving-doc-parser/supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY --chown=${UID}:${GID} build-script/code-serving-doc-parser/scripts /app/scripts
+COPY --chown=${UID}:${GID} build-script/code-serving-doc-parser/src /app/src
+COPY --chown=${UID}:${GID} build-script/code-serving-doc-parser/gunicorn /app/gunicorn
 
+# (root 가 3000 소유 파일을 chmod 하는 것은 문제없고 소유권도 유지된다)
 RUN rm -rf /app/src/service && chmod +x /app/scripts/*.sh
-RUN chown -R $UID:$GID /app /run /var/log /etc/supervisor /models /app/nltk_data
+
+# 위 COPY 들이 이미 ${UID}:${GID} 로 복사했으므로 여기서는 작은 경로만 정리한다.
+#   - /app, /app/nltk_data : 위 apt RUN 에서 root 로 미리 만들어진 디렉토리라
+#     COPY --chown 이 디렉토리 자체의 소유권은 바꾸지 않는다 → 비재귀 chown 으로 보정.
+#   - site-packages/hwp_sdk : 위 RUN 이 만든 심볼릭 링크 자체의 소유권(-h).
+#   - /var/log/supervisor, /var/run/supervisor 는 /var/log, /run 에 포함된다.
+RUN chown "${UID}:${GID}" /app /app/nltk_data && \
+    chown -h "${UID}:${GID}" ${APP_VENV}/lib/python3.12/site-packages/hwp_sdk && \
+    find /app -maxdepth 1 -user 0 -exec chown "${UID}:${GID}" {} + && \
+    chown -R "${UID}:${GID}" /run /var/log /etc/supervisor /app/.cache /app/.config /app/.local /app/tmp /tmp/xdg
 
 USER $UID
 CMD ["supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]

--- a/build-script/code-serving-doc-parser/build.config
+++ b/build-script/code-serving-doc-parser/build.config
@@ -17,7 +17,7 @@ DOCKER_REGISTRY=mnc.genos.io:30500
 IMAGE_NAME=template-code-serving-doc-parser
 
 # 버전
-IMAGE_VERSION=0.1.0
+IMAGE_VERSION=2.1.4
 
 # 하드웨어 variant (gpu / cpu). 비우면 build.sh 에서 즉시 에러.
 #   cpu  — Dockerfile      (python:3.12-slim, CPU torch). 이미지명 ${IMAGE_NAME}, 태그 ${IMAGE_VERSION}

--- a/genon/preprocessor/docker/Dockerfile.standard
+++ b/genon/preprocessor/docker/Dockerfile.standard
@@ -34,6 +34,8 @@ ARG RHWP_GIT_REF=genos/main
 # (rhwp 는 stage 이름 alias 로 분기하므로 다른 문자열이면 빌드가 깨진다).
 ARG INSTALL_LIBREOFFICE=true
 ARG INSTALL_RHWP=true
+# uv 버전 핀 (builder 의 uv_bin 스테이지에서 사용). FROM 에서 쓰려면 첫 FROM 앞에 선언해야 한다.
+ARG UV_VERSION=0.8.0
 
 ############################
 # 1) Base (APT + LibreOffice)
@@ -57,6 +59,10 @@ ENV DEBIAN_FRONTEND=noninteractive \
 #   제대로 읽히는 .pref 파일로 sudo·systemd 만 trixie(우선순위 1001)로 강제한다.
 # 추가로 sudo 의 `systemd | systemd-standalone-tmpfiles | systemd-tmpfiles` 의존은
 # 풀 systemd 대신 컨테이너 친화적 systemd-standalone-tmpfiles 로 충족시킨다.
+# NOTE: /var/cache/apt 와 /var/lib/apt/lists 는 cache mount 라 **이미지 레이어에 포함되지 않는다.**
+#   예전에는 이 RUN 끝에서 `rm -rf /var/lib/apt/lists/*` 를 했는데, 이미지 크기에는 아무 이득이 없고
+#   다음 빌드가 재사용할 apt 인덱스 캐시만 파괴했다(매 빌드 인덱스 재다운로드). 그래서 제거했다.
+#   ⚠️ cache mount 가 없는 다른 apt RUN(rhwp 빌더 등)의 rm 은 실제로 레이어를 줄이므로 유지해야 한다.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     echo "deb http://deb.debian.org/debian sid main" > /etc/apt/sources.list.d/sid.list && \
@@ -110,7 +116,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       imagemagick-7.q16 \
       libmagickcore-7.q16-10 \
       libmagickwand-7.q16-10 \
-    && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /app/.cache/huggingface /app/.cache/fontconfig /app/.config /app/.local/share /app/.fontconfig /app/nltk_data /app/tmp /tmp/xdg
 RUN sed -i 's/# \(ko_KR.UTF-8\)/\1/' /etc/locale.gen \
     && locale-gen \
@@ -122,7 +127,11 @@ RUN sed -i 's/# \(ko_KR.UTF-8\)/\1/' /etc/locale.gen \
 FROM base AS loext
 ARG H2ORESTART_URL
 ARG INSTALL_LIBREOFFICE
-COPY ./genon/preprocessor/resources /app
+# NOTE: 예전에는 `COPY ./genon/preprocessor/resources /app` 로 resources 를 통째 복사했지만,
+#   (1) 필요한 건 HCRBatang 폰트뿐인데 tessedata.tar.gz(35MB, 레포 전역 참조 0건 —
+#       한국어 tessdata 는 apt tesseract-ocr-kor 로 이미 들어온다)까지 이미지에 남았고,
+#   (2) 폰트 tarball 을 다음 레이어에서 rm 해도 COPY 레이어(48MB)는 회수되지 않았다.
+#   → 아래 폰트 설치 RUN 에서 bind mount 로 필요한 파일만 읽어 레이어에 아무것도 남기지 않는다.
 # H2Orestart 는 LibreOffice 확장이라 LibreOffice 미설치 시 단계 자체를 건너뛴다 (이슈 #286)
 RUN --mount=type=cache,target=/opt/h2o_cache \
     set -eux; \
@@ -137,17 +146,23 @@ RUN --mount=type=cache,target=/opt/h2o_cache \
     else \
       echo "[INFO] INSTALL_LIBREOFFICE=false — skipping H2Orestart extension (이슈 #286)"; \
     fi
-RUN set -eux; \
+RUN --mount=type=bind,source=genon/preprocessor/resources/HCRBatang.ttf.tar.gz,target=/tmp/HCRBatang.ttf.tar.gz \
+    set -eux; \
     mkdir -p /usr/share/fonts && \
-    tar zxf /app/HCRBatang.ttf.tar.gz -C /usr/share/fonts/ && \
-    fc-cache -f -v && rm /app/HCRBatang.ttf.tar.gz
+    tar zxf /tmp/HCRBatang.ttf.tar.gz -C /usr/share/fonts/ && \
+    fc-cache -f -v
 
 ############################
 # 3) Builder (앱 venv만)
 ############################
+# uv 버전을 핀한다. 아래 uv sync 가 `--no-install-package` 에 의존하므로 uv 버전이 빌드 동작에
+# 직접 영향을 준다(0.8.0 에 존재함을 확인). `:latest` 는 어느 날 조용히 동작이 바뀔 수 있다.
+# ⚠️ `COPY --from=<이미지>` 는 ARG 를 확장하지 않는다(FROM 만 확장). 그래서 명명된 스테이지를 둔다.
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_bin
+
 FROM loext AS builder
 ARG APP_VENV
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=uv_bin /uv /uvx /bin/
 ENV UV_VIRTUALENVS_CREATE=1 \
     UV_VIRTUALENVS_IN_PROJECT=0 \
     UV_NO_INTERACTION=1 \
@@ -173,40 +188,103 @@ WORKDIR /app/genon/preprocessor
 
 RUN uv venv ${APP_VENV}
 
+# --no-dev: dev 그룹(pytest/mypy/debugpy/ipykernel/pre-commit …)은 런타임 이미지에 불필요.
+# 붙이지 않으면 uv 가 dev 그룹까지 기본 설치해 약 100MB(debugpy 18M, mypy+mypyc .so 47M 등)가 들어온다.
+#
+# CPU 빌드에서는 torch/torchvision/nvidia-*/triton 을 애초에 설치하지 않는다.
+#   uv.lock 의 torch 는 PyPI 기본(CUDA) 휠이라 nvidia 15종 + triton 이 딸려 오는데(약 4GB),
+#   바로 다음 단계에서 CPU 휠로 갈아끼우며 전부 버려진다. 콜드 빌드에서 이 다운로드가
+#   uv sync 시간의 대부분(6GB 중 4GB)을 차지했다.
+# ⚠️ 제외 목록을 하드코딩하지 말 것 — uv.lock 에서 뽑는다.
+#    하드코딩하면 `-cu12` → `-cu13` 같은 개명을 놓친다(code-serving 에서 그 방식 때문에
+#    CUDA 2.7GB 가 CPU 이미지에 그대로 남았던 전례).
+#    uv sync 에는 --torch-backend 옵션이 없어서 --no-install-package 를 쓴다
+#    (uv pip install 에는 있다 — code-serving 쪽은 그쪽을 사용).
+ARG HW_VARIANT
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen || \
-    uv sync
+    set -eu; \
+    if [ "${HW_VARIANT}" = "cpu" ]; then \
+      EXCL=$(grep -oE '^name = "(nvidia-[A-Za-z0-9._-]*|triton)"' uv.lock \
+             | sed 's/^name = "//; s/"$//' \
+             | sed 's/^/--no-install-package /' | tr '\n' ' '); \
+      echo "[INFO] HW_VARIANT=cpu — 설치 제외: torch torchvision ${EXCL}"; \
+      uv sync --frozen --no-dev --no-install-package torch --no-install-package torchvision ${EXCL}; \
+    else \
+      uv sync --frozen --no-dev; \
+    fi
 
 # 이슈 #210 — CPU 빌드 시 GPU 용 torch / nvidia / triton 을 제거하고 CPU wheel 재설치
+#
+# ⚠️ 제거 목록을 하드코딩하지 말 것. 예전에는 `nvidia-cublas-cu12` 처럼 `-cu12` 접미사 목록을
+#    박아두었는데, torch 가 CUDA 13 휠로 넘어가면 패키지명이 바뀐다
+#    (`nvidia_cublas` 접미사 없음, `nvidia_cudnn_cu13`, `nvidia_nccl_cu13` …).
+#    이름이 하나도 일치하지 않으면 uninstall 이 전부 실패하는데 끝의 `|| true` 가 그 실패를
+#    삼켜서 CPU 이미지에 CUDA 라이브러리가 조용히 실려 나간다
+#    (code-serving 쪽 Dockerfile 이 torch 핀 없이 2.13 을 받아 실제로 2.7GB 가 남아 있었다).
+#    → 설치된 목록에서 이름을 뽑아 지우고, `|| true` 로 실패를 감추지 않는다.
+#    (지울 게 없으면 xargs -r 이 uv 를 호출하지 않으므로 그대로 성공한다.)
 ARG HW_VARIANT
 ARG TORCH_CPU_INDEX_URL
 RUN --mount=type=cache,target=/root/.cache/uv \
+    set -eu; \
     if [ "${HW_VARIANT}" = "cpu" ]; then \
-      echo "[INFO] HW_VARIANT=cpu — reinstalling torch/torchvision as CPU wheels" && \
+      echo "[INFO] HW_VARIANT=cpu — reinstalling torch/torchvision as CPU wheels"; \
       uv pip install --python /app/.venv/bin/python \
         --reinstall-package torch --reinstall-package torchvision \
         --index-url "${TORCH_CPU_INDEX_URL}" \
-        torch==2.9.0 torchvision==0.24.0 && \
-      uv pip uninstall --python /app/.venv/bin/python \
-        nvidia-cublas-cu12 \
-        nvidia-cuda-cupti-cu12 \
-        nvidia-cuda-nvrtc-cu12 \
-        nvidia-cuda-runtime-cu12 \
-        nvidia-cudnn-cu12 \
-        nvidia-cufft-cu12 \
-        nvidia-cufile-cu12 \
-        nvidia-curand-cu12 \
-        nvidia-cusolver-cu12 \
-        nvidia-cusparse-cu12 \
-        nvidia-cusparselt-cu12 \
-        nvidia-nccl-cu12 \
-        nvidia-nvjitlink-cu12 \
-        nvidia-nvshmem-cu12 \
-        nvidia-nvtx-cu12 \
-        triton \
-      || true; \
+        torch==2.9.0 torchvision==0.24.0; \
+      uv pip list --python /app/.venv/bin/python --format=freeze \
+        | sed -n 's/^\(nvidia[A-Za-z0-9._-]*\|triton\)==.*/\1/p' \
+        | tee /tmp/cuda_pkgs.txt; \
+      xargs -r uv pip uninstall --python /app/.venv/bin/python < /tmp/cuda_pkgs.txt; \
+      rm -f /tmp/cuda_pkgs.txt; \
+      echo "[INFO] 남은 nvidia/triton 패키지 확인:"; \
+      uv pip list --python /app/.venv/bin/python --format=freeze \
+        | grep -iE '^(nvidia|triton)' && { echo "[ERROR] nvidia/triton 잔존"; exit 1; } || true; \
     else \
       echo "[INFO] HW_VARIANT=${HW_VARIANT} — keeping GPU torch as-is"; \
+    fi
+
+# torch 의 런타임 미사용 자산 제거 (약 141MB: test 81M + include 60M).
+# C++ 헤더와 테스트 픽스처로, 추론 경로에서는 쓰이지 않는다.
+# ⚠️ torch/bin(50MB)은 지우면 안 된다. torch/__init__.py 가 import 시점에 _manager_path() 로
+#    torch/bin/torch_shm_manager 존재를 무조건 확인하고, 없으면 RuntimeError 로 죽는다
+#    (DataLoader 를 쓰지 않아도 발생 — 실제로 제거했다가 import torch 부터 실패했다).
+RUN rm -rf ${APP_VENV}/lib/python3*/site-packages/torch/test \
+           ${APP_VENV}/lib/python3*/site-packages/torch/include
+
+# opencv 를 headless 로 통일한다.
+#   opencv-python(non-headless)과 opencv-python-headless 가 둘 다 해석돼 들어오는데
+#   (전자는 unstructured-inference + 자체 pyproject, 후자는 docling-ibm-models/easyocr),
+#   같은 `cv2` 모듈을 제공하므로 `opencv_python.libs`(약 116MB)가 순수 중복이다.
+#   첫 파티 코드에는 `import cv2` 가 한 건도 없고, cv2 를 쓰는 패키지들은 headless 로 충분하다.
+#   실측 절감: 약 116MB (파일시스템 5.20GB → 5.08GB).
+#
+# ⚠️ 여기서 apt 의 `libgl1` 을 빼려는 시도는 하지 말 것 — 이미 해봤고 **0바이트** 절감이었다.
+#    Mesa 스택(libLLVM 134MB + gallium 47MB + z3 27MB ≈ 208MB)은 opencv 가 아니라
+#    **ffmpeg** 가 끌어온다:
+#      ffmpeg → libsdl2-2.0-0 → libsdl3-0 → libgbm1 → mesa-libgallium → libllvm21 → libz3-4
+#    ffmpeg 는 pydub 오디오 파싱(attachment_processor.py / parser_processor.py)에 필요해
+#    뺄 수 없다. libgl1 만 제거하면 libGL.so.1 이 사라져 검증 못한 렌더링 경로에 위험만 남는다.
+#   (Dockerfile.gpu 의 models_artifacts 가 이미 같은 방식을 쓴다.)
+# ⚠️ 순서 중요: opencv-python 을 지우면 공유되는 cv2/ 파일까지 함께 사라지므로
+#    반드시 그 뒤에 headless 를 --reinstall 해야 한다.
+# ⚠️ 버전을 반드시 uv.lock 에 맞춰 핀한다. `uv pip install` 은 lock 을 참조하지 않으므로
+#    버전을 안 주면 최신(현재 5.0.x)을 가져와 lock 의 4.11 에서 **메이저 점프**가 일어난다.
+#    핵심 이미징 의존성이 이미지 경량화의 부작용으로 바뀌면 안 된다. 하드코딩 대신 lock 에서 뽑는다.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    set -eu; \
+    OCV=$(grep -A1 '^name = "opencv-python-headless"' uv.lock | awk -F'"' '/^version/{print $2}'); \
+    if [ -z "${OCV}" ]; then echo "[ERROR] uv.lock 에서 opencv-python-headless 버전을 못 찾음"; exit 1; fi; \
+    echo "[INFO] opencv-python-headless==${OCV} (uv.lock 기준)"; \
+    if uv pip list --python ${APP_VENV}/bin/python --format=freeze | grep -q '^opencv-python=='; then \
+      uv pip uninstall --python ${APP_VENV}/bin/python opencv-python; \
+    fi; \
+    uv pip install --python ${APP_VENV}/bin/python --reinstall "opencv-python-headless==${OCV}"; \
+    ${APP_VENV}/bin/python -c "import cv2; print('[INFO] cv2', cv2.__version__)"; \
+    ${APP_VENV}/bin/python -c "import unstructured_inference; print('[INFO] unstructured_inference ok')"; \
+    if ls -d ${APP_VENV}/lib/python3*/site-packages/opencv_python.libs >/dev/null 2>&1; then \
+      echo "[ERROR] opencv_python.libs 잔존"; exit 1; \
     fi
 
 ############################
@@ -252,9 +330,16 @@ RUN --mount=type=cache,target=${HF_HOME} \
 # runtime 은 그 "내용"을 /usr/local/bin/ 로 복사하므로 off 일 때는 아무것도 안 들어간다
 # (→ rhwp_available() == False → chain 에서 자동 제외).
 ############################
-FROM rust:latest AS rhwp_builder_true
+FROM rust:1-slim AS rhwp_builder_true
 ARG RHWP_GIT_URL
 ARG RHWP_GIT_REF
+# rust:latest(약 1.5GB)는 buildpack-deps 기반이라 git 이 들어 있지만 rust:slim 에는 없다.
+# 산출물이 바이너리 하나뿐이라 slim 으로 낮추고 git 만 따로 설치한다 — 최종 이미지 크기는 그대로이고
+# 빌드 중 다운로드/디스크만 줄어든다.
+# ⚠️ genos-rhwp 가 pkg-config / libssl-dev / cmake 같은 시스템 의존을 요구하면 cargo build 에서
+#    깨진다. 그때는 아래 목록에 추가하거나 rust:latest 로 되돌린다.
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
@@ -282,6 +367,26 @@ ARG NLTK_PACKAGES
 ARG DOCLING_MODELS_VER=2.41
 ARG HF_MODELS_VER=2.41
 ARG EASYOCR_VER=2.41
+# 받을 docling 모델 목록. 인자 없이 `docling-tools models download` 를 호출하면 기본 세트
+# (layout, tableformer, code_formula, picture_classifier)를 전부 받는데, 그중
+# code_formula(ds4sd--CodeFormula, 506MB)는 이 레포에서 절대 로드되지 않는다:
+#   do_code_enrichment / do_formula_enrichment 기본값 False(pipeline_options.py)이고
+#   이를 켜는 config 키·코드가 없어 CodeFormulaModel 은 enabled=False 로만 생성된다.
+#   ⚠️ 이 판단은 "현재 제품 기능 기준"이다. docling CLI 자체에는 code/formula enrichment 를 켜는
+#      옵션이 있으므로, 향후 facade 가 이를 노출하거나(코드서빙이라면 런타임에 clone 되는 서비스
+#      코드가 켜면) **오프라인 환경에서 모델이 없어 실패**한다. 그때는 DOCLING_MODELS 에
+#      code_formula 를 다시 넣어야 한다.
+# 나머지는 유지한다 (docling/utils/model_downloader.py 의 with_* 플래그와 1:1 대응):
+#   layout            → ds4sd--docling-layout-old. 이름이 old 지만 layout_model_specs.py 의
+#                       "Default Docling Layout Model"(DOCLING_LAYOUT_V2)이다. PDF 는
+#                       genos_layout(dotsocr)을 쓰지만, PPT/PPTX 경량 파이프라인이 bare
+#                       PdfPipelineOptions() 로 LayoutModel 을 만들어 실제 로드하므로 필수.
+#   tableformer       → ds4sd--docling-models. layout_model_type: docling_layout 배포에서 필요.
+#   picture_classifier→ ds4sd--DocumentFigureClassifier. chart.enable opt-in (16MB).
+#   easyocr           → /models/EasyOcr 의 craft_mlt_25k(83MB)/english_g2/latin_g2.
+#                       ⚠️ with_easyocr 도 기본 True 라, 목록에서 빼면 아래 korean_g2.zip
+#                       단계만 남아 CRAFT 검출기가 사라진다(EasyOCR 사용 시 필수).
+ARG DOCLING_MODELS="layout tableformer picture_classifier easyocr"
 
 ENV PATH="${APP_VENV}/bin:${PATH}" \
     HOME=/app \
@@ -293,19 +398,30 @@ ENV PATH="${APP_VENV}/bin:${PATH}" \
     HF_HOME=/app/.cache/huggingface \
     NLTK_DATA=/app/nltk_data
 
-RUN --mount=type=cache,target=/root/.cache/models \
-    echo "Docling models ver: ${DOCLING_MODELS_VER}"; \
+# NOTE: 예전에는 `--mount=type=cache,target=/root/.cache/models` 가 붙어 있었지만 아무도 그 경로를
+#   쓰지 않았다. docling-tools 는 `-o /models`(이미지 레이어)와 HF_HOME 을 쓴다. 실제로 그 캐시는
+#   4KB 로 비어 있었다. 오해를 남기지 않도록 제거했다.
+#   (재빌드 시 모델 다운로드를 건너뛰려면 HF_HOME 을 캐시 마운트해야 한다 — 아래 HF 단계 참고.)
+RUN echo "Docling models ver: ${DOCLING_MODELS_VER}"; \
     if [ ! -d /models ] || [ -z "$(ls -A /models)" ]; then \
-        docling-tools models download -o /models; \
+        docling-tools models download -o /models ${DOCLING_MODELS}; \
     else \
         echo "[INFO] /models already present, skip"; \
     fi
 
+# mncai/doc_parser_models 에서 실제로 쓰는 것은 MiniLM 토크나이저 폴더 하나뿐이다.
+# 예전에는 repo 전체(846MB)를 받았는데 나머지는 모두 사용되지 않았다:
+#   docling-models(506MB)    → 참조 0건. TableFormer 는 ds4sd--docling-models 를 쓴다.
+#   docling-layout-old(164MB)→ MNCAI_CUSTOM_LAYOUT 전용 경로이나 model_spec 을 그 값으로
+#                              바꾸는 코드가 없다 (기본은 ds4sd--docling-layout-old).
+# 또한 두 번째 download 의 --local-dir 이 이미 받은 폴더를 다시 가리켜 동명 하위 디렉토리가
+# 중첩 생성됐다(88MB 중복). 코드는 바깥쪽 경로만 사용하므로 그 줄을 없앤다.
 RUN --mount=type=cache,target=${HF_HOME} \
     echo "HF models ver: ${HF_MODELS_VER}"; \
     mkdir -p /models/doc_parser_models; \
-    huggingface-cli download mncai/doc_parser_models --local-dir /models/doc_parser_models && \
-    huggingface-cli download mncai/doc_parser_models --include "sentence-transformers-all-MiniLM-L6-v2/*" --local-dir /models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2
+    huggingface-cli download mncai/doc_parser_models \
+      --include "sentence-transformers-all-MiniLM-L6-v2/*" \
+      --local-dir /models/doc_parser_models
 
 RUN --mount=type=cache,target=/root/.cache/nltk \
     python - <<'PY'
@@ -323,13 +439,18 @@ else:
         nltk.download(pkg, download_dir=target)
 PY
 
+# ⚠️ 조건은 **캐시 경로**의 zip 을 봐야 한다. 예전에는 `/models/EasyOcr/korean_g2.zip` 을
+#    검사했는데 zip 은 캐시 마운트(`/root/.cache/easyocr_korean/`)에 저장되므로 그 경로에는
+#    zip 이 절대 생기지 않았다 → 조건이 항상 참 → 캐시가 있어도 매번 재다운로드했다.
+#    (code-serving Dockerfile 은 처음부터 캐시 경로를 검사해 올바르게 동작한다.)
+#    unzip 은 조건 밖에 둔다 — 캐시에 zip 이 있어도 /models/EasyOcr 는 새 레이어라 매번 풀어야 한다.
 RUN --mount=type=cache,target=/root/.cache/easyocr_korean \
     echo "EasyOCR ver: ${EASYOCR_VER}"; \
     mkdir -p /models/EasyOcr && \
-    if [ ! -f /models/EasyOcr/korean_g2.zip ]; then \
+    if [ ! -f /root/.cache/easyocr_korean/korean_g2.zip ]; then \
       curl -L -o /root/.cache/easyocr_korean/korean_g2.zip "https://github.com/JaidedAI/EasyOCR/releases/download/v1.3/korean_g2.zip"; \
-      unzip -q -o /root/.cache/easyocr_korean/korean_g2.zip -d /models/EasyOcr; \
-    fi
+    fi; \
+    unzip -q -o /root/.cache/easyocr_korean/korean_g2.zip -d /models/EasyOcr
 
 ############################
 # 5) Runtime (오픈소스)
@@ -369,23 +490,37 @@ LABEL ai.genon.install.libreoffice="${INSTALL_LIBREOFFICE}" \
       ai.genon.install.rhwp="${INSTALL_RHWP}"
 
 WORKDIR /app
-COPY ./genon/preprocessor/configs /app/configs
-COPY ./genon/preprocessor/env /app/env
-COPY ./genon/preprocessor/src /app/src
+
+# 🔴 사용자/그룹 생성을 큰 COPY 보다 "먼저" 수행한다.
+# 예전에는 모든 COPY 뒤에서 `chown -R … /app … /models /app/nltk_data` 를 한 번에 돌렸는데,
+# 이미 복사된 .venv(2.6GB) + /models(2.2GB) + nltk_data + hwp_sdk 의 소유권만 바꾸는 것도
+# overlayfs 에서는 전 파일 copy-up 이라, 같은 데이터를 담은 5.2GB 레이어가 하나 더 생겼다
+# (이미지 내용은 6.8GB인데 레이어 합이 12.5GB가 된 주된 이유).
+#   → 각 COPY 에 --chown 을 주어 처음부터 올바른 소유자로 복사하고,
+#     마지막 RUN 은 작은 디렉토리만 chown 한다.
+RUN getent group "${GID}" || groupadd -g "${GID}" "${GNAME}" && \
+    getent passwd "${UID}" || useradd -m -u "${UID}" -g "${GID}" -s /bin/bash "${UNAME}" && \
+    UNAME_ACTUAL="$(getent passwd "${UID}" | cut -d: -f1)" && \
+    usermod -aG sudo "${UNAME_ACTUAL}" && \
+    echo "${UNAME_ACTUAL} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+COPY --chown=${UID}:${GID} ./genon/preprocessor/configs /app/configs
+COPY --chown=${UID}:${GID} ./genon/preprocessor/env /app/env
+COPY --chown=${UID}:${GID} ./genon/preprocessor/src /app/src
 # HWP → PDF chain 모듈 (이슈 #199). PYTHONPATH=/app 기준 namespace package 로
 # import 되도록 genon/preprocessor 트리 그대로 복사
 # (facade 의 `from genon.preprocessor.converters.hwp_to_pdf import ...` 가 풀림).
-COPY ./genon/preprocessor/converters /app/genon/preprocessor/converters
+COPY --chown=${UID}:${GID} ./genon/preprocessor/converters /app/genon/preprocessor/converters
 # enrichment 패키지를 namespace tree 로 복사 — facade 의
 # `from genon.preprocessor.facade.enrichment.* import ...` (intelligent_processor.py:151-152)
 # 가 /app 기준 namespace package 로 풀리도록. (converters 와 동일 패턴)
-COPY ./genon/preprocessor/facade/enrichment /app/genon/preprocessor/facade/enrichment
+COPY --chown=${UID}:${GID} ./genon/preprocessor/facade/enrichment /app/genon/preprocessor/facade/enrichment
 # guardrail 패키지를 namespace tree 로 복사 — facade 의
 # `from genon.preprocessor.facade import guardrail as gr` (#315) 가 /app 기준으로 풀리도록.
-COPY ./genon/preprocessor/facade/guardrail /app/genon/preprocessor/facade/guardrail
+COPY --chown=${UID}:${GID} ./genon/preprocessor/facade/guardrail /app/genon/preprocessor/facade/guardrail
 
 # 🔴 HWP sdk (무료 자산이라 오픈소스 빌드에도 포함)
-COPY --from=sdk_artifacts /app/hwp_sdk /app/hwp_sdk
+COPY --chown=${UID}:${GID} --from=sdk_artifacts /app/hwp_sdk /app/hwp_sdk
 
 # 🔴 rhwp 바이너리 (이슈 #199 후속 — 컨테이너 내 바이너리, subprocess 호출)
 # 이슈 #286 — /rhwp_out/ 내용을 복사. INSTALL_RHWP=false 면 빈 디렉토리라 아무것도 안 들어감.
@@ -398,22 +533,25 @@ COPY --from=font_artifacts /app/extra_fonts /usr/share/fonts/additional
 RUN fc-cache -f -v
 
 # ✅ 공통 venv 위치만 복사
-COPY --from=builder ${APP_VENV} ${APP_VENV}
+COPY --chown=${UID}:${GID} --from=builder ${APP_VENV} ${APP_VENV}
 
 # 🔴 [매우 중요] 경로 문제 해결을 위한 링크 (USER 설정 이전에 수행)
 RUN ln -s /app/hwp_sdk /app/.venv/lib/python3.12/site-packages/hwp_sdk
 
 # ✅ 모델/자료
-COPY --from=models_artifacts /app/nltk_data /app/nltk_data
-COPY --from=models_artifacts /models /models
+COPY --chown=${UID}:${GID} --from=models_artifacts /app/nltk_data /app/nltk_data
+COPY --chown=${UID}:${GID} --from=models_artifacts /models /models
 
 RUN ln -sf /app/configs/supervisor.conf /etc/supervisor/conf.d/supervisor.conf
-RUN getent group "${GID}" || groupadd -g "${GID}" "${GNAME}" && \
-    getent passwd "${UID}" || useradd -m -u "${UID}" -g "${GID}" -s /bin/bash "${UNAME}" && \
-    UNAME_ACTUAL="$(getent passwd "${UID}" | cut -d: -f1)" && \
-    usermod -aG sudo "${UNAME_ACTUAL}" && \
-    echo "${UNAME_ACTUAL} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-    mkdir -p /app/.cache/huggingface /app/.config/libreoffice /app/.cache/libreoffice /app/.local/share /app/tmp /tmp/xdg && \
-    chown -R "${UID}:${GID}" /app /run /var/log /etc/supervisor /models /app/nltk_data /app/.cache /app/.config /app/.local /tmp/xdg
+# 위 COPY 들이 이미 ${UID}:${GID} 로 복사했으므로, 여기서는 작은 경로만 정리한다.
+#   - /app, /app/nltk_data : base 단계에서 root 로 미리 만들어진 디렉토리라
+#     COPY --chown 이 디렉토리 자체의 소유권은 바꾸지 않는다 → 비재귀 chown 으로 보정.
+#   - site-packages/hwp_sdk : 위 RUN 이 만든 심볼릭 링크 자체의 소유권(-h).
+#   - 나머지는 모두 KB 단위의 작은 트리라 -R 로 돌려도 레이어가 커지지 않는다.
+RUN mkdir -p /app/.cache/huggingface /app/.config/libreoffice /app/.cache/libreoffice /app/.local/share /app/tmp /tmp/xdg && \
+    chown "${UID}:${GID}" /app /app/nltk_data && \
+    chown -h "${UID}:${GID}" /app/.venv/lib/python3.12/site-packages/hwp_sdk && \
+    find /app -maxdepth 1 -user 0 -exec chown "${UID}:${GID}" {} + && \
+    chown -R "${UID}:${GID}" /run /var/log /etc/supervisor /app/.cache /app/.config /app/.local /app/.fontconfig /app/tmp /tmp/xdg
 USER ${UID}:${GID}
 CMD ["supervisord", "-n"]

--- a/genon/preprocessor/docker/Dockerfile.synap
+++ b/genon/preprocessor/docker/Dockerfile.synap
@@ -35,6 +35,8 @@ ARG RHWP_GIT_REF=genos/main
 # (HWP/HWPX 는 rhwp 가 빠지면 PDF SDK 만으로 처리).
 ARG INSTALL_LIBREOFFICE=true
 ARG INSTALL_RHWP=true
+# uv 버전 핀 (builder 의 uv_bin 스테이지에서 사용). FROM 에서 쓰려면 첫 FROM 앞에 선언해야 한다.
+ARG UV_VERSION=0.8.0
 
 ############################
 # 1) Base (APT + LibreOffice)
@@ -58,6 +60,10 @@ ENV DEBIAN_FRONTEND=noninteractive \
 #   제대로 읽히는 .pref 파일로 sudo·systemd 만 trixie(우선순위 1001)로 강제한다.
 # 추가로 sudo 의 `systemd | systemd-standalone-tmpfiles | systemd-tmpfiles` 의존은
 # 풀 systemd 대신 컨테이너 친화적 systemd-standalone-tmpfiles 로 충족시킨다.
+# NOTE: /var/cache/apt 와 /var/lib/apt/lists 는 cache mount 라 **이미지 레이어에 포함되지 않는다.**
+#   예전에는 이 RUN 끝에서 `rm -rf /var/lib/apt/lists/*` 를 했는데, 이미지 크기에는 아무 이득이 없고
+#   다음 빌드가 재사용할 apt 인덱스 캐시만 파괴했다(매 빌드 인덱스 재다운로드). 그래서 제거했다.
+#   ⚠️ cache mount 가 없는 다른 apt RUN(rhwp 빌더 등)의 rm 은 실제로 레이어를 줄이므로 유지해야 한다.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     echo "deb http://deb.debian.org/debian sid main" > /etc/apt/sources.list.d/sid.list && \
@@ -111,7 +117,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       imagemagick-7.q16 \
       libmagickcore-7.q16-10 \
       libmagickwand-7.q16-10 \
-    && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /app/.cache/huggingface /app/.cache/fontconfig /app/.config /app/.local/share /app/.fontconfig /app/nltk_data /app/tmp /tmp/xdg
 RUN sed -i 's/# \(ko_KR.UTF-8\)/\1/' /etc/locale.gen \
     && locale-gen \
@@ -123,7 +128,11 @@ RUN sed -i 's/# \(ko_KR.UTF-8\)/\1/' /etc/locale.gen \
 FROM base AS loext
 ARG H2ORESTART_URL
 ARG INSTALL_LIBREOFFICE
-COPY ./genon/preprocessor/resources /app
+# NOTE: 예전에는 `COPY ./genon/preprocessor/resources /app` 로 resources 를 통째 복사했지만,
+#   (1) 필요한 건 HCRBatang 폰트뿐인데 tessedata.tar.gz(35MB, 레포 전역 참조 0건 —
+#       한국어 tessdata 는 apt tesseract-ocr-kor 로 이미 들어온다)까지 이미지에 남았고,
+#   (2) 폰트 tarball 을 다음 레이어에서 rm 해도 COPY 레이어(48MB)는 회수되지 않았다.
+#   → 아래 폰트 설치 RUN 에서 bind mount 로 필요한 파일만 읽어 레이어에 아무것도 남기지 않는다.
 # H2Orestart 는 LibreOffice 확장이라 LibreOffice 미설치 시 단계 자체를 건너뛴다 (이슈 #286)
 RUN --mount=type=cache,target=/opt/h2o_cache \
     set -eux; \
@@ -138,17 +147,23 @@ RUN --mount=type=cache,target=/opt/h2o_cache \
     else \
       echo "[INFO] INSTALL_LIBREOFFICE=false — skipping H2Orestart extension (이슈 #286)"; \
     fi
-RUN set -eux; \
+RUN --mount=type=bind,source=genon/preprocessor/resources/HCRBatang.ttf.tar.gz,target=/tmp/HCRBatang.ttf.tar.gz \
+    set -eux; \
     mkdir -p /usr/share/fonts && \
-    tar zxf /app/HCRBatang.ttf.tar.gz -C /usr/share/fonts/ && \
-    fc-cache -f -v && rm /app/HCRBatang.ttf.tar.gz
+    tar zxf /tmp/HCRBatang.ttf.tar.gz -C /usr/share/fonts/ && \
+    fc-cache -f -v
 
 ############################
 # 3) Builder (앱 venv만)
 ############################
+# uv 버전을 핀한다. 아래 uv sync 가 `--no-install-package` 에 의존하므로 uv 버전이 빌드 동작에
+# 직접 영향을 준다(0.8.0 에 존재함을 확인). `:latest` 는 어느 날 조용히 동작이 바뀔 수 있다.
+# ⚠️ `COPY --from=<이미지>` 는 ARG 를 확장하지 않는다(FROM 만 확장). 그래서 명명된 스테이지를 둔다.
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_bin
+
 FROM loext AS builder
 ARG APP_VENV
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=uv_bin /uv /uvx /bin/
 ENV UV_VIRTUALENVS_CREATE=1 \
     UV_VIRTUALENVS_IN_PROJECT=0 \
     UV_NO_INTERACTION=1 \
@@ -177,40 +192,101 @@ WORKDIR /app/genon/preprocessor
 RUN uv venv ${APP_VENV}
 
 # ✅ 그 venv에 설치
+# --no-dev: dev 그룹(pytest/mypy/debugpy/ipykernel/pre-commit …)은 런타임 이미지에 불필요.
+# 붙이지 않으면 uv 가 dev 그룹까지 기본 설치해 약 100MB(debugpy 18M, mypy+mypyc .so 47M 등)가 들어온다.
+#
+# CPU 빌드에서는 torch/torchvision/nvidia-*/triton 을 애초에 설치하지 않는다.
+#   uv.lock 의 torch 는 PyPI 기본(CUDA) 휠이라 nvidia 15종 + triton 이 딸려 오는데(약 4GB),
+#   바로 다음 단계에서 CPU 휠로 갈아끼우며 전부 버려진다. 콜드 빌드에서 이 다운로드가
+#   uv sync 시간의 대부분(6GB 중 4GB)을 차지했다.
+# ⚠️ 제외 목록을 하드코딩하지 말 것 — uv.lock 에서 뽑는다.
+#    하드코딩하면 `-cu12` → `-cu13` 같은 개명을 놓친다(code-serving 에서 그 방식 때문에
+#    CUDA 2.7GB 가 CPU 이미지에 그대로 남았던 전례).
+#    uv sync 에는 --torch-backend 옵션이 없어서 --no-install-package 를 쓴다
+#    (uv pip install 에는 있다 — code-serving 쪽은 그쪽을 사용).
+ARG HW_VARIANT
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen || \
-    uv sync
+    set -eu; \
+    if [ "${HW_VARIANT}" = "cpu" ]; then \
+      EXCL=$(grep -oE '^name = "(nvidia-[A-Za-z0-9._-]*|triton)"' uv.lock \
+             | sed 's/^name = "//; s/"$//' \
+             | sed 's/^/--no-install-package /' | tr '\n' ' '); \
+      echo "[INFO] HW_VARIANT=cpu — 설치 제외: torch torchvision ${EXCL}"; \
+      uv sync --frozen --no-dev --no-install-package torch --no-install-package torchvision ${EXCL}; \
+    else \
+      uv sync --frozen --no-dev; \
+    fi
 
 # 이슈 #210 — CPU 빌드 시 GPU 용 torch / nvidia / triton 을 제거하고 CPU wheel 재설치
+#
+# ⚠️ 제거 목록을 하드코딩하지 말 것. 예전에는 `nvidia-cublas-cu12` 처럼 `-cu12` 접미사 목록을
+#    박아두었는데, torch 가 CUDA 13 휠로 넘어가면 패키지명이 바뀐다
+#    (`nvidia_cublas` 접미사 없음, `nvidia_cudnn_cu13`, `nvidia_nccl_cu13` …).
+#    이름이 하나도 일치하지 않으면 uninstall 이 전부 실패하는데 끝의 `|| true` 가 그 실패를
+#    삼켜서 CPU 이미지에 CUDA 라이브러리가 조용히 실려 나간다
+#    (code-serving 쪽 Dockerfile 이 torch 핀 없이 2.13 을 받아 실제로 2.7GB 가 남아 있었다).
+#    → 설치된 목록에서 이름을 뽑아 지우고, `|| true` 로 실패를 감추지 않는다.
+#    (지울 게 없으면 xargs -r 이 uv 를 호출하지 않으므로 그대로 성공한다.)
 ARG HW_VARIANT
 ARG TORCH_CPU_INDEX_URL
 RUN --mount=type=cache,target=/root/.cache/uv \
+    set -eu; \
     if [ "${HW_VARIANT}" = "cpu" ]; then \
-      echo "[INFO] HW_VARIANT=cpu — reinstalling torch/torchvision as CPU wheels" && \
+      echo "[INFO] HW_VARIANT=cpu — reinstalling torch/torchvision as CPU wheels"; \
       uv pip install --python /app/.venv/bin/python \
         --reinstall-package torch --reinstall-package torchvision \
         --index-url "${TORCH_CPU_INDEX_URL}" \
-        torch==2.9.0 torchvision==0.24.0 && \
-      uv pip uninstall --python /app/.venv/bin/python \
-        nvidia-cublas-cu12 \
-        nvidia-cuda-cupti-cu12 \
-        nvidia-cuda-nvrtc-cu12 \
-        nvidia-cuda-runtime-cu12 \
-        nvidia-cudnn-cu12 \
-        nvidia-cufft-cu12 \
-        nvidia-cufile-cu12 \
-        nvidia-curand-cu12 \
-        nvidia-cusolver-cu12 \
-        nvidia-cusparse-cu12 \
-        nvidia-cusparselt-cu12 \
-        nvidia-nccl-cu12 \
-        nvidia-nvjitlink-cu12 \
-        nvidia-nvshmem-cu12 \
-        nvidia-nvtx-cu12 \
-        triton \
-      || true; \
+        torch==2.9.0 torchvision==0.24.0; \
+      uv pip list --python /app/.venv/bin/python --format=freeze \
+        | sed -n 's/^\(nvidia[A-Za-z0-9._-]*\|triton\)==.*/\1/p' \
+        | tee /tmp/cuda_pkgs.txt; \
+      xargs -r uv pip uninstall --python /app/.venv/bin/python < /tmp/cuda_pkgs.txt; \
+      rm -f /tmp/cuda_pkgs.txt; \
+      echo "[INFO] 남은 nvidia/triton 패키지 확인:"; \
+      uv pip list --python /app/.venv/bin/python --format=freeze \
+        | grep -iE '^(nvidia|triton)' && { echo "[ERROR] nvidia/triton 잔존"; exit 1; } || true; \
     else \
       echo "[INFO] HW_VARIANT=${HW_VARIANT} — keeping GPU torch as-is"; \
+    fi
+
+# torch 의 런타임 미사용 자산 제거 (약 141MB: test 81M + include 60M).
+# C++ 헤더와 테스트 픽스처로, 추론 경로에서는 쓰이지 않는다.
+# ⚠️ torch/bin(50MB)은 지우면 안 된다. torch/__init__.py 가 import 시점에 _manager_path() 로
+#    torch/bin/torch_shm_manager 존재를 무조건 확인하고, 없으면 RuntimeError 로 죽는다
+#    (DataLoader 를 쓰지 않아도 발생 — 실제로 제거했다가 import torch 부터 실패했다).
+RUN rm -rf ${APP_VENV}/lib/python3*/site-packages/torch/test \
+           ${APP_VENV}/lib/python3*/site-packages/torch/include
+
+# opencv 를 headless 로 통일한다.
+#   opencv-python(non-headless)과 opencv-python-headless 가 둘 다 해석돼 들어오는데
+#   (전자는 unstructured-inference + 자체 pyproject, 후자는 docling-ibm-models/easyocr),
+#   같은 `cv2` 모듈을 제공하므로 `opencv_python.libs`(약 116MB)가 순수 중복이다.
+#   첫 파티 코드에는 `import cv2` 가 한 건도 없고, cv2 를 쓰는 패키지들은 headless 로 충분하다.
+#   실측 절감: 약 116MB.
+#
+# ⚠️ 여기서 apt 의 `libgl1` 을 빼려는 시도는 하지 말 것 — 이미 해봤고 **0바이트** 절감이었다.
+#    Mesa 스택(약 208MB)은 opencv 가 아니라 **ffmpeg** 가 끌어온다:
+#      ffmpeg → libsdl2-2.0-0 → libsdl3-0 → libgbm1 → mesa-libgallium → libllvm21 → libz3-4
+#    ffmpeg 는 pydub 오디오 파싱에 필요해 뺄 수 없다.
+#   (Dockerfile.gpu 의 models_artifacts 가 이미 같은 방식을 쓴다.)
+# ⚠️ 순서 중요: opencv-python 을 지우면 공유되는 cv2/ 파일까지 함께 사라지므로
+#    반드시 그 뒤에 headless 를 --reinstall 해야 한다.
+# ⚠️ 버전을 반드시 uv.lock 에 맞춰 핀한다. `uv pip install` 은 lock 을 참조하지 않으므로
+#    버전을 안 주면 최신(현재 5.0.x)을 가져와 lock 의 4.11 에서 **메이저 점프**가 일어난다.
+#    핵심 이미징 의존성이 이미지 경량화의 부작용으로 바뀌면 안 된다. 하드코딩 대신 lock 에서 뽑는다.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    set -eu; \
+    OCV=$(grep -A1 '^name = "opencv-python-headless"' uv.lock | awk -F'"' '/^version/{print $2}'); \
+    if [ -z "${OCV}" ]; then echo "[ERROR] uv.lock 에서 opencv-python-headless 버전을 못 찾음"; exit 1; fi; \
+    echo "[INFO] opencv-python-headless==${OCV} (uv.lock 기준)"; \
+    if uv pip list --python ${APP_VENV}/bin/python --format=freeze | grep -q '^opencv-python=='; then \
+      uv pip uninstall --python ${APP_VENV}/bin/python opencv-python; \
+    fi; \
+    uv pip install --python ${APP_VENV}/bin/python --reinstall "opencv-python-headless==${OCV}"; \
+    ${APP_VENV}/bin/python -c "import cv2; print('[INFO] cv2', cv2.__version__)"; \
+    ${APP_VENV}/bin/python -c "import unstructured_inference; print('[INFO] unstructured_inference ok')"; \
+    if ls -d ${APP_VENV}/lib/python3*/site-packages/opencv_python.libs >/dev/null 2>&1; then \
+      echo "[ERROR] opencv_python.libs 잔존"; exit 1; \
     fi
 
 ############################
@@ -278,9 +354,16 @@ RUN --mount=type=cache,target=${HF_HOME} \
 # runtime 은 그 "내용"을 /usr/local/bin/ 로 복사하므로 off 일 때는 아무것도 안 들어간다
 # (→ rhwp_available() == False → chain 에서 자동 제외).
 ############################
-FROM rust:latest AS rhwp_builder_true
+FROM rust:1-slim AS rhwp_builder_true
 ARG RHWP_GIT_URL
 ARG RHWP_GIT_REF
+# rust:latest(약 1.5GB)는 buildpack-deps 기반이라 git 이 들어 있지만 rust:slim 에는 없다.
+# 산출물이 바이너리 하나뿐이라 slim 으로 낮추고 git 만 따로 설치한다 — 최종 이미지 크기는 그대로이고
+# 빌드 중 다운로드/디스크만 줄어든다.
+# ⚠️ genos-rhwp 가 pkg-config / libssl-dev / cmake 같은 시스템 의존을 요구하면 cargo build 에서
+#    깨진다. 그때는 아래 목록에 추가하거나 rust:latest 로 되돌린다.
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
@@ -308,6 +391,26 @@ ARG NLTK_PACKAGES
 ARG DOCLING_MODELS_VER=2.41
 ARG HF_MODELS_VER=2.41
 ARG EASYOCR_VER=2.41
+# 받을 docling 모델 목록. 인자 없이 `docling-tools models download` 를 호출하면 기본 세트
+# (layout, tableformer, code_formula, picture_classifier)를 전부 받는데, 그중
+# code_formula(ds4sd--CodeFormula, 506MB)는 이 레포에서 절대 로드되지 않는다:
+#   do_code_enrichment / do_formula_enrichment 기본값 False(pipeline_options.py)이고
+#   이를 켜는 config 키·코드가 없어 CodeFormulaModel 은 enabled=False 로만 생성된다.
+#   ⚠️ 이 판단은 "현재 제품 기능 기준"이다. docling CLI 자체에는 code/formula enrichment 를 켜는
+#      옵션이 있으므로, 향후 facade 가 이를 노출하거나(코드서빙이라면 런타임에 clone 되는 서비스
+#      코드가 켜면) **오프라인 환경에서 모델이 없어 실패**한다. 그때는 DOCLING_MODELS 에
+#      code_formula 를 다시 넣어야 한다.
+# 나머지는 유지한다 (docling/utils/model_downloader.py 의 with_* 플래그와 1:1 대응):
+#   layout            → ds4sd--docling-layout-old. 이름이 old 지만 layout_model_specs.py 의
+#                       "Default Docling Layout Model"(DOCLING_LAYOUT_V2)이다. PDF 는
+#                       genos_layout(dotsocr)을 쓰지만, PPT/PPTX 경량 파이프라인이 bare
+#                       PdfPipelineOptions() 로 LayoutModel 을 만들어 실제 로드하므로 필수.
+#   tableformer       → ds4sd--docling-models. layout_model_type: docling_layout 배포에서 필요.
+#   picture_classifier→ ds4sd--DocumentFigureClassifier. chart.enable opt-in (16MB).
+#   easyocr           → /models/EasyOcr 의 craft_mlt_25k(83MB)/english_g2/latin_g2.
+#                       ⚠️ with_easyocr 도 기본 True 라, 목록에서 빼면 아래 korean_g2.zip
+#                       단계만 남아 CRAFT 검출기가 사라진다(EasyOCR 사용 시 필수).
+ARG DOCLING_MODELS="layout tableformer picture_classifier easyocr"
 
 ENV PATH="${APP_VENV}/bin:${PATH}" \
     HOME=/app \
@@ -319,19 +422,30 @@ ENV PATH="${APP_VENV}/bin:${PATH}" \
     HF_HOME=/app/.cache/huggingface \
     NLTK_DATA=/app/nltk_data
 
-RUN --mount=type=cache,target=/root/.cache/models \
-    echo "Docling models ver: ${DOCLING_MODELS_VER}"; \
+# NOTE: 예전에는 `--mount=type=cache,target=/root/.cache/models` 가 붙어 있었지만 아무도 그 경로를
+#   쓰지 않았다. docling-tools 는 `-o /models`(이미지 레이어)와 HF_HOME 을 쓴다. 실제로 그 캐시는
+#   4KB 로 비어 있었다. 오해를 남기지 않도록 제거했다.
+#   (재빌드 시 모델 다운로드를 건너뛰려면 HF_HOME 을 캐시 마운트해야 한다 — 아래 HF 단계 참고.)
+RUN echo "Docling models ver: ${DOCLING_MODELS_VER}"; \
     if [ ! -d /models ] || [ -z "$(ls -A /models)" ]; then \
-        docling-tools models download -o /models; \
+        docling-tools models download -o /models ${DOCLING_MODELS}; \
     else \
         echo "[INFO] /models already present, skip"; \
     fi
 
+# mncai/doc_parser_models 에서 실제로 쓰는 것은 MiniLM 토크나이저 폴더 하나뿐이다.
+# 예전에는 repo 전체(846MB)를 받았는데 나머지는 모두 사용되지 않았다:
+#   docling-models(506MB)    → 참조 0건. TableFormer 는 ds4sd--docling-models 를 쓴다.
+#   docling-layout-old(164MB)→ MNCAI_CUSTOM_LAYOUT 전용 경로이나 model_spec 을 그 값으로
+#                              바꾸는 코드가 없다 (기본은 ds4sd--docling-layout-old).
+# 또한 두 번째 download 의 --local-dir 이 이미 받은 폴더를 다시 가리켜 동명 하위 디렉토리가
+# 중첩 생성됐다(88MB 중복). 코드는 바깥쪽 경로만 사용하므로 그 줄을 없앤다.
 RUN --mount=type=cache,target=${HF_HOME} \
     echo "HF models ver: ${HF_MODELS_VER}"; \
     mkdir -p /models/doc_parser_models; \
-    huggingface-cli download mncai/doc_parser_models --local-dir /models/doc_parser_models && \
-    huggingface-cli download mncai/doc_parser_models --include "sentence-transformers-all-MiniLM-L6-v2/*" --local-dir /models/doc_parser_models/sentence-transformers-all-MiniLM-L6-v2
+    huggingface-cli download mncai/doc_parser_models \
+      --include "sentence-transformers-all-MiniLM-L6-v2/*" \
+      --local-dir /models/doc_parser_models
 
 RUN --mount=type=cache,target=/root/.cache/nltk \
     python - <<'PY'
@@ -349,13 +463,18 @@ else:
         nltk.download(pkg, download_dir=target)
 PY
 
+# ⚠️ 조건은 **캐시 경로**의 zip 을 봐야 한다. 예전에는 `/models/EasyOcr/korean_g2.zip` 을
+#    검사했는데 zip 은 캐시 마운트(`/root/.cache/easyocr_korean/`)에 저장되므로 그 경로에는
+#    zip 이 절대 생기지 않았다 → 조건이 항상 참 → 캐시가 있어도 매번 재다운로드했다.
+#    (code-serving Dockerfile 은 처음부터 캐시 경로를 검사해 올바르게 동작한다.)
+#    unzip 은 조건 밖에 둔다 — 캐시에 zip 이 있어도 /models/EasyOcr 는 새 레이어라 매번 풀어야 한다.
 RUN --mount=type=cache,target=/root/.cache/easyocr_korean \
     echo "EasyOCR ver: ${EASYOCR_VER}"; \
     mkdir -p /models/EasyOcr && \
-    if [ ! -f /models/EasyOcr/korean_g2.zip ]; then \
+    if [ ! -f /root/.cache/easyocr_korean/korean_g2.zip ]; then \
       curl -L -o /root/.cache/easyocr_korean/korean_g2.zip "https://github.com/JaidedAI/EasyOCR/releases/download/v1.3/korean_g2.zip"; \
-      unzip -q -o /root/.cache/easyocr_korean/korean_g2.zip -d /models/EasyOcr; \
-    fi
+    fi; \
+    unzip -q -o /root/.cache/easyocr_korean/korean_g2.zip -d /models/EasyOcr
 
 ############################
 # 5) Runtime (엔터프라이즈)
@@ -393,26 +512,40 @@ LABEL ai.genon.install.libreoffice="${INSTALL_LIBREOFFICE}" \
       ai.genon.install.rhwp="${INSTALL_RHWP}"
 
 WORKDIR /app
-COPY ./genon/preprocessor/configs /app/configs
-COPY ./genon/preprocessor/env /app/env
-COPY ./genon/preprocessor/src /app/src
+
+# 🔴 사용자/그룹 생성을 큰 COPY 보다 "먼저" 수행한다.
+# 예전에는 모든 COPY 뒤에서 `chown -R … /app … /models /app/nltk_data` 를 한 번에 돌렸는데,
+# 이미 복사된 .venv(2.6GB) + /models(2.2GB) + nltk_data + hwp_sdk 의 소유권만 바꾸는 것도
+# overlayfs 에서는 전 파일 copy-up 이라, 같은 데이터를 담은 5.2GB 레이어가 하나 더 생겼다
+# (이미지 내용은 6.8GB인데 레이어 합이 12.5GB가 된 주된 이유).
+#   → 각 COPY 에 --chown 을 주어 처음부터 올바른 소유자로 복사하고,
+#     마지막 RUN 은 작은 디렉토리만 chown 한다.
+RUN getent group "${GID}" || groupadd -g "${GID}" "${GNAME}" && \
+    getent passwd "${UID}" || useradd -m -u "${UID}" -g "${GID}" -s /bin/bash "${UNAME}" && \
+    UNAME_ACTUAL="$(getent passwd "${UID}" | cut -d: -f1)" && \
+    usermod -aG sudo "${UNAME_ACTUAL}" && \
+    echo "${UNAME_ACTUAL} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+COPY --chown=${UID}:${GID} ./genon/preprocessor/configs /app/configs
+COPY --chown=${UID}:${GID} ./genon/preprocessor/env /app/env
+COPY --chown=${UID}:${GID} ./genon/preprocessor/src /app/src
 # HWP → PDF chain 모듈 (이슈 #199). PYTHONPATH=/app 기준 namespace package 로
 # import 되도록 genon/preprocessor 트리 그대로 복사
 # (facade 의 `from genon.preprocessor.converters.hwp_to_pdf import ...` 가 풀림).
-COPY ./genon/preprocessor/converters /app/genon/preprocessor/converters
+COPY --chown=${UID}:${GID} ./genon/preprocessor/converters /app/genon/preprocessor/converters
 # enrichment 패키지를 namespace tree 로 복사 — facade 의
 # `from genon.preprocessor.facade.enrichment.* import ...` (intelligent_processor.py:151-152)
 # 가 /app 기준 namespace package 로 풀리도록. (converters 와 동일 패턴)
-COPY ./genon/preprocessor/facade/enrichment /app/genon/preprocessor/facade/enrichment
+COPY --chown=${UID}:${GID} ./genon/preprocessor/facade/enrichment /app/genon/preprocessor/facade/enrichment
 # guardrail 패키지를 namespace tree 로 복사 — facade 의
 # `from genon.preprocessor.facade import guardrail as gr` (#315) 가 /app 기준으로 풀리도록.
-COPY ./genon/preprocessor/facade/guardrail /app/genon/preprocessor/facade/guardrail
+COPY --chown=${UID}:${GID} ./genon/preprocessor/facade/guardrail /app/genon/preprocessor/facade/guardrail
 
 # 🔴 HWP sdk
-COPY --from=sdk_artifacts /app/hwp_sdk /app/hwp_sdk
+COPY --chown=${UID}:${GID} --from=sdk_artifacts /app/hwp_sdk /app/hwp_sdk
 
 # 🔴 PDF SDK (엔터프라이즈 전용)
-COPY --from=pdf_sdk_artifacts /app/pdf_sdk /app/pdf_sdk
+COPY --chown=${UID}:${GID} --from=pdf_sdk_artifacts /app/pdf_sdk /app/pdf_sdk
 
 # 🔴 rhwp 바이너리 (이슈 #199 후속 — 컨테이너 내 바이너리, subprocess 호출)
 # 이슈 #286 — /rhwp_out/ 내용을 복사. INSTALL_RHWP=false 면 빈 디렉토리라 아무것도 안 들어감.
@@ -423,22 +556,25 @@ COPY --from=font_artifacts /app/extra_fonts /usr/share/fonts/additional
 RUN fc-cache -f -v
 
 # ✅ 공통 venv 위치만 복사
-COPY --from=builder ${APP_VENV} ${APP_VENV}
+COPY --chown=${UID}:${GID} --from=builder ${APP_VENV} ${APP_VENV}
 
 # 🔴 [매우 중요] 경로 문제 해결을 위한 링크 (USER 설정 이전에 수행)
 RUN ln -s /app/hwp_sdk /app/.venv/lib/python3.12/site-packages/hwp_sdk
 
 # ✅ 모델/자료
-COPY --from=models_artifacts /app/nltk_data /app/nltk_data
-COPY --from=models_artifacts /models /models
+COPY --chown=${UID}:${GID} --from=models_artifacts /app/nltk_data /app/nltk_data
+COPY --chown=${UID}:${GID} --from=models_artifacts /models /models
 
 RUN ln -sf /app/configs/supervisor.conf /etc/supervisor/conf.d/supervisor.conf
-RUN getent group "${GID}" || groupadd -g "${GID}" "${GNAME}" && \
-    getent passwd "${UID}" || useradd -m -u "${UID}" -g "${GID}" -s /bin/bash "${UNAME}" && \
-    UNAME_ACTUAL="$(getent passwd "${UID}" | cut -d: -f1)" && \
-    usermod -aG sudo "${UNAME_ACTUAL}" && \
-    echo "${UNAME_ACTUAL} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-    mkdir -p /app/.cache/huggingface /app/.config/libreoffice /app/.cache/libreoffice /app/.local/share /app/tmp /tmp/xdg && \
-    chown -R "${UID}:${GID}" /app /run /var/log /etc/supervisor /models /app/nltk_data /app/.cache /app/.config /app/.local /tmp/xdg
+# 위 COPY 들이 이미 ${UID}:${GID} 로 복사했으므로, 여기서는 작은 경로만 정리한다.
+#   - /app, /app/nltk_data : base 단계에서 root 로 미리 만들어진 디렉토리라
+#     COPY --chown 이 디렉토리 자체의 소유권은 바꾸지 않는다 → 비재귀 chown 으로 보정.
+#   - site-packages/hwp_sdk : 위 RUN 이 만든 심볼릭 링크 자체의 소유권(-h).
+#   - 나머지는 모두 KB 단위의 작은 트리라 -R 로 돌려도 레이어가 커지지 않는다.
+RUN mkdir -p /app/.cache/huggingface /app/.config/libreoffice /app/.cache/libreoffice /app/.local/share /app/tmp /tmp/xdg && \
+    chown "${UID}:${GID}" /app /app/nltk_data && \
+    chown -h "${UID}:${GID}" /app/.venv/lib/python3.12/site-packages/hwp_sdk && \
+    find /app -maxdepth 1 -user 0 -exec chown "${UID}:${GID}" {} + && \
+    chown -R "${UID}:${GID}" /run /var/log /etc/supervisor /app/.cache /app/.config /app/.local /app/.fontconfig /app/tmp /tmp/xdg
 USER ${UID}:${GID}
 CMD ["supervisord", "-n"]


### PR DESCRIPTION
# feat(#342): 도커 이미지 용량 최적화 — 4개 Dockerfile 공통 정비 + `.dockerignore` 신설

## 개요

전처리기/코드서빙 도커 이미지가 필요 이상으로 커진 원인을 찾아 제거한다. 대상은 이 레포의
**빌드 대상 Dockerfile 4개 전부**이며, 애플리케이션 코드는 한 줄도 바뀌지 않는다.

| 파일 | 용도 |
|---|---|
| `genon/preprocessor/docker/Dockerfile.standard` | 전처리기 오픈소스 빌드 |
| `genon/preprocessor/docker/Dockerfile.synap` | 전처리기 엔터프라이즈(Synap) 빌드 — standard 와 **동일한 변경** |
| `build-script/code-serving-doc-parser/Dockerfile` | 코드서빙 CPU |
| `build-script/code-serving-doc-parser/Dockerfile.gpu` | 코드서빙 GPU |

여기에 레포 루트 `.dockerignore` 를 새로 추가한다(지금까지 없었다).

## 배경 — 커진 원인은 세 갈래였다

**① 안 쓰는 자산을 받아왔다.** docling 기본 모델 세트의 `code_formula`(506MB), HF 레포
`mncai/doc_parser_models` 전체(846MB) 중 실제 사용은 MiniLM 토크나이저 하나, dev 의존성 그룹
(약 100MB), torch 의 C++ 헤더/테스트 픽스처(141MB), 참조가 0건인 `tessedata.tar.gz`(35MB).

**② 지웠는데 레이어가 회수되지 않았다.** `COPY` 로 가져와 다음 `RUN` 에서 `rm` 하면 상위 레이어에
whiteout 만 생기고 원본 레이어는 그대로 남는다. 더 큰 건 runtime 마지막의
`chown -R … /app /models /app/nltk_data` — overlayfs 에서 소유권만 바꿔도 전 파일이 copy-up 되어
**같은 데이터를 담은 5.2GB 레이어가 하나 더 생겼다**. 이미지 내용은 6.8GB인데 레이어 합이 12.5GB가
된 주된 이유다.

**③ CUDA 휠을 받았다가 버렸다.** CPU 빌드가 PyPI 기본(CUDA) torch 를 먼저 설치해 nvidia 휠 15종 +
triton 약 4GB 를 내려받은 뒤, 바로 다음 단계에서 CPU 휠로 갈아끼우며 전부 폐기했다. GPU 빌드는 더
심해서 기본 CUDA torch 약 4GB 를 받고 다시 cu124 인덱스에서 약 4GB 를 받아 덮어썼다(총 약 8GB, 절반 폐기).

그리고 ③ 을 파고들다 **실제 버그 1건**이 나왔다 — 아래 "하드코딩된 nvidia 제거 목록" 항목.

## 주요 변경

### 1) 레이어 회계 (4개 파일 공통)

**runtime 의 전역 `chown -R` 제거 → `COPY --chown` 으로 전환.**
`.venv`(2.6GB) + `/models`(2.2GB) + `nltk_data` + `hwp_sdk` 를 복사한 뒤 소유권만 바꾸던 마지막
`RUN chown -R` 을 없애고, 각 `COPY` 에 `--chown=${UID}:${GID}` 를 준다. 남은 `chown` 은 작은 것만:

- `/app`, `/app/nltk_data` — base 단계에서 root 로 미리 만들어진 **디렉토리 자체**의 소유권은
  `COPY --chown` 이 바꾸지 않으므로 비재귀 `chown` 으로 보정
- `site-packages/hwp_sdk` — 심볼릭 링크 자체 소유권(`chown -h`)
- `find /app -maxdepth 1 -user 0 -exec chown … {} +` — 누락분 방어
- `/run /var/log /etc/supervisor /app/.cache /app/.config /app/.local /app/tmp /tmp/xdg` — KB 단위라 `-R` 무해

**`resources` 디렉토리 통째 COPY → bind mount.**
필요한 건 `HCRBatang.ttf.tar.gz` 뿐인데 디렉토리를 통째로 복사해 참조 0건인 `tessedata.tar.gz`(35MB)
까지 들어왔고, 폰트 tarball 을 다음 레이어에서 `rm` 해도 COPY 레이어는 회수되지 않았다.
(한국어 tessdata 는 apt `tesseract-ocr-kor` 로 이미 들어온다.)

```dockerfile
RUN --mount=type=bind,source=genon/preprocessor/resources/HCRBatang.ttf.tar.gz,target=/tmp/HCRBatang.ttf.tar.gz \
    set -eux; mkdir -p /usr/share/fonts && tar zxf /tmp/HCRBatang.ttf.tar.gz -C /usr/share/fonts/ && fc-cache -f -v
```

회수된 COPY 레이어: standard/synap 48MB, code-serving 11.6MB.

**cache mount 가 걸린 apt RUN 의 `rm -rf /var/lib/apt/lists/*` 제거.**
`/var/cache/apt` 와 `/var/lib/apt/lists` 를 cache mount 로 잡은 RUN 은 애초에 그 내용이 이미지
레이어에 포함되지 않는다. 크기 이득은 0이면서 다음 빌드가 재사용할 apt 인덱스만 파괴하고 있었다.
⚠️ cache mount 가 **없는** RUN(rhwp 빌더 등)의 `rm` 은 실제로 레이어를 줄이므로 그대로 유지했다.

### 2) 모델 자산 선별

**`docling-tools models download` 목록 명시.** 인자 없이 호출하면 기본 세트를 전부 받는다.

```dockerfile
ARG DOCLING_MODELS="layout tableformer picture_classifier easyocr"
```

- 제외: **`code_formula`**(ds4sd--CodeFormula, 506MB). `do_code_enrichment` /
  `do_formula_enrichment` 가 `pipeline_options.py` 에서 기본 `False` 이고 이를 켜는 config 키·코드가
  없어 `CodeFormulaModel` 은 `enabled=False` 로만 생성된다.
  ⚠️ 이 판단은 **현재 제품 기능 기준**이다. docling CLI 자체에는 enrichment 를 켜는 옵션이 있으므로,
  향후 facade 가 이를 노출하거나 코드서빙에서 런타임 clone 되는 서비스 코드가 켜면
  **오프라인 환경에서 모델이 없어 실패**한다. 그때는 목록에 다시 넣어야 한다.
- 유지 근거 (`docling/utils/model_downloader.py` 의 `with_*` 플래그와 1:1):
  - `layout` → PDF 는 `genos_layout`(dotsocr)을 쓰지만 **PPT/PPTX 경량 파이프라인**이 bare
    `PdfPipelineOptions()` 로 `LayoutModel` 을 만들어 실제 로드한다
  - `tableformer` → `layout_model_type: docling_layout` 배포에서 필요
  - `picture_classifier` → `chart.enable` opt-in (16MB)
  - `easyocr` → CRAFT 검출기(`craft_mlt_25k` 83MB) 등. **목록에서 빼면 아래 `korean_g2.zip`
    단계만 남아 검출기가 사라진다**

**HF 레포 부분 다운로드.** `mncai/doc_parser_models` 에서 실제로 쓰는 건 MiniLM 토크나이저 폴더
하나뿐인데 전체(846MB)를 받고 있었다 — `docling-models`(506MB)는 참조 0건(TableFormer 는
`ds4sd--docling-models` 를 쓴다), `docling-layout-old`(164MB)는 `MNCAI_CUSTOM_LAYOUT` 전용 경로이나
`model_spec` 을 그 값으로 바꾸는 코드가 없다. 게다가 **두 번째 `download` 의 `--local-dir` 이 이미 받은
폴더를 다시 가리켜 동명 하위 디렉토리가 중첩 생성**됐다(88MB 중복). 코드는 바깥쪽만 사용한다.

```dockerfile
huggingface-cli download mncai/doc_parser_models \
  --include "sentence-transformers-all-MiniLM-L6-v2/*" --local-dir /models/doc_parser_models
```

**EasyOCR 한국어 모델 캐시 조건 수정 (버그).** 조건이 `/models/EasyOcr/korean_g2.zip` 존재를 봤는데
zip 은 캐시 마운트 `/root/.cache/easyocr_korean/` 에 저장되므로 그 경로에는 zip 이 절대 생기지 않았다
→ **조건이 항상 참** → 캐시가 있어도 매 빌드 재다운로드. 캐시 경로를 보도록 고치고, `unzip` 은
조건 밖으로 뺐다(캐시에 zip 이 있어도 `/models/EasyOcr` 는 새 레이어라 매번 풀어야 한다).
(code-serving Dockerfile 은 처음부터 캐시 경로를 검사해 올바르게 동작하고 있었다.)

**죽은 캐시 마운트 제거.** `--mount=type=cache,target=/root/.cache/models` 를 아무도 쓰지 않았다
(docling-tools 는 `-o /models` 와 `HF_HOME` 을 쓴다 — 실제로 그 캐시는 4KB로 비어 있었다).

### 3) venv 다이어트

**`uv sync --no-dev`** (전처리기 2개 파일) — dev 그룹(pytest/mypy/debugpy/ipykernel/pre-commit …)은
런타임 이미지에 불필요하다. 붙이지 않으면 uv 가 기본 설치해 약 100MB(debugpy 18M, mypy+mypyc `.so`
47M 등)가 들어온다. 코드서빙은 `uv pip install .` 방식이라 애초에 dev 그룹을 설치하지 않는다.

**CPU/GPU 휠을 처음부터 올바르게 받는다.** 도구별로 방법이 다르다:

| 파일 | 방식 |
|---|---|
| `Dockerfile.standard` / `.synap` | `uv sync` 에는 `--torch-backend` 가 없어 → `uv.lock` 에서 뽑은 `--no-install-package nvidia-… triton` + torch/torchvision 제외 후, CPU 휠 재설치 |
| code-serving CPU | `uv pip install . --torch-backend=cpu` |
| code-serving GPU | `uv pip install . --torch-backend=cu124` (재설치 단계 삭제) |

standard 쪽 제외 목록도 **하드코딩하지 않고 `uv.lock` 에서 추출**한다:

```dockerfile
EXCL=$(grep -oE '^name = "(nvidia-[A-Za-z0-9._-]*|triton)"' uv.lock \
       | sed 's/^name = "//; s/"$//' | sed 's/^/--no-install-package /' | tr '\n' ' ')
uv sync --frozen --no-dev --no-install-package torch --no-install-package torchvision ${EXCL}
```

**🔴 하드코딩된 nvidia 제거 목록 삭제 — 이 PR 의 실질 버그픽스.**
기존 코드는 `nvidia-cublas-cu12` 처럼 `-cu12` 접미사 목록을 박아두고 끝에 `|| true` 를 붙였다.
버전 핀이 없던 code-serving 쪽에서 torch 2.13 이 잡히며 CUDA 13 휠로 패키지명이 바뀌자
(`nvidia_cublas` 접미사 없음, `nvidia_cudnn_cu13`, `nvidia_nccl_cu13` …) **이름이 하나도 일치하지 않아
uninstall 이 전부 실패했고, `|| true` 가 그 실패를 삼켜 CPU 이미지에 CUDA 라이브러리 2.7GB 가 조용히
실려 나가고 있었다.**

기존 smoke test 는 `torch.version.cuda is None` 만 보므로 이걸 잡지 못했다 — torch 자체는 CPU 휠로
교체됐고 딸려온 nvidia 휠만 남아 있었기 때문이다.

→ 설치된 목록에서 이름을 뽑아 지우고, 실패를 감추지 않고, 잔존 시 빌드를 실패시킨다:

```dockerfile
uv pip list --python ${APP_VENV}/bin/python --format=freeze \
  | sed -n 's/^\(nvidia[A-Za-z0-9._-]*\|triton\)==.*/\1/p' | tee /tmp/cuda_pkgs.txt
xargs -r uv pip uninstall --python ${APP_VENV}/bin/python < /tmp/cuda_pkgs.txt
uv pip list … | grep -iE '^(nvidia|triton)' && { echo "[ERROR] nvidia/triton 잔존"; exit 1; } || true
```

**torch 런타임 미사용 자산 제거 — 약 141MB** (`torch/test` 81M + `torch/include` 60M).
C++ 헤더와 테스트 픽스처로 추론 경로에서는 쓰이지 않는다.
⚠️ **`torch/bin`(50MB)은 지우면 안 된다.** `torch/__init__.py` 가 import 시점에 `_manager_path()` 로
`torch/bin/torch_shm_manager` 존재를 무조건 확인하고 없으면 `RuntimeError` 로 죽는다
(DataLoader 를 쓰지 않아도 발생 — 실제로 제거했다가 `import torch` 부터 실패했다).

**opencv headless 통일 — 약 116MB.**
`opencv-python`(non-headless)과 `opencv-python-headless` 가 둘 다 해석돼 들어온다(전자는
unstructured-inference + 자체 pyproject, 후자는 docling-ibm-models/easyocr). 같은 `cv2` 모듈을
제공하므로 `opencv_python.libs` 가 순수 중복이다. 첫 파티 코드에 `import cv2` 는 한 건도 없고,
cv2 를 쓰는 패키지들은 headless 로 충분하다. 실측: 파일시스템 5.20GB → 5.08GB.

- ⚠️ **순서**: `opencv-python` 을 지우면 공유되는 `cv2/` 파일까지 사라지므로 반드시 뒤에 headless 를 `--reinstall`
- ⚠️ **버전 핀**: `uv pip install` 은 lock 을 참조하지 않아 버전을 안 주면 최신(현재 5.0.x)을 가져와
  lock 의 4.11 에서 **메이저 점프**가 일어난다. 하드코딩 대신 `uv.lock` 에서 뽑아 핀한다.
- 설치 후 `import cv2` / `import unstructured_inference` / `opencv_python.libs` 잔존 검사로 자기검증
- `Dockerfile.gpu` 는 이 블록이 **builder apt RUN 뒤**에 와야 한다(ubuntu:22.04 최소 구성이라
  그 전에는 `libglib2.0-0` 이 없어 `import cv2` 가 ImportError)

### 4) 베이스 이미지 / 빌드 환경

**GPU runtime 베이스 다운그레이드 — 약 1.9GB.**
`nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04` → `12.4.1-base-ubuntu22.04`.
torch 는 pip nvidia 휠(uv.lock 에 15개, cuDNN 포함)에 링크되므로 베이스가 주는 시스템 CUDA/cuDNN 은
쓰이지 않는다 — CUDA 를 사실상 두 번 싣고 있었다(실측 `/usr` 4.7GB). CUDA 를 쓰는 다른 패키지도 없다
(onnxruntime 은 CPU 빌드). 같은 스택인 `genon/preprocessor` GPU 빌드는 `python:slim`(시스템 CUDA 없음)
위에서 정상 동작한다.
⚠️ `ubuntu:22.04` 까지 낮추지 말 것 — `-base` 가 포함하는 `cuda-compat` 이 호스트 드라이버가 CUDA 12.4
보다 구버전일 때 호환성을 메워 준다. 추가 절감(약 250MB) 대비 위험이 크다.

**rhwp 빌더 `rust:latest` → `rust:1-slim`** (4개 파일 전부). `rust:latest`(약 1.5GB)는 buildpack-deps
기반이라 git 이 들어 있지만 slim 에는 없어 `git ca-certificates` 만 apt 로 추가했다. 산출물이 바이너리
하나뿐이라 **최종 이미지 크기는 그대로이고 빌드 중 다운로드/디스크만 줄어든다.**
⚠️ genos-rhwp 가 `pkg-config`/`libssl-dev`/`cmake` 같은 시스템 의존을 요구하게 되면 `cargo build` 가
깨진다. 그때는 apt 목록에 추가하거나 `rust:latest` 로 되돌린다.

**uv 버전 `0.8.0` 핀 (4개 파일).** 빌드가 `--no-install-package` / `--torch-backend` 에 의존하게 됐으니
`:latest` 로 두면 어느 날 조용히 동작이 바뀔 수 있다.
⚠️ `COPY --from=<이미지>` 는 ARG 를 확장하지 않는다(FROM 만 확장). 그래서 명명된 스테이지를 둔다:

```dockerfile
ARG UV_VERSION=0.8.0          # 첫 FROM 앞에 선언해야 FROM 에서 쓸 수 있다
FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_bin
...
COPY --from=uv_bin /uv /uvx /bin/
```

부작용 1건: 핀하면서 code-serving 빌드가 깨졌다. base 가 `ENV TMPDIR=/app/tmp` 를 설정하는데 그 RUN 이
`/app/tmp` 를 지운 뒤 다시 만들지 않아 `error: No such file or directory (os error 2) at path
"/app/tmp/.tmpXXXX"` 로 죽는다(이전 미핀 uv 는 TMPDIR 을 자동 생성했다). `mkdir -p /app/tmp` 추가.

**code-serving CPU: `libspatialindex-dev` → `libspatialindex-c8`.**
rtree 가 `libspatialindex_c.so` 를 dlopen 할 때만 필요하므로 런타임 패키지로 충분하다(-dev 는 헤더뿐).
⚠️ 패키지명이 배포판마다 다르다: Debian trixie `-c8`, Ubuntu 22.04(jammy) `-c6`(Dockerfile.gpu 가 쓰는 이름).

### 5) `.dockerignore` 신설

이 레포에는 Dockerfile 이 9개 있고(루트 `./Dockerfile`, `.actor/`, `genon/serving/paddle/`,
`genon/preprocessor/docker/`, `build-script/code-serving-doc-parser/`) **모두 레포 루트를 컨텍스트로
쓴다.** 그래서 whitelist(`*` 로 전부 막고 `!경로` 로 되살리기) 대신 **blacklist** 를 택했다 — whitelist 는
경로 하나만 빠뜨려도 다른 빌드를 조용히 깨뜨린다. 아래 항목이 어떤 Dockerfile 에서도 참조되지 않음을
확인하고 작성했다.

- **비밀 값 (가장 중요)**: `build-script/hf_private_token.env`, `**/*.pem`, `**/*.key`.
  `.gitignore` 로 git 에서는 빠지지만 **docker build context 에는 그대로 들어간다.** 지금은 어떤
  Dockerfile 도 `COPY . .` 를 하지 않아 이미지에 실리지 않지만, 누군가 광범위한 COPY 를 추가하는 순간
  토큰이 이미지에 들어간다. (빌드는 `--secret` 으로 토큰을 주입하므로 컨텍스트에서 빠져도 정상 동작한다.)
- `.git`, `.venv`, `__pycache__`, `*.py[cod]`, `.pytest_cache`/`.mypy_cache`/`.ruff_cache`,
  `*.egg-info`, `.idea`/`.vscode`/`.DS_Store`, `dist`/`build`/`node_modules`

## 변경 파일

| 파일 | 내용 |
|---|---|
| `.dockerignore` | **신규** — blacklist 방식, 비밀 값/개인 작업 공간/캐시 제외 |
| `genon/preprocessor/docker/Dockerfile.standard` | 위 1~4 전부 |
| `genon/preprocessor/docker/Dockerfile.synap` | standard 와 **동일 변경**(주석 문구만 일부 축약) |
| `build-script/code-serving-doc-parser/Dockerfile` | 위 1~4 + `libspatialindex-c8` |
| `build-script/code-serving-doc-parser/Dockerfile.gpu` | 위 1~4 + runtime 베이스 `-cudnn-runtime` → `-base` |
| `build-script/code-serving-doc-parser/build.config` | `IMAGE_VERSION` 0.1.0 → 2.1.4 |

## 하위 호환 / 동작 변경

**애플리케이션 코드 변경 0건.** Dockerfile / `.dockerignore` / `build.config` 만 바뀐다.

이미지에서 빠지는 것과 판단 근거:

| 빠지는 것 | 왜 안전한가 | 언제 되돌려야 하나 |
|---|---|---|
| `code_formula` 모델 | code/formula enrichment 가 기본 off 이고 켜는 코드가 없음 | facade 나 서비스 코드가 enrichment 를 노출/활성화할 때 |
| `doc_parser_models` 의 docling-models / layout-old | 참조 0건, 기본 layout 은 `ds4sd--docling-layout-old` | `MNCAI_CUSTOM_LAYOUT` 경로를 실제로 쓰게 될 때 |
| `tessedata.tar.gz` | 참조 0건, 한국어 tessdata 는 apt 로 이미 존재 | — |
| `torch/test`, `torch/include` | 추론 경로 미사용 | `torch.utils.cpp_extension`(JIT C++ 확장)을 쓰는 코드가 붙을 때 |
| `opencv-python`(non-headless) | 첫 파티 `import cv2` 0건, GUI 불필요 | GUI 렌더링이 필요해질 때 |
| dev 의존성 그룹 | 런타임 불필요 | 이미지 안에서 pytest 를 돌려야 할 때 |
| 시스템 CUDA/cuDNN (GPU) | torch 가 pip nvidia 휠에 링크 | 시스템 CUDA 를 직접 링크하는 패키지를 추가할 때 |

**코드서빙 특유의 리스크**: 이 이미지는 런타임에 서비스 코드를 `git clone` 해서 실행한다. 그 외부 코드가
`torch.utils.cpp_extension` 을 쓰면 `torch/include` 부재로 실패한다. 현재 이 레포에는 사용처가 없지만
서비스 코드는 이미지 밖에서 오므로 보장할 수 없다 — 그런 서비스를 붙이려면 해당 `RUN` 에서 include
제거를 빼야 한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the document-parsing service image to version 2.1.4.
  * Improved CPU and GPU deployment support with more consistent dependency and hardware configuration.
  * Reduced container size by removing unused libraries, models, and assets.
  * Improved container file ownership and runtime permissions for more reliable deployments.
  * Limited downloaded document-processing models to those required by the service.
* **Security**
  * Added container build exclusions for secrets, local environments, metadata, caches, and personal workspace files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->