### PR TITLE
첨부 PPT 파싱을 docling에서 PyMuPDF로 전환 (#358)

### DIFF
--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -223,6 +223,7 @@ from docling.document_converter import (
 from genon.preprocessor.facade.enrichment.page_description import (
     PageDescriptionOptions,
     describe_page_images,
+    should_describe,
 )
 from docling_core.transforms.chunker import BaseChunk, BaseChunker, DocChunk, DocMeta
 from docling_core.transforms.serializer.markdown import (
@@ -2083,10 +2084,12 @@ class DocumentProcessor:
             if text:
                 page_texts[int(page_document.metadata.get('page', 0)) + 1] = text
 
-        # 페이지 단위 image description(옵션). enable=false 면 렌더/요청을 모두 skip(파싱은 유지).
+        # 페이지 단위 image description(옵션). enable=false 이거나 url 미설정이면 렌더/요청을 모두
+        # skip 한다(파싱은 유지). 렌더가 describe_page_images 의 인자라 먼저 평가되므로,
+        # 설정 판정을 호출 전에 해야 헛렌더를 막을 수 있다.
         # native text 가 있으면 프롬프트({{page_text}})에 반영해 요청한다.
         page_descs: dict[int, str] = {}
-        if self._page_desc_options.enabled:
+        if should_describe(self._page_desc_options):
             page_descs = describe_page_images(
                 self._render_pdf_page_images(pdf_path, self._page_desc_options.images_scale),
                 self._page_desc_options,

--- a/genon/preprocessor/facade/attachment_processor.py
+++ b/genon/preprocessor/facade/attachment_processor.py
@@ -23,6 +23,7 @@ import yaml
 from datetime import datetime
 import logging
 from fastapi import Request
+from PIL import Image
 
 _log = logging.getLogger(__name__)
 
@@ -213,15 +214,15 @@ except (ImportError, OSError):
     HTML = None
 
 from docling.datamodel.base_models import InputFormat
-from docling.datamodel.pipeline_options import PipelineOptions, PdfPipelineOptions
+from docling.datamodel.pipeline_options import PipelineOptions
 from docling.datamodel.document import ConversionResult, InputDocument
 from docling.pipeline.simple_pipeline import SimplePipeline
 from docling.document_converter import (
-    DocumentConverter, HwpxFormatOption, WordFormatOption, PdfFormatOption,
+    DocumentConverter, HwpxFormatOption, WordFormatOption,
 )
 from genon.preprocessor.facade.enrichment.page_description import (
     PageDescriptionOptions,
-    describe_pages,
+    describe_page_images,
 )
 from docling_core.transforms.chunker import BaseChunk, BaseChunker, DocChunk, DocMeta
 from docling_core.transforms.serializer.markdown import (
@@ -2039,32 +2040,32 @@ class DocumentProcessor:
                 merged[k] = v
         return merged
 
-    def _get_ppt_pdf_converter(self) -> DocumentConverter:
-        """이미지 기반 PPT(→PDF) 파싱용 경량 docling 컨버터(lazy, 캐시).
+    @staticmethod
+    def _render_pdf_page_images(pdf_path: str, scale: float) -> "dict[int, Image.Image]":
+        """PDF 각 페이지를 PIL 이미지로 렌더한다(page_description 전용).
 
-        첨부용은 dotsocr(genos_layout) 미수행 + do_ocr=False 로 최소 파싱만 수행한다.
-        페이지 단위 설명이 켜져 있으면 generate_page_images=True 로 페이지 렌더 이미지를 만든다.
+        scale 은 docling images_scale 과 같은 의미(1.0 = 72 DPI 기준 배율)다.
+        반환: {page_no(1-based): PIL Image}
         """
-        converter = getattr(self, "_ppt_pdf_converter", None)
-        if converter is not None:
-            return converter
-        opts = PdfPipelineOptions()
-        opts.do_ocr = False
-        opts.do_table_structure = False
-        opts.generate_page_images = bool(self._page_desc_options.enabled)
-        opts.generate_picture_images = False
-        opts.images_scale = self._page_desc_options.images_scale
-        converter = DocumentConverter(
-            format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=opts)}
-        )
-        self._ppt_pdf_converter = converter
-        return converter
+        images: "dict[int, Image.Image]" = {}
+        matrix = fitz.Matrix(scale, scale)
+        with fitz.open(pdf_path) as pdf:
+            for idx, page in enumerate(pdf):
+                pixmap = page.get_pixmap(matrix=matrix)
+                images[idx + 1] = Image.frombytes(
+                    "RGB", (pixmap.width, pixmap.height), pixmap.samples
+                )
+        return images
 
     def _load_ppt_page_documents(self, file_path: str, **kwargs: dict) -> "Optional[list[Document]]":
-        """PPT/PPTX → PDF 변환 후 docling 경량 파싱 + 페이지 단위 image description.
+        """PPT/PPTX → PDF 변환 후 PyMuPDF 페이지 파싱 + 페이지 단위 image description.
 
         페이지별 Document(metadata['page']=0-based) 리스트를 반환한다. PDF 변환이 불가하면
         None 을 반환해 호출부가 레거시 langchain 경로로 폴백하도록 한다.
+
+        파싱은 .pdf 첨부와 동일한 PyMuPDFLoader 를 쓴다. docling StandardPdfPipeline 은
+        레이아웃 모델을 무조건 태우면서(끌 수 없음) 정작 첨부가 쓰는 건 페이지 텍스트뿐이었고,
+        레이아웃 클러스터에 안 잡힌 텍스트(표지 문구·차트 라벨·리스트 번호 등)를 누락시켰다.
         """
         pdf_path = convert_to_pdf(file_path, use_pdf_sdk=kwargs.get('use_pdf_sdk', True))
         if not pdf_path or not os.path.exists(pdf_path):
@@ -2074,31 +2075,25 @@ class DocumentProcessor:
             _log.warning(f"[ppt] PDF 변환 실패 — 레거시 경로로 폴백: {os.path.basename(file_path)}")
             return None
 
-        converter = self._get_ppt_pdf_converter()
-        document: DoclingDocument = converter.convert(pdf_path, raises_on_error=True).document
+        # 페이지별 네이티브 텍스트 수집(page_no 는 1-based 로 정규화)
+        page_documents = PyMuPDFLoader(pdf_path, mode="page").load()
+        page_texts: dict[int, str] = {}
+        for page_document in page_documents:
+            text = str(page_document.page_content or "").strip()
+            if text:
+                page_texts[int(page_document.metadata.get('page', 0)) + 1] = text
 
-        # 페이지별 네이티브 텍스트 수집
-        page_text_parts: dict[int, list[str]] = defaultdict(list)
-        for item, _ in document.iterate_items():
-            text = str(getattr(item, "text", "") or "").strip()
-            if not text:
-                continue
-            prov = getattr(item, "prov", None) or []
-            page_no = prov[0].page_no if prov and getattr(prov[0], "page_no", None) else 1
-            page_text_parts[page_no].append(text)
-        page_texts: dict[int, str] = {
-            pno: "\n".join(parts).strip() for pno, parts in page_text_parts.items()
-        }
-
-        # 페이지 단위 image description(옵션). enable=false 면 설명만 skip(파싱은 유지).
+        # 페이지 단위 image description(옵션). enable=false 면 렌더/요청을 모두 skip(파싱은 유지).
         # native text 가 있으면 프롬프트({{page_text}})에 반영해 요청한다.
-        page_descs: dict[int, str] = describe_pages(
-            document, self._page_desc_options, page_texts=page_texts
-        )
+        page_descs: dict[int, str] = {}
+        if self._page_desc_options.enabled:
+            page_descs = describe_page_images(
+                self._render_pdf_page_images(pdf_path, self._page_desc_options.images_scale),
+                self._page_desc_options,
+                page_texts=page_texts,
+            )
 
-        all_pages: set[int] = set()
-        if getattr(document, "pages", None):
-            all_pages |= set(document.pages.keys())
+        all_pages: set[int] = set(range(1, len(page_documents) + 1))
         all_pages |= set(page_texts.keys()) | set(page_descs.keys())
         if not all_pages:
             all_pages = {1}

--- a/genon/preprocessor/facade/enrichment/page_description.py
+++ b/genon/preprocessor/facade/enrichment/page_description.py
@@ -5,7 +5,8 @@ facade 의 "페이지 자체"를 렌더링해 VLM 으로 설명하는 로직을 
 
 - `PageDescriptionOptions`  : config(formats.ppt.page_description) → 옵션 dataclass
 - `collect_page_texts`      : DoclingDocument → {page_no: native text}
-- `describe_pages`          : 각 페이지 렌더 이미지 + native text 를 VLM 에 보내 설명 반환
+- `describe_page_images`    : {page_no: PIL Image} + native text 를 VLM 에 보내 설명 반환(docling 비의존)
+- `describe_pages`          : DoclingDocument 에서 페이지 이미지를 뽑아 위 코어에 위임
 
 프롬프트는 `{{page_text}}` 변수를 지원한다(PromptTemplate). 페이지 native text 를 프롬프트에
 직접 반영해 요청한다.
@@ -168,16 +169,16 @@ def collect_page_texts(document: Any) -> "dict[int, str]":
     return {pno: "\n".join(v).strip() for pno, v in parts.items()}
 
 
-def describe_pages(
-    document: Any,
+def describe_page_images(
+    images: "dict[int, Image.Image]",
     options: PageDescriptionOptions,
     page_texts: Optional[dict] = None,
 ) -> "dict[int, str]":
-    """각 페이지를 렌더 이미지로 VLM 에 보내 설명을 반환한다.
+    """페이지 렌더 이미지를 VLM 에 보내 설명을 반환한다(docling 비의존 코어).
 
-    generate_page_images=True 로 파싱되어 page.image.pil_image 가 있어야 한다.
-    page_texts 가 주어지면 프롬프트의 `{{page_text}}` 변수에 반영해 요청한다.
-    반환: {page_no(1-based): description text}. 비활성/URL 없음/페이지 이미지 없음 → 빈 dict.
+    images: {page_no(1-based): PIL Image}. 이미지 출처(docling 페이지 렌더 / PyMuPDF 렌더 등)를
+    가리지 않는다. page_texts 가 주어지면 프롬프트의 `{{page_text}}` 변수에 반영해 요청한다.
+    반환: {page_no(1-based): description text}. 비활성/URL 없음/이미지 없음 → 빈 dict.
     """
     if not options.enabled:
         return {}
@@ -185,8 +186,8 @@ def describe_pages(
         _log.warning("[page_description] enable=true 이지만 url 이 비어 있어 건너뜁니다.")
         return {}
 
-    pages = getattr(document, "pages", None) or {}
-    page_nos = sorted(pages.keys())
+    images = images or {}
+    page_nos = sorted(images.keys())
     if not page_nos:
         return {}
 
@@ -211,10 +212,7 @@ def describe_pages(
     lock = threading.Lock()
 
     def _describe(page_no: int) -> None:
-        page = pages.get(page_no)
-        if page is None or getattr(page, "image", None) is None:
-            return
-        image = page.image.pil_image
+        image = images.get(page_no)
         if image is None:
             return
         image = _maybe_downscale(image, options.max_image_side)
@@ -241,3 +239,29 @@ def describe_pages(
         # #329: 워커 스레드에도 llm_cache 컨텍스트 전파
         list(executor.map(in_current_context(_describe), page_nos))
     return results
+
+
+def describe_pages(
+    document: Any,
+    options: PageDescriptionOptions,
+    page_texts: Optional[dict] = None,
+) -> "dict[int, str]":
+    """DoclingDocument 의 페이지 렌더 이미지를 VLM 에 보내 설명을 반환한다.
+
+    generate_page_images=True 로 파싱되어 page.image.pil_image 가 있어야 한다.
+    실제 요청은 `describe_page_images` 가 수행한다(첨부 PPT 경로는 PyMuPDF 렌더로 코어를 직접 호출).
+    반환: {page_no(1-based): description text}. 비활성/URL 없음/페이지 이미지 없음 → 빈 dict.
+    """
+    if not options.enabled:
+        return {}
+    if not options.url:
+        _log.warning("[page_description] enable=true 이지만 url 이 비어 있어 건너뜁니다.")
+        return {}
+
+    images: "dict[int, Image.Image]" = {}
+    for page_no, page in (getattr(document, "pages", None) or {}).items():
+        image = getattr(page, "image", None)
+        pil_image = getattr(image, "pil_image", None) if image is not None else None
+        if pil_image is not None:
+            images[page_no] = pil_image
+    return describe_page_images(images, options, page_texts=page_texts)

--- a/genon/preprocessor/facade/enrichment/page_description.py
+++ b/genon/preprocessor/facade/enrichment/page_description.py
@@ -4,6 +4,7 @@ facade 의 "페이지 자체"를 렌더링해 VLM 으로 설명하는 로직을 
 (기존 PictureItem 단위 image_description enricher 와는 별개; 이미지형 슬라이드/PDF 대응)
 
 - `PageDescriptionOptions`  : config(formats.ppt.page_description) → 옵션 dataclass
+- `should_describe`         : 설명 요청 가능 설정인지 판정(렌더 등 선행 비용 전에 호출)
 - `collect_page_texts`      : DoclingDocument → {page_no: native text}
 - `describe_page_images`    : {page_no: PIL Image} + native text 를 VLM 에 보내 설명 반환(docling 비의존)
 - `describe_pages`          : DoclingDocument 에서 페이지 이미지를 뽑아 위 코어에 위임
@@ -153,6 +154,20 @@ def _maybe_downscale(image: "Image.Image", max_side: int) -> "Image.Image":
     return resized
 
 
+def should_describe(options: PageDescriptionOptions) -> bool:
+    """설명 요청이 가능한 설정인지 판정한다(경고 로그를 이 함수가 소유).
+
+    페이지 렌더처럼 비싼 선행 작업 전에 호출부가 먼저 물어볼 수 있도록 분리했다.
+    False 경로에서만 경고하므로, 호출부와 코어가 모두 호출해도 로그가 중복되지 않는다.
+    """
+    if not options.enabled:
+        return False
+    if not options.url:
+        _log.warning("[page_description] enable=true 이지만 url 이 비어 있어 건너뜁니다.")
+        return False
+    return True
+
+
 def collect_page_texts(document: Any) -> "dict[int, str]":
     """DoclingDocument 의 아이템을 prov.page_no 로 그룹핑해 페이지별 native text 를 만든다.
 
@@ -180,10 +195,7 @@ def describe_page_images(
     가리지 않는다. page_texts 가 주어지면 프롬프트의 `{{page_text}}` 변수에 반영해 요청한다.
     반환: {page_no(1-based): description text}. 비활성/URL 없음/이미지 없음 → 빈 dict.
     """
-    if not options.enabled:
-        return {}
-    if not options.url:
-        _log.warning("[page_description] enable=true 이지만 url 이 비어 있어 건너뜁니다.")
+    if not should_describe(options):
         return {}
 
     images = images or {}
@@ -252,10 +264,7 @@ def describe_pages(
     실제 요청은 `describe_page_images` 가 수행한다(첨부 PPT 경로는 PyMuPDF 렌더로 코어를 직접 호출).
     반환: {page_no(1-based): description text}. 비활성/URL 없음/페이지 이미지 없음 → 빈 dict.
     """
-    if not options.enabled:
-        return {}
-    if not options.url:
-        _log.warning("[page_description] enable=true 이지만 url 이 비어 있어 건너뜁니다.")
+    if not should_describe(options):
         return {}
 
     images: "dict[int, Image.Image]" = {}


### PR DESCRIPTION
# refactor(#358): 첨부 PPT 파싱을 docling → PyMuPDF 로 전환

## 개요

첨부용 전처리기의 `.ppt/.pptx`는 PDF 변환 후 docling `StandardPdfPipeline`으로 파싱해 왔다.
이 경로는 **레이아웃 모델을 끌 수 없어 페이지마다 AI 추론이 돌면서도**, 정작 그 결과를 쓰지 않고
버렸고 **텍스트를 상당량 누락**시켰다.

파싱을 `.pdf` 첨부와 동일한 `PyMuPDFLoader`로 교체했다. 샘플 16페이지 기준 추출 텍스트가
**4,491자 → 11,704자**로 늘고 파싱 시간은 **5.26s → 0.03s**로 줄었다. pptx 가 첨부 전처리기에서
`StandardPdfPipeline`을 타는 유일한 포맷이었으므로, 이제 **첨부 전처리기는 AI 모델 가중치를
하나도 로드하지 않는다**.

## 원인 (root cause)

- `StandardPdfPipeline`은 `LayoutModel`을 **enabled 플래그 없이 무조건** `build_pipe`에 넣는다
  (`docling/pipeline/standard_pdf_pipeline.py:135-139`). `do_ocr=False`, `do_table_structure=False`로
  꺼도 페이지당 레이아웃 추론은 남는다. (`OCR`/`TableFormer`/`code-formula`/`picture-classifier`는
  모두 `if self.enabled:` 가드가 있어 실제로 꺼짐.)
- 반면 첨부 경로가 docling 결과에서 쓰던 건 **페이지 텍스트 · 페이지 수 · 페이지 렌더 이미지** 3개뿐.
  레이아웃 클러스터 · reading order · 표 구조는 전부 버려졌다.
- 더 큰 문제는 **레이아웃 클러스터에 안 잡힌 텍스트를 버린다**는 점. 표지 슬라이드처럼 텍스트 박스가
  느슨하게 배치된 페이지는 통째로 0자가 나왔다.

## 주요 변경

### 1) `facade/enrichment/page_description.py` — 코어 분리 (additive)

- `describe_page_images(images, options, page_texts)` 신설 — `{page_no(1-based): PIL Image}`를 받아
  VLM 요청. **docling 비의존**. 기존 `describe_pages` 본문(프롬프트 구성 · `ThreadPoolExecutor` ·
  `api_image_request` · `_maybe_downscale` · `in_current_context` 전파)을 그대로 옮겼다.
- `describe_pages(document, options, page_texts)`는 `DoclingDocument`에서 `page.image.pil_image`를
  모아 코어에 위임하는 **래퍼로 유지** → `parser`/`convert`/`intelligent` 3개 호출부는 무변경.

### 2) `facade/attachment_processor.py` — PPT 경로 교체

- `_get_ppt_pdf_converter()` 제거 (docling `StandardPdfPipeline` 진입점 소멸).
- `_load_ppt_page_documents()`가 `PyMuPDFLoader(pdf_path, mode="page")`로 페이지 텍스트를 뽑는다.
  `metadata['page']`가 0-based라 기존 `_chunk_ppt_pages` 기대 형식과 그대로 맞고, 빈 페이지도
  Document가 생성되어 페이지 수 계산이 안정적이다.
- `_render_pdf_page_images(pdf_path, scale)` 신설 — `page_description`이 **켜졌을 때만**
  `fitz.get_pixmap(matrix=fitz.Matrix(scale, scale))` → `Image.frombytes("RGB", ...)`로 렌더.
  PNG 인코딩 없이 메모리에서 바로 PIL 로 만든다.
- 텍스트와 이미지가 **같은 변환 PDF 하나**를 공유한다(재변환 없음).
- 미사용이 된 `PdfPipelineOptions` / `PdfFormatOption` import 정리. `PipelineOptions`,
  `SimplePipeline`, `HwpxFormatOption`, `WordFormatOption`은 hwp/docx가 계속 쓰므로 유지.

## 측정 결과 (`sample_files/pptx_sample.pptx`, 16p)

| | 추출 텍스트 | 파싱 시간 |
|---|---|---|
| docling `StandardPdfPipeline` | 4,491자 | 5.26s |
| PyMuPDF | 11,704자 | 0.03s |

docling 이 누락하던 것:

- **표지 슬라이드 전체**(제목 · 부제 · 면책조항) → 0자
- 차트 축 라벨 · 범례(`글로벌 주식/채권/사모대체`) · 연도(`2015`~`2025`) · 수치(`-30`~`40`)
- 리스트 번호(`1. 2. 3.`)
- 도형 내부 텍스트(`A rectangle shape with this text inside.`)

## 하위 호환 / 동작 변경

- **동작 변경(의도)**: pptx 청크 본문의 텍스트가 늘어난다(누락 해소). 텍스트 순서는
  레이아웃 정렬 → PDF content-stream 순서로 바뀐다. 슬라이드는 텍스트 박스가 적어 실측상
  차이가 미미했고, `page_description` 프롬프트(`{{page_text}}`)에 들어가는 근거도 더 완전해진다.
- **불변**: `metadata['page']`(0-based) · 빈 페이지 `'.'` 폴백 · 페이지 결합 청킹(`_chunk_ppt_pages`) ·
  임시 PDF 삭제(`compose_vectors`) · PDF 변환 실패 시 `UnstructuredPowerPointLoader` 폴백.
- **불변**: `page_description` 설정 키와 의미. `fitz.Matrix(s, s)`는 docling `images_scale`과 같은
  기준(1.0 = 72 DPI 배율)이라 기존 `images_scale: 1.0`에서 렌더 해상도가 동일하다
  (1280×720pt 슬라이드 → 961×540px). 전송 전 `max_image_side` 캡도 코어에 그대로 남아 있다.
- **개선**: `page_description.enable: false`일 때 이제 렌더도 추론도 전혀 하지 않는다
  (기존에는 렌더만 건너뛰고 레이아웃 추론은 계속 돌았다).
- **운영**: 첨부 전처리기 경로에서 `DOCLING_ARTIFACTS_PATH` / `/models` 의존이 사라진다.
  단 `parser`/`convert`/`intelligent`는 여전히 필요하다.

## 검증 (preprocessor venv, in-process)

- **A/B**: `pptx_sample.pptx`(16p) · `powerpoint_sample.pptx`(3p)를 PDF 변환 후 docling/PyMuPDF
  양쪽으로 페이지별 추출 비교 — 위 표 및 누락 항목 확인.
- **기능**: 두 샘플 모두 페이지 수 · `metadata['page']`(0-based) · 청크 수(1 page = 1 chunk) 정상.
  렌더 결과 scale 1.0 → 961×540 RGB, scale 2.0 → 1921×1080. VLM 엔드포인트는 호출하지 않고
  파싱/청킹/렌더까지만 검증.
- **회귀**: 첨부·PPT 관련 테스트(`test_attachment_processor_samples` / `test_attachment_compact_tables_unit` /
  `test_attachment_hybrid_config` / `test_attachment_chunk_config_unit` / `test_mspowerpoint_backend_unit`)
  **84 passed, 34 skipped**.
- **전체**: `tests/unit` **878 passed, 17 failed, 50 skipped**. 실패 17건은 변경분을 stash 하고
  돌려도 동일하게 실패하는 기존 건(`test_pii_masking_unit` 7 · monimo custom_fields/json_records 6 ·
  `test_intelligent_processor_unit` 4 = 모델서버 미접속·HWP SDK Exec format error).

## 변경 파일

- `genon/preprocessor/facade/attachment_processor.py`
- `genon/preprocessor/facade/enrichment/page_description.py`

`code-serving/`은 gitignore 된 빌드 산출물이며 `build-script/sync-serving-repo.sh`가
`git archive`로 **커밋된 ref**에서 재생성하므로 수동 동기화 대상이 아니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved PowerPoint and presentation-file processing with support for native page text and rendered page images.
  * Added richer page descriptions by combining visual content with available text.

* **Bug Fixes**
  * Improved consistency and reliability when generating descriptions for presentation pages.
  * Preserved page filtering, image resizing, concurrent processing, and error handling during enrichment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->